### PR TITLE
Add user blocking feature

### DIFF
--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/user/block/UserBlockController.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/user/block/UserBlockController.kt
@@ -1,0 +1,38 @@
+package com.stark.shoot.adapter.`in`.web.user.block
+
+import com.stark.shoot.adapter.`in`.web.dto.ResponseDto
+import com.stark.shoot.application.port.`in`.user.block.UserBlockUseCase
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.*
+
+@Tag(name = "사용자 차단", description = "사용자 차단 관련 API")
+@RestController
+@RequestMapping("/api/v1/users")
+class UserBlockController(
+    private val userBlockUseCase: UserBlockUseCase
+) {
+
+    @Operation(summary = "사용자 차단", description = "특정 사용자를 차단합니다.")
+    @PostMapping("/{targetId}/block")
+    fun blockUser(
+        @PathVariable targetId: Long,
+        authentication: Authentication
+    ): ResponseDto<Boolean> {
+        val userId = authentication.name.toLong()
+        userBlockUseCase.blockUser(userId, targetId)
+        return ResponseDto.success(true, "사용자를 차단했습니다.")
+    }
+
+    @Operation(summary = "차단 해제", description = "차단한 사용자를 해제합니다.")
+    @DeleteMapping("/{targetId}/block")
+    fun unblockUser(
+        @PathVariable targetId: Long,
+        authentication: Authentication
+    ): ResponseDto<Boolean> {
+        val userId = authentication.name.toLong()
+        userBlockUseCase.unblockUser(userId, targetId)
+        return ResponseDto.success(true, "차단을 해제했습니다.")
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/mapper/UserMapper.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/mapper/UserMapper.kt
@@ -39,6 +39,7 @@ class UserMapper {
             friendIds = emptySet(),
             incomingFriendRequestIds = emptySet(),
             outgoingFriendRequestIds = emptySet(),
+            blockedUserIds = emptySet(),
             userCode = userEntity.userCode
         )
     }

--- a/src/main/kotlin/com/stark/shoot/application/port/in/user/block/UserBlockUseCase.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/user/block/UserBlockUseCase.kt
@@ -1,0 +1,6 @@
+package com.stark.shoot.application.port.`in`.user.block
+
+interface UserBlockUseCase {
+    fun blockUser(currentUserId: Long, targetUserId: Long)
+    fun unblockUser(currentUserId: Long, targetUserId: Long)
+}

--- a/src/main/kotlin/com/stark/shoot/application/service/user/block/UserBlockService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/user/block/UserBlockService.kt
@@ -1,0 +1,35 @@
+package com.stark.shoot.application.service.user.block
+
+import com.stark.shoot.application.port.`in`.user.block.UserBlockUseCase
+import com.stark.shoot.application.port.out.user.FindUserPort
+import com.stark.shoot.application.port.out.user.UserUpdatePort
+import com.stark.shoot.domain.service.user.block.UserBlockDomainService
+import com.stark.shoot.infrastructure.annotation.UseCase
+import com.stark.shoot.infrastructure.exception.web.ResourceNotFoundException
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional
+@UseCase
+class UserBlockService(
+    private val findUserPort: FindUserPort,
+    private val userUpdatePort: UserUpdatePort,
+    private val userBlockDomainService: UserBlockDomainService,
+) : UserBlockUseCase {
+
+    override fun blockUser(currentUserId: Long, targetUserId: Long) {
+        val current = findUserPort.findUserWithAllRelationshipsById(currentUserId)
+            ?: throw ResourceNotFoundException("사용자를 찾을 수 없습니다: $currentUserId")
+        if (!findUserPort.existsById(targetUserId)) {
+            throw ResourceNotFoundException("사용자를 찾을 수 없습니다: $targetUserId")
+        }
+        val updated = userBlockDomainService.block(current, targetUserId)
+        userUpdatePort.updateUser(updated)
+    }
+
+    override fun unblockUser(currentUserId: Long, targetUserId: Long) {
+        val current = findUserPort.findUserWithAllRelationshipsById(currentUserId)
+            ?: throw ResourceNotFoundException("사용자를 찾을 수 없습니다: $currentUserId")
+        val updated = userBlockDomainService.unblock(current, targetUserId)
+        userUpdatePort.updateUser(updated)
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/domain/chat/user/User.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/user/User.kt
@@ -26,6 +26,7 @@ data class User(
     var friendIds: Set<Long> = emptySet(),                 // 이미 친구인 사용자들의 id 목록
     var incomingFriendRequestIds: Set<Long> = emptySet(),  // 받은 친구 요청의 사용자 id 목록
     var outgoingFriendRequestIds: Set<Long> = emptySet(),  // 보낸 친구 요청의 사용자 id 목록
+    var blockedUserIds: Set<Long> = emptySet(),             // 차단한 사용자 id 목록
 ) {
 
     companion object {
@@ -226,6 +227,53 @@ data class User(
 
         return this.copy(
             friendIds = updatedFriendIds,
+            updatedAt = Instant.now()
+        )
+    }
+
+    /**
+     * 사용자를 차단합니다.
+     * 친구 관계와 친구 요청을 모두 제거합니다.
+     */
+    fun blockUser(userId: Long): User {
+        if (blockedUserIds.contains(userId)) {
+            return this
+        }
+
+        val updatedBlocked = this.blockedUserIds.toMutableSet()
+        updatedBlocked.add(userId)
+
+        val updatedFriends = this.friendIds.toMutableSet()
+        updatedFriends.remove(userId)
+
+        val updatedOutgoing = this.outgoingFriendRequestIds.toMutableSet()
+        updatedOutgoing.remove(userId)
+
+        val updatedIncoming = this.incomingFriendRequestIds.toMutableSet()
+        updatedIncoming.remove(userId)
+
+        return this.copy(
+            blockedUserIds = updatedBlocked,
+            friendIds = updatedFriends,
+            outgoingFriendRequestIds = updatedOutgoing,
+            incomingFriendRequestIds = updatedIncoming,
+            updatedAt = Instant.now()
+        )
+    }
+
+    /**
+     * 차단을 해제합니다.
+     */
+    fun unblockUser(userId: Long): User {
+        if (!blockedUserIds.contains(userId)) {
+            return this
+        }
+
+        val updatedBlocked = this.blockedUserIds.toMutableSet()
+        updatedBlocked.remove(userId)
+
+        return this.copy(
+            blockedUserIds = updatedBlocked,
             updatedAt = Instant.now()
         )
     }

--- a/src/main/kotlin/com/stark/shoot/domain/service/user/block/UserBlockDomainService.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/service/user/block/UserBlockDomainService.kt
@@ -1,0 +1,16 @@
+package com.stark.shoot.domain.service.user.block
+
+import com.stark.shoot.domain.chat.user.User
+import org.springframework.stereotype.Service
+
+@Service
+class UserBlockDomainService {
+    fun block(currentUser: User, targetId: Long): User {
+        require(currentUser.id != targetId) { "자신을 차단할 수 없습니다." }
+        return currentUser.blockUser(targetId)
+    }
+
+    fun unblock(currentUser: User, targetId: Long): User {
+        return currentUser.unblockUser(targetId)
+    }
+}


### PR DESCRIPTION
## Summary
- allow users to block or unblock other users
- keep track of blocked user ids in the User aggregate
- provide `UserBlockService` and use case API
- expose REST endpoints for blocking actions

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6844f813b9748320b1572cbe8ef686f9