### PR TITLE
Refactor controllers to use DTO outputs

### DIFF
--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/chatroom/ChatRoomController.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/chatroom/ChatRoomController.kt
@@ -26,7 +26,7 @@ class ChatRoomController(
         @RequestParam friendId: Long
     ): ResponseDto<ChatRoomResponse> {
         val room = createChatRoomUseCase.createDirectChat(userId, friendId)
-        return ResponseDto.success(ChatRoomResponse.from(room, userId), "채팅방이 생성되었습니다.")
+        return ResponseDto.success(room, "채팅방이 생성되었습니다.")
     }
 
     @Operation(summary = "사용자의 채팅방 목록 조회", description = "특정 사용자의 채팅방 전체 목록을 조회합니다.")

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/chatroom/ChatRoomFavoriteController.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/chatroom/ChatRoomFavoriteController.kt
@@ -29,7 +29,7 @@ class ChatRoomFavoriteController(
     ): ResponseDto<ChatRoomResponse> {
         val updatedRoom = updateFavoriteUseCase.updateFavoriteStatus(roomId, userId, isFavorite)
         val message = if (isFavorite) "채팅방이 즐겨찾기에 추가되었습니다." else "채팅방이 즐겨찾기에서 제거되었습니다."
-        return ResponseDto.success(ChatRoomResponse.from(updatedRoom, userId), message)
+        return ResponseDto.success(updatedRoom, message)
     }
 
 }

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/chatroom/ChatRoomResponse.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/chatroom/ChatRoomResponse.kt
@@ -2,9 +2,10 @@ package com.stark.shoot.adapter.`in`.web.dto.chatroom
 
 import com.stark.shoot.domain.chat.room.ChatRoomType
 import com.stark.shoot.domain.chat.room.ChatRoom
