### PR TITLE
Fix null handling in several services

### DIFF
--- a/src/main/kotlin/com/stark/shoot/adapter/in/kafka/MessageKafkaConsumer.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/kafka/MessageKafkaConsumer.kt
@@ -41,7 +41,11 @@ class MessageKafkaConsumer(
         if (event.type == EventType.MESSAGE_CREATED) {
             try {
                 // 메시지 내부의 임시 ID, 채팅방 ID 추출
-                val tempId = event.data.metadata.tempId!!
+                val tempId = event.data.metadata.tempId
+                    ?: run {
+                        logger.warn { "Received message event without tempId" }
+                        return
+                    }
                 val roomId = event.data.roomId
 
                 // MongoDB 저장 전 처리 중 상태 업데이트
@@ -130,7 +134,7 @@ class MessageKafkaConsumer(
         if (savedMessage.metadata.needsUrlPreview &&
             savedMessage.metadata.previewUrl != null
         ) {
-            val previewUrl = savedMessage.metadata.previewUrl!!
+            val previewUrl = savedMessage.metadata.previewUrl ?: return
 
             // URL 미리보기 비동기 처리
             try {

--- a/src/main/kotlin/com/stark/shoot/application/service/user/auth/UserLoginService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/user/auth/UserLoginService.kt
@@ -36,16 +36,18 @@ class UserLoginService(
         }
 
         // JWT 토큰 생성
-        val accessToken = jwtProvider.generateToken(user.id.toString(), user.username)
-        val refreshToken = jwtProvider.generateRefreshToken(user.id.toString(), user.username, 43200) // 30일
+        val userId = user.id ?: throw IllegalStateException("User ID must not be null")
+
+        val accessToken = jwtProvider.generateToken(userId.toString(), user.username)
+        val refreshToken = jwtProvider.generateRefreshToken(userId.toString(), user.username, 43200) // 30일
 
         // 리프레시 토큰 저장 (기본 정보만)
         refreshTokenPort.createRefreshToken(
-            userId = user.id!!,
+            userId = userId,
             token = refreshToken
         )
 
-        return LoginResponse(user.id.toString(), accessToken, refreshToken)
+        return LoginResponse(userId.toString(), accessToken, refreshToken)
     }
 
 }

--- a/src/main/kotlin/com/stark/shoot/infrastructure/config/socket/interceptor/RateLimitInterceptor.kt
+++ b/src/main/kotlin/com/stark/shoot/infrastructure/config/socket/interceptor/RateLimitInterceptor.kt
@@ -26,10 +26,11 @@ class RateLimitInterceptor(
 
         val userId = accessor.user?.name ?: return message
         val key = "ratelimit:chat:$userId"
-        val count = redisTemplate.opsForValue().increment(key, 1)
+
+        val count = redisTemplate.opsForValue().increment(key, 1) ?: 0L
         redisTemplate.expire(key, java.time.Duration.ofMinutes(1))
 
-        if (count!! > 500) { // 제한 증가: 300 -> 500
+        if (count > 500) { // 제한 증가: 300 -> 500
             throw MessageDeliveryException("Rate limit exceeded")
         }
 


### PR DESCRIPTION
## Summary
- avoid possible NPEs in Kafka consumer when metadata is missing
- avoid NPE when login user id is null
- handle Redis increment failure in rate limit interceptor

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6844401cb2a0832087ffc09a86d83485