### PR TITLE
Fix duplicate FriendRequestStatus enum

### DIFF
--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/user/FindUserPersistenceAdapter.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/user/FindUserPersistenceAdapter.kt
@@ -4,7 +4,7 @@ import com.stark.shoot.adapter.out.persistence.postgres.entity.UserEntity
 import com.stark.shoot.adapter.out.persistence.postgres.mapper.UserMapper
 import com.stark.shoot.adapter.out.persistence.postgres.repository.FriendRequestRepository
 import com.stark.shoot.adapter.out.persistence.postgres.repository.FriendshipMappingRepository
-import com.stark.shoot.adapter.out.persistence.postgres.entity.enumerate.FriendRequestStatus
+import com.stark.shoot.domain.chat.user.FriendRequestStatus
 import com.stark.shoot.adapter.out.persistence.postgres.repository.UserRepository
 import com.stark.shoot.application.port.out.user.FindUserPort
 import com.stark.shoot.domain.chat.user.User

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/user/friend/FriendPersistenceAdapter.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/user/friend/FriendPersistenceAdapter.kt
@@ -2,7 +2,7 @@ package com.stark.shoot.adapter.out.persistence.postgres.adapter.user.friend
 
 import com.stark.shoot.adapter.out.persistence.postgres.entity.FriendRequestEntity
 import com.stark.shoot.adapter.out.persistence.postgres.entity.FriendshipMappingEntity
-import com.stark.shoot.adapter.out.persistence.postgres.entity.enumerate.FriendRequestStatus
+import com.stark.shoot.domain.chat.user.FriendRequestStatus
 import com.stark.shoot.adapter.out.persistence.postgres.mapper.UserMapper
 import com.stark.shoot.adapter.out.persistence.postgres.repository.FriendRequestRepository
 import com.stark.shoot.adapter.out.persistence.postgres.repository.FriendshipMappingRepository

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/user/friend/RecommendFriendJpaAdapter.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/user/friend/RecommendFriendJpaAdapter.kt
@@ -4,7 +4,7 @@ import com.stark.shoot.adapter.out.persistence.postgres.entity.UserEntity
 import com.stark.shoot.adapter.out.persistence.postgres.mapper.UserMapper
 import com.stark.shoot.adapter.out.persistence.postgres.repository.FriendRequestRepository
 import com.stark.shoot.adapter.out.persistence.postgres.repository.FriendshipMappingRepository
-import com.stark.shoot.adapter.out.persistence.postgres.entity.enumerate.FriendRequestStatus
+import com.stark.shoot.domain.chat.user.FriendRequestStatus
 import com.stark.shoot.application.port.out.user.friend.RecommendFriendPort
 import com.stark.shoot.domain.chat.user.User
 import com.stark.shoot.infrastructure.annotation.Adapter

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/entity/FriendRequestEntity.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/entity/FriendRequestEntity.kt
@@ -1,7 +1,7 @@
 package com.stark.shoot.adapter.out.persistence.postgres.entity
 
 import jakarta.persistence.*
-import com.stark.shoot.adapter.out.persistence.postgres.entity.enumerate.FriendRequestStatus
+import com.stark.shoot.domain.chat.user.FriendRequestStatus
 import java.time.Instant
 
 // 친구 요청 정보를 따로 관리하여, 보낸 요청과 받은 요청을 모두 처리할 수 있습니다.

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/entity/enumerate/FriendRequestStatus.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/entity/enumerate/FriendRequestStatus.kt
@@ -1,8 +1,0 @@
-package com.stark.shoot.adapter.out.persistence.postgres.entity.enumerate
-
-enum class FriendRequestStatus {
-    PENDING,
-    ACCEPTED,
-    REJECTED,
-    CANCELLED
-}

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/mapper/FriendRequestMapper.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/mapper/FriendRequestMapper.kt
@@ -2,41 +2,28 @@ package com.stark.shoot.adapter.out.persistence.postgres.mapper
 
 import com.stark.shoot.adapter.out.persistence.postgres.entity.FriendRequestEntity
 import com.stark.shoot.adapter.out.persistence.postgres.entity.UserEntity
-import com.stark.shoot.adapter.out.persistence.postgres.entity.enumerate.FriendRequestStatus as PersistenceStatus
 import com.stark.shoot.domain.chat.user.FriendRequest
-import com.stark.shoot.domain.chat.user.FriendRequestStatus as DomainStatus
+import com.stark.shoot.domain.chat.user.FriendRequestStatus
 import org.springframework.stereotype.Component
 
 @Component
 class FriendRequestMapper {
     fun toEntity(domain: FriendRequest, sender: UserEntity, receiver: UserEntity): FriendRequestEntity {
-        val status = when (domain.status) {
-            DomainStatus.PENDING -> PersistenceStatus.PENDING
-            DomainStatus.ACCEPTED -> PersistenceStatus.ACCEPTED
-            DomainStatus.REJECTED -> PersistenceStatus.REJECTED
-            DomainStatus.CANCELLED -> PersistenceStatus.CANCELLED
-        }
         return FriendRequestEntity(
             sender = sender,
             receiver = receiver,
-            status = status,
+            status = domain.status,
             requestDate = domain.createdAt,
             respondedAt = domain.respondedAt
         )
     }
 
     fun toDomain(entity: FriendRequestEntity): FriendRequest {
-        val status = when (entity.status) {
-            PersistenceStatus.PENDING -> DomainStatus.PENDING
-            PersistenceStatus.ACCEPTED -> DomainStatus.ACCEPTED
-            PersistenceStatus.REJECTED -> DomainStatus.REJECTED
-            PersistenceStatus.CANCELLED -> DomainStatus.CANCELLED
-        }
         return FriendRequest(
             id = entity.id,
             senderId = entity.sender.id!!,
             receiverId = entity.receiver.id!!,
-            status = status,
+            status = entity.status,
             createdAt = entity.requestDate,
             respondedAt = entity.respondedAt
         )

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/repository/FriendRequestRepository.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/repository/FriendRequestRepository.kt
@@ -1,7 +1,7 @@
 package com.stark.shoot.adapter.out.persistence.postgres.repository
 
 import com.stark.shoot.adapter.out.persistence.postgres.entity.FriendRequestEntity
-import com.stark.shoot.adapter.out.persistence.postgres.entity.enumerate.FriendRequestStatus
+import com.stark.shoot.domain.chat.user.FriendRequestStatus
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface FriendRequestRepository : JpaRepository<FriendRequestEntity, Long> {


### PR DESCRIPTION
## Summary
- remove persistence-specific FriendRequestStatus enum
- use domain FriendRequestStatus across persistence layer
- simplify FriendRequestMapper conversions

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68482eaff7788320b2e031f2f84ee727