+import com.stark.shoot.infrastructure.annotation.ApplicationDto
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
-
+@ApplicationDto
 data class ChatRoomResponse(
     val roomId: Long,
     val title: String,  // 1:1 채팅인 경우, 상대방의 이름이나 채팅방 제목을 담습니다.

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/user/LoginDto.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/user/LoginDto.kt
@@ -1,4 +1,6 @@
-package com.stark.shoot.application.dto.user
+package com.stark.shoot.adapter.`in`.web.dto.user
+
+import com.stark.shoot.infrastructure.annotation.ApplicationDto
 
 /**
  * 사용자 로그인 요청
@@ -11,6 +13,7 @@ data class LoginRequest(
 /**
  * 로그인 응답
  */
+@ApplicationDto
 data class LoginResponse(
     val userId: String,
     val accessToken: String,

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/user/AuthController.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/user/AuthController.kt
@@ -1,8 +1,8 @@
 package com.stark.shoot.adapter.`in`.web.user
 
 import com.stark.shoot.adapter.`in`.web.dto.ResponseDto
-import com.stark.shoot.application.dto.user.LoginRequest
-import com.stark.shoot.application.dto.user.LoginResponse
+import com.stark.shoot.adapter.`in`.web.dto.user.LoginRequest
+import com.stark.shoot.adapter.`in`.web.dto.user.LoginResponse
 import com.stark.shoot.adapter.`in`.web.dto.user.UserResponse
 import com.stark.shoot.application.port.`in`.user.auth.UserAuthUseCase
 import com.stark.shoot.application.port.`in`.user.auth.UserLoginUseCase

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/user/TokenController.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/user/TokenController.kt
@@ -1,7 +1,7 @@
 package com.stark.shoot.adapter.`in`.web.user
 
 import com.stark.shoot.adapter.`in`.web.dto.ResponseDto
-import com.stark.shoot.application.dto.user.LoginResponse
+import com.stark.shoot.adapter.`in`.web.dto.user.LoginResponse
 import com.stark.shoot.application.port.`in`.user.token.RefreshTokenUseCase
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag

--- a/src/main/kotlin/com/stark/shoot/application/port/in/chatroom/CreateChatRoomUseCase.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/chatroom/CreateChatRoomUseCase.kt
@@ -1,7 +1,7 @@
 package com.stark.shoot.application.port.`in`.chatroom
 
-import com.stark.shoot.domain.chat.room.ChatRoom
+import com.stark.shoot.adapter.`in`.web.dto.chatroom.ChatRoomResponse
 
 interface CreateChatRoomUseCase {
-    fun createDirectChat(userId: Long, friendId: Long): ChatRoom
+    fun createDirectChat(userId: Long, friendId: Long): ChatRoomResponse
 }

--- a/src/main/kotlin/com/stark/shoot/application/port/in/chatroom/UpdateChatRoomFavoriteUseCase.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/chatroom/UpdateChatRoomFavoriteUseCase.kt
@@ -1,7 +1,7 @@
 package com.stark.shoot.application.port.`in`.chatroom
 
-import com.stark.shoot.domain.chat.room.ChatRoom
+import com.stark.shoot.adapter.`in`.web.dto.chatroom.ChatRoomResponse
 
 interface UpdateChatRoomFavoriteUseCase {
-    fun updateFavoriteStatus(roomId: Long, userId: Long, isFavorite: Boolean): ChatRoom
+    fun updateFavoriteStatus(roomId: Long, userId: Long, isFavorite: Boolean): ChatRoomResponse
 }

--- a/src/main/kotlin/com/stark/shoot/application/port/in/user/auth/UserLoginUseCase.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/user/auth/UserLoginUseCase.kt
@@ -1,7 +1,7 @@
 package com.stark.shoot.application.port.`in`.user.auth
 
-import com.stark.shoot.application.dto.user.LoginRequest
-import com.stark.shoot.application.dto.user.LoginResponse
+import com.stark.shoot.adapter.`in`.web.dto.user.LoginRequest
+import com.stark.shoot.adapter.`in`.web.dto.user.LoginResponse
 
 interface UserLoginUseCase {
     fun login(request: LoginRequest): LoginResponse

--- a/src/main/kotlin/com/stark/shoot/application/port/in/user/token/RefreshTokenUseCase.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/user/token/RefreshTokenUseCase.kt
@@ -1,6 +1,6 @@
 package com.stark.shoot.application.port.`in`.user.token
 
-import com.stark.shoot.application.dto.user.LoginResponse
+import com.stark.shoot.adapter.`in`.web.dto.user.LoginResponse
 
 interface RefreshTokenUseCase {
     fun generateNewAccessToken(refreshTokenHeader: String): LoginResponse

--- a/src/main/kotlin/com/stark/shoot/application/service/chatroom/UpdateChatRoomFavoriteService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/chatroom/UpdateChatRoomFavoriteService.kt
@@ -4,6 +4,7 @@ import com.stark.shoot.application.port.`in`.chatroom.UpdateChatRoomFavoriteUseC
 import com.stark.shoot.application.port.out.chatroom.LoadChatRoomPort
 import com.stark.shoot.application.port.out.chatroom.LoadPinnedRoomsPort
 import com.stark.shoot.application.port.out.chatroom.SaveChatRoomPort
+import com.stark.shoot.adapter.`in`.web.dto.chatroom.ChatRoomResponse
 import com.stark.shoot.domain.chat.room.ChatRoom
 import com.stark.shoot.infrastructure.annotation.UseCase
 import com.stark.shoot.infrastructure.exception.web.ResourceNotFoundException
@@ -24,7 +25,7 @@ class UpdateChatRoomFavoriteService(
         roomId: Long,
         userId: Long,
         isFavorite: Boolean
-    ): ChatRoom {
+    ): ChatRoomResponse {
         // 채팅방 조회 (도메인 객체로 반환)
         val chatRoom: ChatRoom = loadChatRoomPort.findById(roomId)
             ?: throw ResourceNotFoundException("채팅방을 찾을 수 없습니다. id=$roomId")
@@ -39,6 +40,7 @@ class UpdateChatRoomFavoriteService(
             userPinnedRoomsCount = pinnedRooms.size
         )
 
-        return saveChatRoomPort.save(updatedChatRoom)
+        val saved = saveChatRoomPort.save(updatedChatRoom)
+        return ChatRoomResponse.from(saved, userId)
     }
 }

--- a/src/main/kotlin/com/stark/shoot/application/service/message/ForwardMessageToUserService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/message/ForwardMessageToUserService.kt
@@ -4,6 +4,7 @@ import com.stark.shoot.application.port.`in`.chatroom.CreateChatRoomUseCase
 import com.stark.shoot.application.port.`in`.message.ForwardMessageToUserUseCase
 import com.stark.shoot.application.port.`in`.message.ForwardMessageUseCase
 import com.stark.shoot.domain.chat.message.ChatMessage
+import com.stark.shoot.adapter.`in`.web.dto.chatroom.ChatRoomResponse
 import com.stark.shoot.infrastructure.annotation.UseCase
 
 @UseCase
@@ -22,13 +23,12 @@ class ForwardMessageToUserService(
         forwardingUserId: Long
     ): ChatMessage {
         // 1. 사용자 간 1:1 채팅방 생성 또는 조회
-        val chatRoom = createChatRoomUseCase.createDirectChat(
+        val chatRoom: ChatRoomResponse = createChatRoomUseCase.createDirectChat(
             userId = forwardingUserId,
             friendId = targetUserId
         )
 
-        // 채팅방 ID가 null인 경우 예외 처리
-        val roomId = chatRoom.id ?: throw IllegalStateException("채팅방 ID가 null입니다. 메시지를 전달할 수 없습니다.")
+        val roomId = chatRoom.roomId
 
         // 2. 해당 채팅방으로 메시지 전달
         return forwardMessageUseCase.forwardMessage(

--- a/src/main/kotlin/com/stark/shoot/application/service/user/auth/UserLoginService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/user/auth/UserLoginService.kt
@@ -1,7 +1,7 @@
 package com.stark.shoot.application.service.user.auth
 
-import com.stark.shoot.application.dto.user.LoginRequest
-import com.stark.shoot.application.dto.user.LoginResponse
+import com.stark.shoot.adapter.`in`.web.dto.user.LoginRequest
+import com.stark.shoot.adapter.`in`.web.dto.user.LoginResponse
 import com.stark.shoot.application.port.`in`.user.auth.UserLoginUseCase
 import com.stark.shoot.application.port.out.user.FindUserPort
 import com.stark.shoot.application.port.out.user.token.RefreshTokenPort

--- a/src/main/kotlin/com/stark/shoot/application/service/user/token/RefreshTokenService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/user/token/RefreshTokenService.kt
@@ -1,6 +1,6 @@
 package com.stark.shoot.application.service.user.token
 
-import com.stark.shoot.application.dto.user.LoginResponse
+import com.stark.shoot.adapter.`in`.web.dto.user.LoginResponse
 import com.stark.shoot.application.port.`in`.user.token.RefreshTokenUseCase
 import com.stark.shoot.application.port.out.user.token.RefreshTokenPort
 import com.stark.shoot.infrastructure.annotation.UseCase

--- a/src/main/kotlin/com/stark/shoot/infrastructure/annotation/ApplicationDto.kt
+++ b/src/main/kotlin/com/stark/shoot/infrastructure/annotation/ApplicationDto.kt
@@ -1,0 +1,10 @@
+package com.stark.shoot.infrastructure.annotation
+
+/**
+ * Marker annotation for DTOs returned from the application layer.
+ * This helps separate domain models from external adapters.
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@MustBeDocumented
+annotation class ApplicationDto


### PR DESCRIPTION
## Summary
- mark application layer DTOs with `@ApplicationDto`
- move Login DTOs to adapter layer
- return `ChatRoomResponse` from create and favorite chatroom use cases
- adapt services and controllers to new signatures

## Testing
- `./gradlew test --no-build-cache` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6848413103f483208f52fe20de50facd