### PR TITLE
Fix chat room search and list endpoints

### DIFF
--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/chatroom/ChatRoomListController.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/chatroom/ChatRoomListController.kt
@@ -17,6 +17,13 @@ class ChatRoomListController(
     private val findChatRoomUseCase: FindChatRoomUseCase
 ) {
 
-
+    @Operation(summary = "채팅방 목록 조회", description = "사용자가 참여 중인 채팅방 목록을 반환합니다.")
+    @GetMapping("/list")
+    fun getChatRooms(
+        @RequestParam userId: Long
+    ): ResponseDto<List<ChatRoomResponse>> {
+        val chatRooms = findChatRoomUseCase.getChatRoomsForUser(userId)
+        return ResponseDto.success(chatRooms)
+    }
 
 }


### PR DESCRIPTION
## Summary
- fill in ChatRoomSearchService to properly filter and map chat rooms
- implement missing REST endpoint in ChatRoomListController

## Testing
- `./gradlew test -q` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684ad9b9c3e883208b683b3a641798aa