### PR TITLE
Add metadata conversion helpers

### DIFF
--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/mapper/ChatMessageMetadataExtensions.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/mapper/ChatMessageMetadataExtensions.kt
@@ -1,0 +1,25 @@
+package com.stark.shoot.adapter.out.persistence.mongodb.mapper
+
+import com.stark.shoot.adapter.`in`.web.dto.message.MessageMetadataResponseDto
+import com.stark.shoot.adapter.out.persistence.mongodb.document.message.embedded.MessageMetadataDocument
+import com.stark.shoot.domain.chat.message.ChatMessageMetadata
+
+fun ChatMessageMetadata.toMessageMetadataDocument(): MessageMetadataDocument {
+    return MessageMetadataDocument(
+        tempId = tempId,
+        needsUrlPreview = needsUrlPreview,
+        previewUrl = previewUrl,
+        urlPreview = urlPreview,
+        readAt = readAt
+    )
+}
+
+fun ChatMessageMetadata.toMessageMetadataResponseDto(): MessageMetadataResponseDto {
+    return MessageMetadataResponseDto(
+        tempId = tempId,
+        needsUrlPreview = needsUrlPreview,
+        previewUrl = previewUrl,
+        urlPreview = urlPreview,
+        readAt = readAt
+    )
+}


### PR DESCRIPTION
## Summary
- provide extensions to convert `ChatMessageMetadata` to persistence documents and response DTOs

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684848dbd2808320a360f93d782256b3