### PR TITLE
Add FriendRequest aggregate

### DIFF
--- a/src/main/kotlin/com/stark/shoot/domain/chat/user/FriendRequest.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/user/FriendRequest.kt
@@ -1,0 +1,36 @@
+package com.stark.shoot.domain.chat.user
+
+import java.time.Instant
+
+/**
+ * 친구 요청 애그리게이트
+ */
+data class FriendRequest(
+    val id: Long? = null,
+    val senderId: Long,
+    val receiverId: Long,
+    val status: FriendRequestStatus = FriendRequestStatus.PENDING,
+    val createdAt: Instant = Instant.now(),
+    val respondedAt: Instant? = null,
+) {
+    /**
+     * 친구 요청을 수락합니다.
+     */
+    fun accept(): FriendRequest {
+        return copy(status = FriendRequestStatus.ACCEPTED, respondedAt = Instant.now())
+    }
+
+    /**
+     * 친구 요청을 거절합니다.
+     */
+    fun reject(): FriendRequest {
+        return copy(status = FriendRequestStatus.REJECTED, respondedAt = Instant.now())
+    }
+
+    /**
+     * 친구 요청을 취소합니다.
+     */
+    fun cancel(): FriendRequest {
+        return copy(status = FriendRequestStatus.CANCELLED, respondedAt = Instant.now())
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/domain/chat/user/FriendRequestStatus.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/user/FriendRequestStatus.kt
@@ -1,0 +1,11 @@
+package com.stark.shoot.domain.chat.user
+
+/**
+ * 친구 요청 상태를 나타내는 열거형
+ */
+enum class FriendRequestStatus {
+    PENDING,
+    ACCEPTED,
+    REJECTED,
+    CANCELLED
+}

--- a/src/test/kotlin/com/stark/shoot/domain/chat/user/FriendRequestTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/chat/user/FriendRequestTest.kt
@@ -1,0 +1,39 @@
+package com.stark.shoot.domain.chat.user
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("FriendRequest 애그리게이트")
+class FriendRequestTest {
+
+    @Nested
+    @DisplayName("상태 변경")
+    inner class StateChange {
+
+        @Test
+        fun `친구 요청을 수락하면 ACCEPTED 상태가 된다`() {
+            val request = FriendRequest(senderId = 1L, receiverId = 2L)
+            val result = request.accept()
+            assertThat(result.status).isEqualTo(FriendRequestStatus.ACCEPTED)
+            assertThat(result.respondedAt).isNotNull()
+        }
+
+        @Test
+        fun `친구 요청을 거절하면 REJECTED 상태가 된다`() {
+            val request = FriendRequest(senderId = 1L, receiverId = 2L)
+            val result = request.reject()
+            assertThat(result.status).isEqualTo(FriendRequestStatus.REJECTED)
+            assertThat(result.respondedAt).isNotNull()
+        }
+
+        @Test
+        fun `친구 요청을 취소하면 CANCELLED 상태가 된다`() {
+            val request = FriendRequest(senderId = 1L, receiverId = 2L)
+            val result = request.cancel()
+            assertThat(result.status).isEqualTo(FriendRequestStatus.CANCELLED)
+            assertThat(result.respondedAt).isNotNull()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `FriendRequest` aggregate with state transitions
- add enum `FriendRequestStatus`
- test FriendRequest state changes

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68481935dab883209c953fde7d93d14a