### PR TITLE
Add bookmark feature for chat messages

### DIFF
--- a/src/main/kotlin/com/stark/shoot/application/port/in/message/bookmark/BookmarkMessageUseCase.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/message/bookmark/BookmarkMessageUseCase.kt
@@ -1,0 +1,9 @@
+package com.stark.shoot.application.port.`in`.message.bookmark
+
+import com.stark.shoot.domain.chat.bookmark.MessageBookmark
+
+interface BookmarkMessageUseCase {
+    fun bookmarkMessage(messageId: String, userId: Long): MessageBookmark
+    fun removeBookmark(messageId: String, userId: Long)
+    fun getBookmarks(userId: Long, roomId: Long? = null): List<MessageBookmark>
+}

--- a/src/main/kotlin/com/stark/shoot/application/port/out/message/BookmarkMessagePort.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/out/message/BookmarkMessagePort.kt
@@ -1,0 +1,10 @@
+package com.stark.shoot.application.port.out.message
+
+import com.stark.shoot.domain.chat.bookmark.MessageBookmark
+
+interface BookmarkMessagePort {
+    fun saveBookmark(bookmark: MessageBookmark): MessageBookmark
+    fun deleteBookmark(messageId: String, userId: Long)
+    fun findBookmarksByUser(userId: Long, roomId: Long? = null): List<MessageBookmark>
+    fun exists(messageId: String, userId: Long): Boolean
+}

