### PR TITLE
Add comprehensive domain service tests

### DIFF
--- a/src/test/kotlin/com/stark/shoot/domain/chat/bookmark/MessageBookmarkTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/chat/bookmark/MessageBookmarkTest.kt
@@ -1,0 +1,41 @@
+package com.stark.shoot.domain.chat.bookmark
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+@DisplayName("메시지 북마크 도메인 테스트")
+class MessageBookmarkTest {
+
+    @Nested
+    @DisplayName("북마크 생성 시")
+    inner class CreateBookmark {
+        @Test
+        fun `필수 정보로 북마크를 생성할 수 있다`() {
+            val bookmark = MessageBookmark(messageId = "m1", userId = 1L)
+
+            assertThat(bookmark.id).isNull()
+            assertThat(bookmark.messageId).isEqualTo("m1")
+            assertThat(bookmark.userId).isEqualTo(1L)
+            assertThat(bookmark.createdAt).isNotNull()
+        }
+
+        @Test
+        fun `모든 정보를 사용하여 북마크를 생성할 수 있다`() {
+            val now = Instant.now()
+            val bookmark = MessageBookmark(
+                id = "b1",
+                messageId = "m1",
+                userId = 2L,
+                createdAt = now
+            )
+
+            assertThat(bookmark.id).isEqualTo("b1")
+            assertThat(bookmark.messageId).isEqualTo("m1")
+            assertThat(bookmark.userId).isEqualTo(2L)
+            assertThat(bookmark.createdAt).isEqualTo(now)
+        }
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/domain/service/chatroom/ChatRoomDomainServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/service/chatroom/ChatRoomDomainServiceTest.kt
@@ -1,0 +1,36 @@
+package com.stark.shoot.domain.service.chatroom
+
+import com.stark.shoot.domain.chat.room.ChatRoom
+import com.stark.shoot.domain.chat.room.ChatRoomType
+import com.stark.shoot.domain.chat.room.service.ChatRoomDomainService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+@DisplayName("채팅방 도메인 서비스 테스트")
+class ChatRoomDomainServiceTest {
+    private val service = ChatRoomDomainService()
+
+    @Test
+    fun `채팅방 리스트를 제목으로 필터링할 수 있다`() {
+        val rooms = listOf(
+            ChatRoom(id = 1L, title = "hello", type = ChatRoomType.GROUP, participants = mutableSetOf(1L)),
+            ChatRoom(id = 2L, title = "world", type = ChatRoomType.GROUP, participants = mutableSetOf(1L))
+        )
+        val result = service.filterChatRooms(rooms, "hello", null, null, 1L)
+        assertThat(result.map { it.id }).containsExactly(1L)
+    }
+
+    @Test
+    fun `채팅방 제목 맵을 준비할 수 있다`() {
+        val now = Instant.now()
+        val rooms = listOf(
+            ChatRoom(id = 1L, title = "room1", type = ChatRoomType.GROUP, participants = mutableSetOf(1L), lastActiveAt = now),
+            ChatRoom(id = 2L, title = null, type = ChatRoomType.INDIVIDUAL, participants = mutableSetOf(1L,2L), lastActiveAt = now)
+        )
+        val titles = service.prepareChatRoomTitles(rooms, 1L)
+        assertThat(titles[1L]).isEqualTo("room1")
+        assertThat(titles[2L]).isEqualTo("1:1 채팅방")
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/domain/service/chatroom/ChatRoomEventServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/service/chatroom/ChatRoomEventServiceTest.kt
@@ -1,0 +1,30 @@
+package com.stark.shoot.domain.service.chatroom
+
+import com.stark.shoot.domain.chat.event.ChatRoomCreatedEvent
+import com.stark.shoot.domain.chat.room.ChatRoom
+import com.stark.shoot.domain.chat.room.ChatRoomType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("채팅방 이벤트 도메인 서비스 테스트")
+class ChatRoomEventServiceTest {
+    private val service = ChatRoomEventService()
+
+    @Test
+    fun `채팅방 생성 이벤트를 생성할 수 있다`() {
+        val room = ChatRoom(id = 1L, title = "room", type = ChatRoomType.GROUP, participants = mutableSetOf(1L,2L))
+        val events = service.createChatRoomCreatedEvents(room)
+        assertThat(events).hasSize(2)
+        assertThat(events[0]).isEqualTo(ChatRoomCreatedEvent.create(1L, 1L))
+        assertThat(events[1]).isEqualTo(ChatRoomCreatedEvent.create(1L, 2L))
+    }
+
+    @Test
+    fun `ID가 없는 채팅방 이벤트 생성 시 예외가 발생한다`() {
+        val room = ChatRoom(title = "room", type = ChatRoomType.GROUP, participants = mutableSetOf(1L))
+        org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
+            service.createChatRoomCreatedEvents(room)
+        }
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/domain/service/chatroom/ChatRoomMetadataDomainServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/service/chatroom/ChatRoomMetadataDomainServiceTest.kt
@@ -1,0 +1,33 @@
+package com.stark.shoot.domain.service.chatroom
+
+import com.stark.shoot.domain.chat.message.ChatMessage
+import com.stark.shoot.domain.chat.message.MessageContent
+import com.stark.shoot.domain.chat.message.type.MessageStatus
+import com.stark.shoot.domain.chat.message.type.MessageType
+import com.stark.shoot.domain.chat.room.ChatRoom
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Instant
+
+@DisplayName("채팅방 메타데이터 도메인 서비스 테스트")
+class ChatRoomMetadataDomainServiceTest {
+    private val service = ChatRoomMetadataDomainService()
+
+    @Test
+    fun `메시지 ID가 없으면 예외가 발생한다`() {
+        val room = ChatRoom(title = "room", type = com.stark.shoot.domain.chat.room.ChatRoomType.GROUP, participants = mutableSetOf(1L))
+        val msg = ChatMessage(roomId = 1L, senderId = 2L, content = MessageContent("hi", MessageType.TEXT), status = MessageStatus.SAVED, createdAt = Instant.now())
+        assertThrows<IllegalArgumentException> { service.updateChatRoomWithNewMessage(room, msg) }
+    }
+
+    @Test
+    fun `새 메시지로 채팅방 메타데이터를 업데이트할 수 있다`() {
+        val room = ChatRoom(id = 1L, title = "room", type = com.stark.shoot.domain.chat.room.ChatRoomType.GROUP, participants = mutableSetOf(1L))
+        val msg = ChatMessage(id = "m1", roomId = 1L, senderId = 2L, content = MessageContent("hi", MessageType.TEXT), status = MessageStatus.SAVED, createdAt = Instant.now())
+        val updated = service.updateChatRoomWithNewMessage(room, msg)
+        assertThat(updated.lastMessageId).isEqualTo("m1")
+        assertThat(updated.lastActiveAt).isAfter(room.lastActiveAt)
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/domain/service/message/MessageDomainServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/service/message/MessageDomainServiceTest.kt
@@ -1,0 +1,47 @@
+package com.stark.shoot.domain.service.message
+
+import com.stark.shoot.domain.chat.event.EventType
+import com.stark.shoot.domain.chat.message.type.MessageType
+import com.stark.shoot.domain.chat.message.UrlPreview
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("메시지 도메인 서비스 테스트")
+class MessageDomainServiceTest {
+
+    private val service = MessageDomainService()
+
+    @Test
+    fun `메시지를 생성하고 URL 미리보기를 적용할 수 있다`() {
+        val result = service.createAndProcessMessage(
+            roomId = 1L,
+            senderId = 2L,
+            contentText = "check https://example.com",
+            contentType = MessageType.TEXT,
+            extractUrls = { listOf("https://example.com") },
+            getCachedPreview = { UrlPreview(it, "Example", "desc") }
+        )
+
+        assertThat(result.content.text).contains("check")
+        assertThat(result.metadata.urlPreview).isNotNull()
+        assertThat(result.metadata.urlPreview?.title).isEqualTo("Example")
+    }
+
+    @Test
+    fun `메시지로 이벤트를 생성할 수 있다`() {
+        val message = service.createAndProcessMessage(
+            roomId = 1L,
+            senderId = 2L,
+            contentText = "hello",
+            contentType = MessageType.TEXT,
+            extractUrls = { emptyList() },
+            getCachedPreview = { null }
+        )
+
+        val event = service.createMessageEvent(message)
+
+        assertThat(event.type).isEqualTo(EventType.MESSAGE_CREATED)
+        assertThat(event.data).isEqualTo(message)
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/domain/service/message/MessageEditDomainServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/service/message/MessageEditDomainServiceTest.kt
@@ -1,0 +1,65 @@
+package com.stark.shoot.domain.service.message
+
+import com.stark.shoot.domain.chat.message.ChatMessage
+import com.stark.shoot.domain.chat.message.MessageContent
+import com.stark.shoot.domain.chat.message.type.MessageStatus
+import com.stark.shoot.domain.chat.message.type.MessageType
+import com.stark.shoot.domain.service.chatroom.EditabilityResult
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Instant
+
+@DisplayName("메시지 편집 도메인 서비스 테스트")
+class MessageEditDomainServiceTest {
+    private val service = MessageEditDomainService()
+
+    private fun baseMessage(createdAt: Instant = Instant.now()) = ChatMessage(
+        id = "m1",
+        roomId = 1L,
+        senderId = 2L,
+        content = MessageContent("text", MessageType.TEXT),
+        status = MessageStatus.SAVED,
+        createdAt = createdAt
+    )
+
+    @Nested
+    inner class CanEditMessage {
+        @Test
+        fun `삭제된 메시지는 수정할 수 없다`() {
+            val msg = baseMessage().copy(content = MessageContent("text", MessageType.TEXT, isDeleted = true))
+            val result = service.canEditMessage(msg)
+            assertThat(result).isEqualTo(EditabilityResult(false, "삭제된 메시지는 수정할 수 없습니다."))
+        }
+
+        @Test
+        fun `생성 후 24시간이 지나면 수정할 수 없다`() {
+            val msg = baseMessage(Instant.now().minusSeconds(25 * 3600))
+            val result = service.canEditMessage(msg)
+            assertThat(result.canEdit).isFalse()
+        }
+
+        @Test
+        fun `텍스트 메시지는 수정 가능하다`() {
+            val msg = baseMessage()
+            val result = service.canEditMessage(msg)
+            assertThat(result.canEdit).isTrue()
+        }
+    }
+
+    @Test
+    fun `메시지를 수정할 수 있다`() {
+        val msg = baseMessage()
+        val edited = service.editMessage(msg, "new")
+        assertThat(edited.content.text).isEqualTo("new")
+        assertThat(edited.content.isEdited).isTrue()
+    }
+
+    @Test
+    fun `편집 불가능한 메시지를 수정하면 예외가 발생한다`() {
+        val msg = baseMessage().copy(content = MessageContent("text", MessageType.FILE))
+        assertThrows<IllegalArgumentException> { service.editMessage(msg, "x") }
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/domain/service/message/MessageForwardDomainServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/service/message/MessageForwardDomainServiceTest.kt
@@ -1,0 +1,41 @@
+package com.stark.shoot.domain.service.message
+
+import com.stark.shoot.domain.chat.message.ChatMessage
+import com.stark.shoot.domain.chat.message.MessageContent
+import com.stark.shoot.domain.chat.message.type.MessageStatus
+import com.stark.shoot.domain.chat.message.type.MessageType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+@DisplayName("메시지 전달 도메인 서비스 테스트")
+class MessageForwardDomainServiceTest {
+    private val service = MessageForwardDomainService()
+
+    @Test
+    fun `메시지 전달용 내용을 생성할 수 있다`() {
+        val original = ChatMessage(
+            id = "m1",
+            roomId = 1L,
+            senderId = 2L,
+            content = MessageContent("hello", MessageType.TEXT),
+            status = MessageStatus.SAVED,
+            createdAt = Instant.now()
+        )
+
+        val content = service.createForwardedContent(original)
+        assertThat(content.text).isEqualTo("[Forwarded] hello")
+    }
+
+    @Test
+    fun `전달 메시지를 생성할 수 있다`() {
+        val content = MessageContent("[Forwarded] hi", MessageType.TEXT)
+        val msg = service.createForwardedMessage(3L, 4L, content)
+
+        assertThat(msg.roomId).isEqualTo(3L)
+        assertThat(msg.senderId).isEqualTo(4L)
+        assertThat(msg.content).isEqualTo(content)
+        assertThat(msg.status).isEqualTo(MessageStatus.SAVED)
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/domain/service/message/MessagePinDomainServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/service/message/MessagePinDomainServiceTest.kt
@@ -1,0 +1,56 @@
+package com.stark.shoot.domain.service.message
+
+import com.stark.shoot.domain.chat.event.MessagePinEvent
+import com.stark.shoot.domain.chat.message.ChatMessage
+import com.stark.shoot.domain.chat.message.MessageContent
+import com.stark.shoot.domain.chat.message.type.MessageStatus
+import com.stark.shoot.domain.chat.message.type.MessageType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+@DisplayName("메시지 핀 도메인 서비스 테스트")
+class MessagePinDomainServiceTest {
+    private val service = MessagePinDomainService()
+
+    @Nested
+    inner class CreatePinEvent {
+        @Test
+        fun `메시지 ID가 없으면 null을 반환한다`() {
+            val message = ChatMessage(
+                roomId = 1L,
+                senderId = 2L,
+                content = MessageContent("hi", MessageType.TEXT),
+                status = MessageStatus.SAVED,
+                createdAt = Instant.now()
+            )
+
+            val event = service.createPinEvent(message, 1L, true)
+            assertThat(event).isNull()
+        }
+
+        @Test
+        fun `메시지 핀 이벤트를 생성할 수 있다`() {
+            val message = ChatMessage(
+                id = "m1",
+                roomId = 1L,
+                senderId = 2L,
+                content = MessageContent("hi", MessageType.TEXT),
+                status = MessageStatus.SAVED,
+                createdAt = Instant.now()
+            )
+
+            val event = service.createPinEvent(message, 1L, true)
+            assertThat(event).isEqualTo(
+                MessagePinEvent.create(
+                    messageId = "m1",
+                    roomId = 1L,
+                    isPinned = true,
+                    userId = 1L
+                )
+            )
+        }
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/domain/service/message/MessageReactionServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/service/message/MessageReactionServiceTest.kt
@@ -1,0 +1,70 @@
+package com.stark.shoot.domain.service.message
+
+import com.stark.shoot.domain.chat.event.MessageReactionEvent
+import com.stark.shoot.domain.chat.message.ChatMessage
+import com.stark.shoot.domain.chat.message.MessageContent
+import com.stark.shoot.domain.chat.message.ReactionToggleResult
+import com.stark.shoot.domain.chat.message.type.MessageStatus
+import com.stark.shoot.domain.chat.message.type.MessageType
+import com.stark.shoot.domain.chat.reaction.MessageReactions
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+@DisplayName("메시지 리액션 도메인 서비스 테스트")
+class MessageReactionServiceTest {
+    private val service = MessageReactionService()
+
+    private fun message() = ChatMessage(
+        id = "m1",
+        roomId = 1L,
+        senderId = 2L,
+        content = MessageContent("hi", MessageType.TEXT),
+        status = MessageStatus.SAVED,
+        createdAt = Instant.now()
+    )
+
+    @Nested
+    inner class ProcessResult {
+        @Test
+        fun `리액션 교체 결과는 두 개의 이벤트를 생성한다`() {
+            val result = ReactionToggleResult(
+                reactions = MessageReactions(),
+                message = message(),
+                userId = 1L,
+                reactionType = "heart",
+                isAdded = true,
+                previousReactionType = "like",
+                isReplacement = true
+            )
+
+            val events = service.processReactionToggleResult(result)
+            assertThat(events).hasSize(2)
+            assertThat(events[0]).isEqualTo(
+                MessageReactionEvent.create("m1", "1", "1", "like", false, true)
+            )
+            assertThat(events[1].isAdded).isTrue()
+        }
+
+        @Test
+        fun `일반 추가 결과는 하나의 이벤트를 생성한다`() {
+            val result = ReactionToggleResult(
+                reactions = MessageReactions(),
+                message = message(),
+                userId = 1L,
+                reactionType = "like",
+                isAdded = true,
+                previousReactionType = null,
+                isReplacement = false
+            )
+
+            val events = service.processReactionToggleResult(result)
+            assertThat(events).hasSize(1)
+            assertThat(events[0]).isEqualTo(
+                MessageReactionEvent.create("m1", "1", "1", "like", true, false)
+            )
+        }
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/domain/service/user/FriendDomainServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/service/user/FriendDomainServiceTest.kt
@@ -1,0 +1,37 @@
+package com.stark.shoot.domain.service.user
+
+import com.stark.shoot.domain.chat.event.FriendAddedEvent
+import com.stark.shoot.domain.chat.user.User
+import com.stark.shoot.domain.chat.user.UserStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@DisplayName("친구 도메인 서비스 테스트")
+class FriendDomainServiceTest {
+    private val service = FriendDomainService()
+
+    @Nested
+    inner class ValidateRequest {
+        @Test
+        fun `자신에게 요청하면 예외`() {
+            assertThrows<IllegalArgumentException> {
+                service.validateFriendRequest(1L,1L,false,false,false)
+            }
+        }
+    }
+
+    @Test
+    fun `친구 요청 수락을 처리할 수 있다`() {
+        val current = User(id=1L, username="a", nickname="A", userCode="A1", incomingFriendRequestIds=setOf(2L))
+        val requester = User(id=2L, username="b", nickname="B", userCode="B1")
+        val result = service.processFriendAccept(current, requester, 2L)
+        assertThat(result.updatedCurrentUser.friendIds).contains(2L)
+        assertThat(result.updatedRequester.friendIds).contains(1L)
+        assertThat(result.events).containsExactly(
+            FriendAddedEvent.create(1L,2L), FriendAddedEvent.create(2L,1L)
+        )
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/domain/service/user/FriendGroupDomainServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/service/user/FriendGroupDomainServiceTest.kt
@@ -1,0 +1,25 @@
+package com.stark.shoot.domain.service.user
+
+import com.stark.shoot.domain.chat.user.FriendGroup
+import com.stark.shoot.domain.service.user.group.FriendGroupDomainService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@DisplayName("친구 그룹 도메인 서비스 테스트")
+class FriendGroupDomainServiceTest {
+    private val service = FriendGroupDomainService()
+
+    @Test
+    fun `빈 이름으로 그룹을 생성하면 예외`() {
+        assertThrows<IllegalArgumentException> { service.create(1L, "", null) }
+    }
+
+    @Test
+    fun `그룹 이름을 변경할 수 있다`() {
+        val group = service.create(1L, "g1", null)
+        val updated = service.rename(group, "new")
+        assertThat(updated.name).isEqualTo("new")
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/domain/service/user/UserBlockDomainServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/service/user/UserBlockDomainServiceTest.kt
@@ -1,0 +1,28 @@
+package com.stark.shoot.domain.service.user
+
+import com.stark.shoot.domain.chat.user.User
+import com.stark.shoot.domain.service.user.block.UserBlockDomainService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@DisplayName("사용자 차단 도메인 서비스 테스트")
+class UserBlockDomainServiceTest {
+    private val service = UserBlockDomainService()
+
+    @Test
+    fun `자신을 차단하면 예외`() {
+        val user = User(id=1L, username="a", nickname="A", userCode="A1")
+        assertThrows<IllegalArgumentException> { service.block(user,1L) }
+    }
+
+    @Test
+    fun `차단과 해제가 가능하다`() {
+        val user = User(id=1L, username="a", nickname="A", userCode="A1")
+        val blocked = service.block(user,2L)
+        assertThat(blocked.blockedUserIds).contains(2L)
+        val unblocked = service.unblock(blocked,2L)
+        assertThat(unblocked.blockedUserIds).doesNotContain(2L)
+    }
+}


### PR DESCRIPTION
## Summary
- add missing tests for message bookmark domain
- cover message-related domain services
- add chatroom and user domain service unit tests
- ensure chat room utility methods are tested

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6849851a0dc08320b4211e848b24ad50