### PR TITLE
Integrate FriendRequest aggregate

### DIFF
--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/user/FindUserPersistenceAdapter.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/user/FindUserPersistenceAdapter.kt
@@ -4,6 +4,7 @@ import com.stark.shoot.adapter.out.persistence.postgres.entity.UserEntity
 import com.stark.shoot.adapter.out.persistence.postgres.mapper.UserMapper
 import com.stark.shoot.adapter.out.persistence.postgres.repository.FriendRequestRepository
 import com.stark.shoot.adapter.out.persistence.postgres.repository.FriendshipMappingRepository
+import com.stark.shoot.adapter.out.persistence.postgres.entity.enumerate.FriendRequestStatus
 import com.stark.shoot.adapter.out.persistence.postgres.repository.UserRepository
 import com.stark.shoot.application.port.out.user.FindUserPort
 import com.stark.shoot.domain.chat.user.User
@@ -136,12 +137,14 @@ class FindUserPersistenceAdapter(
         val user = userMapper.toDomain(userEntity)
 
         // 받은 친구 요청 조회
-        val incomingRequestIds = friendRequestRepository.findAllByReceiverId(userId)
+        val incomingRequestIds = friendRequestRepository
+            .findAllByReceiverIdAndStatus(userId, FriendRequestStatus.PENDING)
             .map { it.sender.id!! }
             .toSet()
 
         // 보낸 친구 요청 조회
-        val outgoingRequestIds = friendRequestRepository.findAllBySenderId(userId)
+        val outgoingRequestIds = friendRequestRepository
+            .findAllBySenderIdAndStatus(userId, FriendRequestStatus.PENDING)
             .map { it.receiver.id!! }
             .toSet()
 
@@ -173,12 +176,14 @@ class FindUserPersistenceAdapter(
         val allFriendIds = outgoingFriendIds.union(incomingFriendIds)
 
         // 받은 친구 요청 조회
-        val incomingRequestIds = friendRequestRepository.findAllByReceiverId(userId)
+        val incomingRequestIds = friendRequestRepository
+            .findAllByReceiverIdAndStatus(userId, FriendRequestStatus.PENDING)
             .map { it.sender.id!! }
             .toSet()
 
         // 보낸 친구 요청 조회
-        val outgoingRequestIds = friendRequestRepository.findAllBySenderId(userId)
+        val outgoingRequestIds = friendRequestRepository
+            .findAllBySenderIdAndStatus(userId, FriendRequestStatus.PENDING)
             .map { it.receiver.id!! }
             .toSet()
 
@@ -214,7 +219,11 @@ class FindUserPersistenceAdapter(
         userId: Long,
         targetId: Long
     ): Boolean {
-        return friendRequestRepository.existsBySenderIdAndReceiverId(userId, targetId)
+        return friendRequestRepository.existsBySenderIdAndReceiverIdAndStatus(
+            userId,
+            targetId,
+            FriendRequestStatus.PENDING
+        )
     }
 
     /**
@@ -224,7 +233,11 @@ class FindUserPersistenceAdapter(
         userId: Long,
         requesterId: Long
     ): Boolean {
-        return friendRequestRepository.existsBySenderIdAndReceiverId(requesterId, userId)
+        return friendRequestRepository.existsBySenderIdAndReceiverIdAndStatus(
+            requesterId,
+            userId,
+            FriendRequestStatus.PENDING
+        )
     }
 
 }

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/user/friend/RecommendFriendJpaAdapter.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/user/friend/RecommendFriendJpaAdapter.kt
@@ -4,6 +4,7 @@ import com.stark.shoot.adapter.out.persistence.postgres.entity.UserEntity
 import com.stark.shoot.adapter.out.persistence.postgres.mapper.UserMapper
 import com.stark.shoot.adapter.out.persistence.postgres.repository.FriendRequestRepository
 import com.stark.shoot.adapter.out.persistence.postgres.repository.FriendshipMappingRepository
+import com.stark.shoot.adapter.out.persistence.postgres.entity.enumerate.FriendRequestStatus
 import com.stark.shoot.application.port.out.user.friend.RecommendFriendPort
 import com.stark.shoot.domain.chat.user.User
 import com.stark.shoot.infrastructure.annotation.Adapter
@@ -95,12 +96,14 @@ class RecommendFriendJpaAdapter(
         excludeIds.addAll(incomingFriendIds)
 
         // 보낸 친구 요청 추가
-        val outgoingRequestIds = friendRequestRepository.findAllBySenderId(userId)
+        val outgoingRequestIds = friendRequestRepository
+            .findAllBySenderIdAndStatus(userId, FriendRequestStatus.PENDING)
             .map { it.receiver.id!! }
         excludeIds.addAll(outgoingRequestIds)
 
         // 받은 친구 요청 추가
-        val incomingRequestIds = friendRequestRepository.findAllByReceiverId(userId)
+        val incomingRequestIds = friendRequestRepository
+            .findAllByReceiverIdAndStatus(userId, FriendRequestStatus.PENDING)
             .map { it.sender.id!! }
         excludeIds.addAll(incomingRequestIds)
 

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/entity/FriendRequestEntity.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/entity/FriendRequestEntity.kt
@@ -1,9 +1,7 @@
 package com.stark.shoot.adapter.out.persistence.postgres.entity
 
-import jakarta.persistence.Entity
-import jakarta.persistence.JoinColumn
-import jakarta.persistence.ManyToOne
-import jakarta.persistence.Table
+import jakarta.persistence.*
+import com.stark.shoot.adapter.out.persistence.postgres.entity.enumerate.FriendRequestStatus
 import java.time.Instant
 
 // 친구 요청 정보를 따로 관리하여, 보낸 요청과 받은 요청을 모두 처리할 수 있습니다.
@@ -20,6 +18,11 @@ class FriendRequestEntity(
     @JoinColumn(name = "receiver_id", referencedColumnName = "id")
     val receiver: UserEntity,
 
+    @Enumerated(EnumType.STRING)
+    var status: FriendRequestStatus = FriendRequestStatus.PENDING,
+
     // 요청 보낸 시간 등 추가 정보도 관리 가능
-    val requestDate: Instant = Instant.now()
+    val requestDate: Instant = Instant.now(),
+
+    var respondedAt: Instant? = null,
 ) : BaseEntity()

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/entity/enumerate/FriendRequestStatus.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/entity/enumerate/FriendRequestStatus.kt
@@ -1,0 +1,8 @@
+package com.stark.shoot.adapter.out.persistence.postgres.entity.enumerate
+
+enum class FriendRequestStatus {
+    PENDING,
+    ACCEPTED,
+    REJECTED,
+    CANCELLED
+}

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/mapper/FriendRequestMapper.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/mapper/FriendRequestMapper.kt
@@ -1,0 +1,44 @@
+package com.stark.shoot.adapter.out.persistence.postgres.mapper
+
+import com.stark.shoot.adapter.out.persistence.postgres.entity.FriendRequestEntity
+import com.stark.shoot.adapter.out.persistence.postgres.entity.UserEntity
+import com.stark.shoot.adapter.out.persistence.postgres.entity.enumerate.FriendRequestStatus as PersistenceStatus
+import com.stark.shoot.domain.chat.user.FriendRequest
+import com.stark.shoot.domain.chat.user.FriendRequestStatus as DomainStatus
+import org.springframework.stereotype.Component
+
+@Component
+class FriendRequestMapper {
+    fun toEntity(domain: FriendRequest, sender: UserEntity, receiver: UserEntity): FriendRequestEntity {
+        val status = when (domain.status) {
+            DomainStatus.PENDING -> PersistenceStatus.PENDING
+            DomainStatus.ACCEPTED -> PersistenceStatus.ACCEPTED
+            DomainStatus.REJECTED -> PersistenceStatus.REJECTED
+            DomainStatus.CANCELLED -> PersistenceStatus.CANCELLED
+        }
+        return FriendRequestEntity(
+            sender = sender,
+            receiver = receiver,
+            status = status,
+            requestDate = domain.createdAt,
+            respondedAt = domain.respondedAt
+        )
+    }
+
+    fun toDomain(entity: FriendRequestEntity): FriendRequest {
+        val status = when (entity.status) {
+            PersistenceStatus.PENDING -> DomainStatus.PENDING
+            PersistenceStatus.ACCEPTED -> DomainStatus.ACCEPTED
+            PersistenceStatus.REJECTED -> DomainStatus.REJECTED
+            PersistenceStatus.CANCELLED -> DomainStatus.CANCELLED
+        }
+        return FriendRequest(
+            id = entity.id,
+            senderId = entity.sender.id!!,
+            receiverId = entity.receiver.id!!,
+            status = status,
+            createdAt = entity.requestDate,
+            respondedAt = entity.respondedAt
+        )
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/repository/FriendRequestRepository.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/repository/FriendRequestRepository.kt
@@ -1,11 +1,12 @@
 package com.stark.shoot.adapter.out.persistence.postgres.repository
 
 import com.stark.shoot.adapter.out.persistence.postgres.entity.FriendRequestEntity
+import com.stark.shoot.adapter.out.persistence.postgres.entity.enumerate.FriendRequestStatus
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface FriendRequestRepository : JpaRepository<FriendRequestEntity, Long> {
-    fun findAllBySenderId(senderId: Long): List<FriendRequestEntity>
-    fun findAllByReceiverId(receiverId: Long): List<FriendRequestEntity>
-    fun deleteBySenderIdAndReceiverId(senderId: Long, receiverId: Long)
-    fun existsBySenderIdAndReceiverId(senderId: Long, receiverId: Long): Boolean
+    fun findAllBySenderIdAndStatus(senderId: Long, status: FriendRequestStatus): List<FriendRequestEntity>
+    fun findAllByReceiverIdAndStatus(receiverId: Long, status: FriendRequestStatus): List<FriendRequestEntity>
+    fun findBySenderIdAndReceiverId(senderId: Long, receiverId: Long): FriendRequestEntity?
+    fun existsBySenderIdAndReceiverIdAndStatus(senderId: Long, receiverId: Long, status: FriendRequestStatus): Boolean
 }


### PR DESCRIPTION
## Summary
- add FriendRequestStatus enum and mapper
- extend FriendRequestEntity with status and respondedAt fields
- update persistence adapters and repositories to work with the new fields
- keep controller paths unchanged

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68482b1d91648320bb13aa1ac7fcf664