### PR TITLE
Add tests for reaction types and event factories

### DIFF
--- a/src/test/kotlin/com/stark/shoot/domain/chat/event/EventFactoryTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/chat/event/EventFactoryTest.kt
@@ -1,0 +1,58 @@
+package com.stark.shoot.domain.chat.event
+
+import com.stark.shoot.domain.chat.message.ChatMessage
+import com.stark.shoot.domain.chat.message.type.MessageType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("채팅 이벤트 팩토리 메서드 테스트")
+class EventFactoryTest {
+    @Test
+    fun `ChatEvent fromMessage 함수는 메시지를 기반으로 이벤트를 생성한다`() {
+        val message = ChatMessage.create(roomId = 1L, senderId = 2L, text = "hi")
+        val event = ChatEvent.fromMessage(message)
+
+        assertThat(event.type).isEqualTo(EventType.MESSAGE_CREATED)
+        assertThat(event.data).isEqualTo(message)
+    }
+
+    @Test
+    fun `ChatBulkReadEvent create 함수는 주어진 값으로 이벤트를 생성한다`() {
+        val event = ChatBulkReadEvent.create(1L, listOf("m1", "m2"), 3L)
+        assertThat(event).isEqualTo(ChatBulkReadEvent(1L, listOf("m1", "m2"), 3L))
+    }
+
+    @Test
+    fun `ChatUnreadCountUpdatedEvent create 함수는 주어진 값으로 이벤트를 생성한다`() {
+        val counts = mapOf(1L to 2)
+        val event = ChatUnreadCountUpdatedEvent.create(1L, counts)
+        assertThat(event).isEqualTo(ChatUnreadCountUpdatedEvent(1L, counts, null))
+    }
+
+    @Test
+    fun `FriendAddedEvent create 함수는 주어진 값으로 이벤트를 생성한다`() {
+        val event = FriendAddedEvent.create(1L, 2L)
+        assertThat(event).isEqualTo(FriendAddedEvent(1L, 2L))
+    }
+
+    @Test
+    fun `ChatRoomCreatedEvent create 함수는 주어진 값으로 이벤트를 생성한다`() {
+        val event = ChatRoomCreatedEvent.create(1L, 2L)
+        assertThat(event).isEqualTo(ChatRoomCreatedEvent(1L, 2L))
+    }
+
+    @Test
+    fun `MessagePinEvent create 함수는 주어진 값으로 이벤트를 생성한다`() {
+        val event = MessagePinEvent.create("m1", 1L, true, 2L)
+        assertThat(event).isEqualTo(MessagePinEvent("m1", 1L, true, 2L))
+    }
+
+    @Test
+    fun `MessageReactionEvent create 함수는 주어진 값으로 이벤트를 생성한다`() {
+        val event = MessageReactionEvent.create("m1", "1", "2", "like", true)
+        assertThat(event).isEqualTo(
+            MessageReactionEvent("m1", "1", "2", "like", true, false)
+        )
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/domain/chat/reaction/ReactionTypeTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/chat/reaction/ReactionTypeTest.kt
@@ -1,0 +1,39 @@
+package com.stark.shoot.domain.chat.reaction
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("리액션 타입 비즈니스 로직 테스트")
+class ReactionTypeTest {
+    @Test
+    fun `code 값으로 리액션 타입을 조회할 수 있다`() {
+        val result = ReactionType.fromCode("like")
+        assertThat(result).isEqualTo(ReactionType.LIKE)
+    }
+
+    @Test
+    fun `없는 코드면 null을 반환한다`() {
+        val result = ReactionType.fromCode("unknown")
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `이모지 값으로 리액션 타입을 조회할 수 있다`() {
+        val result = ReactionType.fromEmoji("😡")
+        assertThat(result).isEqualTo(ReactionType.ANGRY)
+    }
+
+    @Test
+    fun `없는 이모지면 null을 반환한다`() {
+        val result = ReactionType.fromEmoji("🤷")
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `지원하는 모든 리액션 타입 정보를 가져올 수 있다`() {
+        val list = ReactionType.getAllReactionTypes()
+        assertThat(list).hasSize(ReactionType.entries.size)
+        assertThat(list[0]).containsKeys("code", "emoji", "description")
+    }
+}


### PR DESCRIPTION
## Summary
- add ReactionTypeTest to cover enum utilities
- add EventFactoryTest to test event creation helpers

## Testing
- `gradle test` *(fails: Plugin [id: 'org.jetbrains.kotlin.jvm', version: '1.9.25'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ad3887d7883208f6a929ac54efd41