### PR TITLE
Add FriendGroup aggregate

### DIFF
--- a/src/main/kotlin/com/stark/shoot/domain/chat/user/FriendGroup.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/user/FriendGroup.kt
@@ -1,0 +1,47 @@
+package com.stark.shoot.domain.chat.user
+
+import java.time.Instant
+
+/**
+ * 친구를 그룹화하여 관리하기 위한 애그리게이트
+ */
+data class FriendGroup(
+    val id: Long? = null,
+    val ownerId: Long,
+    val name: String,
+    val description: String? = null,
+    val memberIds: Set<Long> = emptySet(),
+    val createdAt: Instant = Instant.now(),
+    val updatedAt: Instant? = null,
+) {
+    /** 그룹 이름 변경 */
+    fun rename(newName: String): FriendGroup {
+        require(newName.isNotBlank()) { "그룹 이름은 비어있을 수 없습니다." }
+        return copy(name = newName, updatedAt = Instant.now())
+    }
+
+    /** 그룹 설명 업데이트 */
+    fun updateDescription(newDescription: String?): FriendGroup {
+        return copy(description = newDescription, updatedAt = Instant.now())
+    }
+
+    /** 그룹에 멤버 추가 */
+    fun addMember(userId: Long): FriendGroup {
+        if (memberIds.contains(userId)) {
+            return this
+        }
+        val updatedMembers = memberIds.toMutableSet()
+        updatedMembers.add(userId)
+        return copy(memberIds = updatedMembers, updatedAt = Instant.now())
+    }
+
+    /** 그룹에서 멤버 제거 */
+    fun removeMember(userId: Long): FriendGroup {
+        if (!memberIds.contains(userId)) {
+            return this
+        }
+        val updatedMembers = memberIds.toMutableSet()
+        updatedMembers.remove(userId)
+        return copy(memberIds = updatedMembers, updatedAt = Instant.now())
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/domain/chat/user/FriendGroupTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/chat/user/FriendGroupTest.kt
@@ -1,0 +1,64 @@
+package com.stark.shoot.domain.chat.user
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("FriendGroup 애그리게이트")
+class FriendGroupTest {
+
+    @Nested
+    @DisplayName("그룹 정보 업데이트")
+    inner class UpdateGroupInfo {
+
+        @Test
+        fun `그룹 이름을 변경할 수 있다`() {
+            val group = FriendGroup(ownerId = 1L, name = "친구들")
+            val updated = group.rename("베프")
+            assertThat(updated.name).isEqualTo("베프")
+            assertThat(updated.updatedAt).isNotNull()
+        }
+
+        @Test
+        fun `그룹 설명을 수정할 수 있다`() {
+            val group = FriendGroup(ownerId = 1L, name = "친구들")
+            val updated = group.updateDescription("오래된 친구")
+            assertThat(updated.description).isEqualTo("오래된 친구")
+            assertThat(updated.updatedAt).isNotNull()
+        }
+    }
+
+    @Nested
+    @DisplayName("멤버 관리")
+    inner class ManageMembers {
+
+        @Test
+        fun `멤버를 추가할 수 있다`() {
+            val group = FriendGroup(ownerId = 1L, name = "친구들")
+            val updated = group.addMember(2L)
+            assertThat(updated.memberIds).contains(2L)
+        }
+
+        @Test
+        fun `이미 있는 멤버를 추가하면 변경이 없다`() {
+            val group = FriendGroup(ownerId = 1L, name = "친구들", memberIds = setOf(2L))
+            val updated = group.addMember(2L)
+            assertThat(updated).isEqualTo(group)
+        }
+
+        @Test
+        fun `멤버를 제거할 수 있다`() {
+            val group = FriendGroup(ownerId = 1L, name = "친구들", memberIds = setOf(2L, 3L))
+            val updated = group.removeMember(2L)
+            assertThat(updated.memberIds).doesNotContain(2L)
+        }
+
+        @Test
+        fun `존재하지 않는 멤버를 제거하면 변경이 없다`() {
+            val group = FriendGroup(ownerId = 1L, name = "친구들", memberIds = setOf(2L))
+            val updated = group.removeMember(3L)
+            assertThat(updated).isEqualTo(group)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `FriendGroup` aggregate to organise friends into groups
- provide CRUD-style operations for renaming, adding and removing members
- remove the previously added `FriendRequest` aggregate
- add unit tests for `FriendGroup`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68481935dab883209c953fde7d93d14a