--- a/src/main/kotlin/com/stark/shoot/application/service/message/bookmark/MessageBookmarkService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/message/bookmark/MessageBookmarkService.kt
@@ -1,0 +1,45 @@
+package com.stark.shoot.application.service.message.bookmark
+
+import com.stark.shoot.application.port.`in`.message.bookmark.BookmarkMessageUseCase
+import com.stark.shoot.application.port.out.message.BookmarkMessagePort
+import com.stark.shoot.application.port.out.message.LoadMessagePort
+import com.stark.shoot.domain.chat.bookmark.MessageBookmark
+import com.stark.shoot.infrastructure.annotation.UseCase
+import com.stark.shoot.infrastructure.exception.web.ResourceNotFoundException
+import com.stark.shoot.infrastructure.util.toObjectId
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.time.Instant
+
+@UseCase
+class MessageBookmarkService(
+    private val bookmarkPort: BookmarkMessagePort,
+    private val loadMessagePort: LoadMessagePort,
+) : BookmarkMessageUseCase {
+
+    private val logger = KotlinLogging.logger {}
+
+    override fun bookmarkMessage(messageId: String, userId: Long): MessageBookmark {
+        if (bookmarkPort.exists(messageId, userId)) {
+            logger.debug { "이미 북마크된 메시지입니다: messageId=$messageId, userId=$userId" }
+            throw IllegalArgumentException("이미 북마크된 메시지입니다.")
+        }
+
+        loadMessagePort.findById(messageId.toObjectId())
+            ?: throw ResourceNotFoundException("메시지를 찾을 수 없습니다: messageId=$messageId")
+
+        val bookmark = MessageBookmark(
+            messageId = messageId,
+            userId = userId,
+            createdAt = Instant.now(),
+        )
+        return bookmarkPort.saveBookmark(bookmark)
+    }
+
+    override fun removeBookmark(messageId: String, userId: Long) {
+        bookmarkPort.deleteBookmark(messageId, userId)
+    }
+
+    override fun getBookmarks(userId: Long, roomId: Long?): List<MessageBookmark> {
+        return bookmarkPort.findBookmarksByUser(userId, roomId)
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/domain/chat/bookmark/MessageBookmark.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/bookmark/MessageBookmark.kt
@@ -1,0 +1,13 @@
+package com.stark.shoot.domain.chat.bookmark
+
+import java.time.Instant
+
+/**
+ * 사용자 개인의 메시지 북마크 정보를 나타내는 애그리게이트
+ */
+data class MessageBookmark(
+    val id: String? = null,
+    val messageId: String,
+    val userId: Long,
+    val createdAt: Instant = Instant.now(),
+)

--- a/src/test/kotlin/com/stark/shoot/application/service/message/bookmark/MessageBookmarkServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/application/service/message/bookmark/MessageBookmarkServiceTest.kt
@@ -1,0 +1,88 @@
+package com.stark.shoot.application.service.message.bookmark
+
+import com.stark.shoot.application.port.out.message.BookmarkMessagePort
+import com.stark.shoot.application.port.out.message.LoadMessagePort
+import com.stark.shoot.domain.chat.bookmark.MessageBookmark
+import com.stark.shoot.domain.chat.message.ChatMessage
+import com.stark.shoot.domain.chat.message.MessageContent
+import com.stark.shoot.adapter.out.persistence.mongodb.document.message.embedded.type.MessageStatus
+import com.stark.shoot.adapter.out.persistence.mongodb.document.message.embedded.type.MessageType
+import com.stark.shoot.infrastructure.exception.web.ResourceNotFoundException
+import com.stark.shoot.infrastructure.util.toObjectId
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.*
+import java.time.Instant
+
+@DisplayName("메시지 북마크 서비스 테스트")
+class MessageBookmarkServiceTest {
+
+    @Test
+    fun `존재하지 않는 메시지를 북마크하면 예외가 발생한다`() {
+        val bookmarkPort = mock(BookmarkMessagePort::class.java)
+        val loadMessagePort = mock(LoadMessagePort::class.java)
+        val service = MessageBookmarkService(bookmarkPort, loadMessagePort)
+
+        val messageId = "1"
+        val userId = 1L
+
+        `when`(loadMessagePort.findById(messageId.toObjectId())).thenReturn(null)
+
+        assertThrows<ResourceNotFoundException> { service.bookmarkMessage(messageId, userId) }
+        verify(loadMessagePort).findById(messageId.toObjectId())
+        verifyNoInteractions(bookmarkPort)
+    }
+
+    @Test
+    fun `이미 북마크된 메시지를 다시 북마크하면 예외가 발생한다`() {
+        val bookmarkPort = mock(BookmarkMessagePort::class.java)
+        val loadMessagePort = mock(LoadMessagePort::class.java)
+        val service = MessageBookmarkService(bookmarkPort, loadMessagePort)
+
+        val messageId = "1"
+        val userId = 1L
+
+        `when`(loadMessagePort.findById(messageId.toObjectId())).thenReturn(createMessage(messageId))
+        `when`(bookmarkPort.exists(messageId, userId)).thenReturn(true)
+
+        assertThrows<IllegalArgumentException> { service.bookmarkMessage(messageId, userId) }
+
+        verify(bookmarkPort).exists(messageId, userId)
+        verifyNoMoreInteractions(bookmarkPort)
+    }
+
+    @Test
+    fun `정상적으로 메시지를 북마크한다`() {
+        val bookmarkPort = mock(BookmarkMessagePort::class.java)
+        val loadMessagePort = mock(LoadMessagePort::class.java)
+        val service = MessageBookmarkService(bookmarkPort, loadMessagePort)
+
+        val messageId = "1"
+        val userId = 1L
+        val message = createMessage(messageId)
+        val savedBookmark = MessageBookmark("b1", messageId, userId, Instant.now())
+
+        `when`(loadMessagePort.findById(messageId.toObjectId())).thenReturn(message)
+        `when`(bookmarkPort.exists(messageId, userId)).thenReturn(false)
+        `when`(bookmarkPort.saveBookmark(any())).thenReturn(savedBookmark)
+
+        val result = service.bookmarkMessage(messageId, userId)
+
+        assertThat(result).isEqualTo(savedBookmark)
+        verify(bookmarkPort).saveBookmark(any())
+    }
+
+    private fun createMessage(id: String): ChatMessage {
+        return ChatMessage(
+            id = id,
+            roomId = 1L,
+            senderId = 2L,
+            content = MessageContent("hi", MessageType.TEXT),
+            status = MessageStatus.SAVED,
+            createdAt = Instant.now()
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- revert scheduled message send logic changes
- introduce message bookmark aggregate and use cases
- implement `MessageBookmarkService`
- add unit tests for bookmarking logic

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68452d0f98c483209f7b90b453313418