### PR TITLE
Add friend group management

### DIFF
--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/user/FriendGroupResponse.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/user/FriendGroupResponse.kt
@@ -1,0 +1,19 @@
+package com.stark.shoot.adapter.`in`.web.dto.user
+
+import com.stark.shoot.domain.chat.user.FriendGroup
+
+data class FriendGroupResponse(
+    val id: Long,
+    val ownerId: Long,
+    val name: String,
+    val description: String?,
+    val memberIds: Set<Long>
+)
+
+fun FriendGroup.toResponse() = FriendGroupResponse(
+    id = id ?: 0L,
+    ownerId = ownerId,
+    name = name,
+    description = description,
+    memberIds = memberIds
+)

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/social/group/FriendGroupController.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/social/group/FriendGroupController.kt
@@ -1,0 +1,91 @@
+package com.stark.shoot.adapter.`in`.web.social.group
+
+import com.stark.shoot.adapter.`in`.web.dto.ResponseDto
+import com.stark.shoot.adapter.`in`.web.dto.user.FriendGroupResponse
+import com.stark.shoot.adapter.`in`.web.dto.user.toResponse
+import com.stark.shoot.application.port.`in`.user.group.FindFriendGroupUseCase
+import com.stark.shoot.application.port.`in`.user.group.ManageFriendGroupUseCase
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.*
+
+@Tag(name = "친구그룹", description = "친구 그룹 관리 API")
+@RestController
+@RequestMapping("/api/v1/friends/groups")
+class FriendGroupController(
+    private val manageUseCase: ManageFriendGroupUseCase,
+    private val findUseCase: FindFriendGroupUseCase,
+) {
+
+    @Operation(summary = "그룹 생성")
+    @PostMapping
+    fun createGroup(
+        @RequestParam ownerId: Long,
+        @RequestParam name: String,
+        @RequestParam(required = false) description: String?
+    ): ResponseDto<FriendGroupResponse> {
+        val group = manageUseCase.createGroup(ownerId, name, description)
+        return ResponseDto.success(group.toResponse())
+    }
+
+    @Operation(summary = "그룹 이름 변경")
+    @PutMapping("/{groupId}/name")
+    fun renameGroup(
+        @PathVariable groupId: Long,
+        @RequestParam name: String
+    ): ResponseDto<FriendGroupResponse> {
+        val group = manageUseCase.renameGroup(groupId, name)
+        return ResponseDto.success(group.toResponse())
+    }
+
+    @Operation(summary = "그룹 설명 수정")
+    @PutMapping("/{groupId}/description")
+    fun updateDescription(
+        @PathVariable groupId: Long,
+        @RequestParam description: String?
+    ): ResponseDto<FriendGroupResponse> {
+        val group = manageUseCase.updateDescription(groupId, description)
+        return ResponseDto.success(group.toResponse())
+    }
+
+    @Operation(summary = "멤버 추가")
+    @PostMapping("/{groupId}/members/{memberId}")
+    fun addMember(
+        @PathVariable groupId: Long,
+        @PathVariable memberId: Long
+    ): ResponseDto<FriendGroupResponse> {
+        val group = manageUseCase.addMember(groupId, memberId)
+        return ResponseDto.success(group.toResponse())
+    }
+
+    @Operation(summary = "멤버 제거")
+    @DeleteMapping("/{groupId}/members/{memberId}")
+    fun removeMember(
+        @PathVariable groupId: Long,
+        @PathVariable memberId: Long
+    ): ResponseDto<FriendGroupResponse> {
+        val group = manageUseCase.removeMember(groupId, memberId)
+        return ResponseDto.success(group.toResponse())
+    }
+
+    @Operation(summary = "그룹 삭제")
+    @DeleteMapping("/{groupId}")
+    fun deleteGroup(@PathVariable groupId: Long): ResponseDto<Unit> {
+        manageUseCase.deleteGroup(groupId)
+        return ResponseDto.success(Unit)
+    }
+
+    @Operation(summary = "그룹 단건 조회")
+    @GetMapping("/{groupId}")
+    fun getGroup(@PathVariable groupId: Long): ResponseDto<FriendGroupResponse?> {
+        val group = findUseCase.getGroup(groupId)?.toResponse()
+        return ResponseDto.success(group)
+    }
+
+    @Operation(summary = "내 그룹 목록")
+    @GetMapping
+    fun getGroups(@RequestParam ownerId: Long): ResponseDto<List<FriendGroupResponse>> {
+        val groups = findUseCase.getGroups(ownerId).map { it.toResponse() }
+        return ResponseDto.success(groups)
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/user/group/FriendGroupPersistenceAdapter.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/user/group/FriendGroupPersistenceAdapter.kt
@@ -1,0 +1,75 @@
+package com.stark.shoot.adapter.out.persistence.postgres.adapter.user.group
+
+import com.stark.shoot.adapter.out.persistence.postgres.entity.FriendGroupEntity
+import com.stark.shoot.adapter.out.persistence.postgres.entity.FriendGroupMemberEntity
+import com.stark.shoot.adapter.out.persistence.postgres.mapper.FriendGroupMapper
+import com.stark.shoot.adapter.out.persistence.postgres.repository.FriendGroupMemberRepository
+import com.stark.shoot.adapter.out.persistence.postgres.repository.FriendGroupRepository
+import com.stark.shoot.adapter.out.persistence.postgres.repository.UserRepository
+import com.stark.shoot.application.port.out.user.group.DeleteFriendGroupPort
+import com.stark.shoot.application.port.out.user.group.LoadFriendGroupPort
+import com.stark.shoot.application.port.out.user.group.SaveFriendGroupPort
+import com.stark.shoot.domain.chat.user.FriendGroup
+import com.stark.shoot.infrastructure.annotation.Adapter
+import com.stark.shoot.infrastructure.exception.web.ResourceNotFoundException
+
+@Adapter
+class FriendGroupPersistenceAdapter(
+    private val groupRepository: FriendGroupRepository,
+    private val memberRepository: FriendGroupMemberRepository,
+    private val userRepository: UserRepository,
+    private val mapper: FriendGroupMapper,
+) : SaveFriendGroupPort, LoadFriendGroupPort, DeleteFriendGroupPort {
+
+    override fun save(group: FriendGroup): FriendGroup {
+        val ownerEntity = userRepository.findById(group.ownerId)
+            .orElseThrow { ResourceNotFoundException("사용자를 찾을 수 없습니다: ${group.ownerId}") }
+
+        val entity: FriendGroupEntity = if (group.id != null) {
+            val existing = groupRepository.findById(group.id).orElseThrow { ResourceNotFoundException("그룹을 찾을 수 없습니다: ${group.id}") }
+            existing.name = group.name
+            existing.description = group.description
+            existing
+        } else {
+            mapper.toEntity(group, ownerEntity)
+        }
+
+        val saved = groupRepository.save(entity)
+
+        val currentMembers = memberRepository.findAllByGroupId(saved.id)
+        val currentIds = currentMembers.map { it.member.id!! }.toSet()
+        val toAdd = group.memberIds - currentIds
+        val toRemove = currentIds - group.memberIds
+
+        toAdd.forEach { memberId ->
+            val user = userRepository.findById(memberId)
+                .orElseThrow { ResourceNotFoundException("사용자를 찾을 수 없습니다: $memberId") }
+            memberRepository.save(FriendGroupMemberEntity(saved, user))
+        }
+        toRemove.forEach { memberId ->
+            memberRepository.deleteByGroupIdAndMemberId(saved.id, memberId)
+        }
+
+        val members = memberRepository.findAllByGroupId(saved.id).map { it.member.id!! }.toSet()
+        return mapper.toDomain(saved, members)
+    }
+
+    override fun findById(groupId: Long): FriendGroup? {
+        val entity = groupRepository.findById(groupId).orElse(null) ?: return null
+        val members = memberRepository.findAllByGroupId(entity.id).map { it.member.id!! }.toSet()
+        return mapper.toDomain(entity, members)
+    }
+
+    override fun findByOwnerId(ownerId: Long): List<FriendGroup> {
+        val groups = groupRepository.findAllByOwnerId(ownerId)
+        return groups.map { entity ->
+            val members = memberRepository.findAllByGroupId(entity.id).map { it.member.id!! }.toSet()
+            mapper.toDomain(entity, members)
+        }
+    }
+
+    override fun deleteById(groupId: Long) {
+        memberRepository.deleteAllByGroupId(groupId)
+        groupRepository.deleteById(groupId)
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/entity/FriendGroupEntity.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/entity/FriendGroupEntity.kt
@@ -1,0 +1,13 @@
+package com.stark.shoot.adapter.out.persistence.postgres.entity
+
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "friend_groups")
+class FriendGroupEntity(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "owner_id", nullable = false)
+    val owner: UserEntity,
+    var name: String,
+    var description: String?
+) : BaseEntity()

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/entity/FriendGroupMemberEntity.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/entity/FriendGroupMemberEntity.kt
@@ -1,0 +1,18 @@
+package com.stark.shoot.adapter.out.persistence.postgres.entity
+
+import jakarta.persistence.*
+
+@Entity
+@Table(
+    name = "friend_group_members",
+    uniqueConstraints = [UniqueConstraint(columnNames = ["group_id", "member_id"])]
+)
+class FriendGroupMemberEntity(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id", nullable = false)
+    val group: FriendGroupEntity,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    val member: UserEntity,
+) : BaseEntity()

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/mapper/FriendGroupMapper.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/mapper/FriendGroupMapper.kt
@@ -1,0 +1,29 @@
+package com.stark.shoot.adapter.out.persistence.postgres.mapper
+
+import com.stark.shoot.adapter.out.persistence.postgres.entity.FriendGroupEntity
+import com.stark.shoot.adapter.out.persistence.postgres.entity.UserEntity
+import com.stark.shoot.domain.chat.user.FriendGroup
+import org.springframework.stereotype.Component
+
+@Component
+class FriendGroupMapper {
+    fun toDomain(entity: FriendGroupEntity, memberIds: Set<Long>): FriendGroup {
+        return FriendGroup(
+            id = entity.id,
+            ownerId = entity.owner.id,
+            name = entity.name,
+            description = entity.description,
+            memberIds = memberIds,
+            createdAt = entity.createdAt,
+            updatedAt = entity.updatedAt
+        )
+    }
+
+    fun toEntity(domain: FriendGroup, owner: UserEntity): FriendGroupEntity {
+        return FriendGroupEntity(
+            owner = owner,
+            name = domain.name,
+            description = domain.description
+        )
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/repository/FriendGroupMemberRepository.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/repository/FriendGroupMemberRepository.kt
@@ -1,0 +1,10 @@
+package com.stark.shoot.adapter.out.persistence.postgres.repository
+
+import com.stark.shoot.adapter.out.persistence.postgres.entity.FriendGroupMemberEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface FriendGroupMemberRepository : JpaRepository<FriendGroupMemberEntity, Long> {
+    fun findAllByGroupId(groupId: Long): List<FriendGroupMemberEntity>
+    fun deleteByGroupIdAndMemberId(groupId: Long, memberId: Long)
+    fun deleteAllByGroupId(groupId: Long)
+}

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/repository/FriendGroupRepository.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/repository/FriendGroupRepository.kt
@@ -1,0 +1,8 @@
+package com.stark.shoot.adapter.out.persistence.postgres.repository
+
+import com.stark.shoot.adapter.out.persistence.postgres.entity.FriendGroupEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface FriendGroupRepository : JpaRepository<FriendGroupEntity, Long> {
+    fun findAllByOwnerId(ownerId: Long): List<FriendGroupEntity>
+}

--- a/src/main/kotlin/com/stark/shoot/application/port/in/user/group/FindFriendGroupUseCase.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/user/group/FindFriendGroupUseCase.kt
@@ -1,0 +1,8 @@
+package com.stark.shoot.application.port.`in`.user.group
+
+import com.stark.shoot.domain.chat.user.FriendGroup
+
+interface FindFriendGroupUseCase {
+    fun getGroup(groupId: Long): FriendGroup?
+    fun getGroups(ownerId: Long): List<FriendGroup>
+}

--- a/src/main/kotlin/com/stark/shoot/application/port/in/user/group/ManageFriendGroupUseCase.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/user/group/ManageFriendGroupUseCase.kt
@@ -1,0 +1,12 @@
+package com.stark.shoot.application.port.`in`.user.group
+
+import com.stark.shoot.domain.chat.user.FriendGroup
+
+interface ManageFriendGroupUseCase {
+    fun createGroup(ownerId: Long, name: String, description: String?): FriendGroup
+    fun renameGroup(groupId: Long, newName: String): FriendGroup
+    fun updateDescription(groupId: Long, description: String?): FriendGroup
+    fun addMember(groupId: Long, memberId: Long): FriendGroup
+    fun removeMember(groupId: Long, memberId: Long): FriendGroup
+    fun deleteGroup(groupId: Long)
+}

--- a/src/main/kotlin/com/stark/shoot/application/port/out/user/group/DeleteFriendGroupPort.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/out/user/group/DeleteFriendGroupPort.kt
@@ -1,0 +1,5 @@
+package com.stark.shoot.application.port.out.user.group
+
+interface DeleteFriendGroupPort {
+    fun deleteById(groupId: Long)
+}

--- a/src/main/kotlin/com/stark/shoot/application/port/out/user/group/LoadFriendGroupPort.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/out/user/group/LoadFriendGroupPort.kt
@@ -1,0 +1,8 @@
+package com.stark.shoot.application.port.out.user.group
+
+import com.stark.shoot.domain.chat.user.FriendGroup
+
+interface LoadFriendGroupPort {
+    fun findById(groupId: Long): FriendGroup?
+    fun findByOwnerId(ownerId: Long): List<FriendGroup>
+}

--- a/src/main/kotlin/com/stark/shoot/application/port/out/user/group/SaveFriendGroupPort.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/out/user/group/SaveFriendGroupPort.kt
@@ -1,0 +1,7 @@
+package com.stark.shoot.application.port.out.user.group
+
+import com.stark.shoot.domain.chat.user.FriendGroup
+
+interface SaveFriendGroupPort {
+    fun save(group: FriendGroup): FriendGroup
+}

--- a/src/main/kotlin/com/stark/shoot/application/service/user/group/FriendGroupService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/user/group/FriendGroupService.kt
@@ -1,0 +1,75 @@
+package com.stark.shoot.application.service.user.group
+
+import com.stark.shoot.application.port.`in`.user.group.FindFriendGroupUseCase
+import com.stark.shoot.application.port.`in`.user.group.ManageFriendGroupUseCase
+import com.stark.shoot.application.port.out.user.FindUserPort
+import com.stark.shoot.application.port.out.user.group.DeleteFriendGroupPort
+import com.stark.shoot.application.port.out.user.group.LoadFriendGroupPort
+import com.stark.shoot.application.port.out.user.group.SaveFriendGroupPort
+import com.stark.shoot.domain.chat.user.FriendGroup
+import com.stark.shoot.domain.service.user.group.FriendGroupDomainService
+import com.stark.shoot.infrastructure.annotation.UseCase
+import com.stark.shoot.infrastructure.exception.web.ResourceNotFoundException
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional
+@UseCase
+class FriendGroupService(
+    private val findUserPort: FindUserPort,
+    private val loadFriendGroupPort: LoadFriendGroupPort,
+    private val saveFriendGroupPort: SaveFriendGroupPort,
+    private val deleteFriendGroupPort: DeleteFriendGroupPort,
+    private val domainService: FriendGroupDomainService,
+) : ManageFriendGroupUseCase, FindFriendGroupUseCase {
+
+    override fun createGroup(ownerId: Long, name: String, description: String?): FriendGroup {
+        if (!findUserPort.existsById(ownerId)) {
+            throw ResourceNotFoundException("사용자를 찾을 수 없습니다: $ownerId")
+        }
+        val group = domainService.create(ownerId, name, description)
+        return saveFriendGroupPort.save(group)
+    }
+
+    override fun renameGroup(groupId: Long, newName: String): FriendGroup {
+        val group = loadFriendGroupPort.findById(groupId)
+            ?: throw ResourceNotFoundException("그룹을 찾을 수 없습니다: $groupId")
+        val updated = domainService.rename(group, newName)
+        return saveFriendGroupPort.save(updated)
+    }
+
+    override fun updateDescription(groupId: Long, description: String?): FriendGroup {
+        val group = loadFriendGroupPort.findById(groupId)
+            ?: throw ResourceNotFoundException("그룹을 찾을 수 없습니다: $groupId")
+        val updated = domainService.updateDescription(group, description)
+        return saveFriendGroupPort.save(updated)
+    }
+
+    override fun addMember(groupId: Long, memberId: Long): FriendGroup {
+        if (!findUserPort.existsById(memberId)) {
+            throw ResourceNotFoundException("사용자를 찾을 수 없습니다: $memberId")
+        }
+        val group = loadFriendGroupPort.findById(groupId)
+            ?: throw ResourceNotFoundException("그룹을 찾을 수 없습니다: $groupId")
+        val updated = domainService.addMember(group, memberId)
+        return saveFriendGroupPort.save(updated)
+    }
+
+    override fun removeMember(groupId: Long, memberId: Long): FriendGroup {
+        val group = loadFriendGroupPort.findById(groupId)
+            ?: throw ResourceNotFoundException("그룹을 찾을 수 없습니다: $groupId")
+        val updated = domainService.removeMember(group, memberId)
+        return saveFriendGroupPort.save(updated)
+    }
+
+    override fun deleteGroup(groupId: Long) {
+        deleteFriendGroupPort.deleteById(groupId)
+    }
+
+    override fun getGroup(groupId: Long): FriendGroup? {
+        return loadFriendGroupPort.findById(groupId)
+    }
+
+    override fun getGroups(ownerId: Long): List<FriendGroup> {
+        return loadFriendGroupPort.findByOwnerId(ownerId)
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/domain/service/user/group/FriendGroupDomainService.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/service/user/group/FriendGroupDomainService.kt
@@ -1,0 +1,21 @@
+package com.stark.shoot.domain.service.user.group
+
+import com.stark.shoot.domain.chat.user.FriendGroup
+import org.springframework.stereotype.Service
+
+@Service
+class FriendGroupDomainService {
+    fun create(ownerId: Long, name: String, description: String?): FriendGroup {
+        require(name.isNotBlank()) { "그룹 이름은 비어있을 수 없습니다." }
+        return FriendGroup(ownerId = ownerId, name = name, description = description)
+    }
+
+    fun rename(group: FriendGroup, newName: String): FriendGroup = group.rename(newName)
+
+    fun updateDescription(group: FriendGroup, description: String?): FriendGroup =
+        group.updateDescription(description)
+
+    fun addMember(group: FriendGroup, memberId: Long): FriendGroup = group.addMember(memberId)
+
+    fun removeMember(group: FriendGroup, memberId: Long): FriendGroup = group.removeMember(memberId)
+}


### PR DESCRIPTION
## Summary
- add FriendGroup ports, service, controller and domain service
- implement JPA entities and repository for friend groups
- create persistence adapter and DTO mapping

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6848272754cc8320a62c8446a5a61509