### PR TITLE
Add notification domain tests

### DIFF
--- a/src/test/kotlin/com/stark/shoot/domain/notification/NotificationTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/notification/NotificationTest.kt
@@ -1,0 +1,36 @@
+package com.stark.shoot.domain.notification
+
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class NotificationTest {
+    @Test
+    fun markReadAndDelete() {
+        val n = Notification.create(
+            userId = 1L,
+            title = "t",
+            message = "m",
+            type = NotificationType.NEW_MESSAGE,
+            sourceId = "s",
+            sourceType = SourceType.CHAT
+        )
+        val read = n.markAsRead()
+        assertTrue(read.isRead)
+        val deleted = read.markAsDeleted()
+        assertTrue(deleted.isDeleted)
+    }
+
+    @Test
+    fun validateOwnershipThrows() {
+        val n = Notification.create(
+            userId = 1L,
+            title = "t",
+            message = "m",
+            type = NotificationType.NEW_MESSAGE,
+            sourceId = "s",
+            sourceType = SourceType.CHAT
+        )
+        assertFailsWith<NotificationException> { n.validateOwnership(2L) }
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/domain/notification/service/NotificationDomainServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/notification/service/NotificationDomainServiceTest.kt
@@ -1,0 +1,27 @@
+package com.stark.shoot.domain.notification.service
+
+import com.stark.shoot.domain.notification.Notification
+import com.stark.shoot.domain.notification.NotificationType
+import com.stark.shoot.domain.notification.SourceType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class NotificationDomainServiceTest {
+    private val service = NotificationDomainService()
+
+    @Test
+    fun markAsReadAndDeleted() {
+        val n = Notification.create(1L, "t", "m", NotificationType.NEW_MESSAGE, "s", SourceType.CHAT)
+        val read = service.markNotificationsAsRead(listOf(n))
+        val deleted = service.markNotificationsAsDeleted(read)
+        assertEquals(true, deleted[0].isDeleted)
+    }
+
+    @Test
+    fun filterUnread() {
+        val n1 = Notification.create(1L, "t", "m", NotificationType.NEW_MESSAGE, "s", SourceType.CHAT)
+        val n2 = n1.markAsRead()
+        val unread = service.filterUnread(listOf(n1, n2))
+        assertEquals(1, unread.size)
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for Notification domain entity
- add tests for NotificationDomainService

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684990608d5883208b4c69439e411509