### PR TITLE
Add JPA adapter tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,6 +68,9 @@ dependencies {
 
     // mockito 오류 해결 (java 21)
     testImplementation("org.mockito:mockito-core:5.15.2")
+
+    // in-memory database for JPA tests
+    testImplementation("com.h2database:h2")
 }
 
 kotlin {

--- a/src/test/kotlin/com/stark/shoot/adapter/persistence/chatroom/DeleteChatRoomPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/stark/shoot/adapter/persistence/chatroom/DeleteChatRoomPersistenceAdapterTest.kt
@@ -1,0 +1,30 @@
+package com.stark.shoot.adapter.persistence.chatroom
+
+import com.stark.shoot.adapter.out.persistence.postgres.adapter.chatroom.DeleteChatRoomPersistenceAdapter
+import com.stark.shoot.adapter.out.persistence.postgres.repository.ChatRoomRepository
+import com.stark.shoot.util.TestEntityFactory
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+
+@DataJpaTest
+@Import(DeleteChatRoomPersistenceAdapter::class)
+class DeleteChatRoomPersistenceAdapterTest @Autowired constructor(
+    private val chatRoomRepository: ChatRoomRepository,
+    private val deleteChatRoomPersistenceAdapter: DeleteChatRoomPersistenceAdapter
+) {
+
+    @Test
+    @DisplayName("채팅방을 삭제할 수 있다")
+    fun deleteChatRoom() {
+        val room = chatRoomRepository.save(
+            TestEntityFactory.createChatRoomEntity("room")
+        )
+        val result = deleteChatRoomPersistenceAdapter.deleteById(room.id)
+        assertThat(result).isTrue()
+        assertThat(chatRoomRepository.existsById(room.id)).isFalse()
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/adapter/persistence/chatroom/LoadChatRoomPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/stark/shoot/adapter/persistence/chatroom/LoadChatRoomPersistenceAdapterTest.kt
@@ -1,0 +1,58 @@
+package com.stark.shoot.adapter.persistence.chatroom
+
+import com.stark.shoot.adapter.out.persistence.postgres.adapter.chatroom.LoadChatRoomPersistenceAdapter
+import com.stark.shoot.adapter.out.persistence.postgres.mapper.ChatRoomMapper
+import com.stark.shoot.adapter.out.persistence.postgres.repository.ChatRoomRepository
+import com.stark.shoot.adapter.out.persistence.postgres.repository.ChatRoomUserRepository
+import com.stark.shoot.adapter.out.persistence.postgres.repository.UserRepository
+import com.stark.shoot.domain.chat.room.ChatRoomType
+import com.stark.shoot.util.TestEntityFactory
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+
+@DataJpaTest
+@Import(LoadChatRoomPersistenceAdapter::class, ChatRoomMapper::class)
+class LoadChatRoomPersistenceAdapterTest @Autowired constructor(
+    private val chatRoomRepository: ChatRoomRepository,
+    private val chatRoomUserRepository: ChatRoomUserRepository,
+    private val userRepository: UserRepository,
+    private val loadChatRoomPersistenceAdapter: LoadChatRoomPersistenceAdapter
+) {
+
+    @Test
+    @DisplayName("ID로 채팅방을 조회할 수 있다")
+    fun findById() {
+        val user1 = userRepository.save(TestEntityFactory.createUser("user1", "u1"))
+        val user2 = userRepository.save(TestEntityFactory.createUser("user2", "u2"))
+        val roomEntity = chatRoomRepository.save(
+            TestEntityFactory.createChatRoomEntity("room", ChatRoomType.GROUP)
+        )
+        chatRoomUserRepository.save(TestEntityFactory.createChatRoomUser(roomEntity, user1))
+        chatRoomUserRepository.save(TestEntityFactory.createChatRoomUser(roomEntity, user2, isPinned = true))
+
+        val room = loadChatRoomPersistenceAdapter.findById(roomEntity.id)
+        assertThat(room).isNotNull
+        assertThat(room!!.participants).containsExactlyInAnyOrder(user1.id, user2.id)
+        assertThat(room.pinnedParticipants).contains(user2.id)
+    }
+
+    @Test
+    @DisplayName("참여자 ID로 채팅방을 조회할 수 있다")
+    fun findByParticipantId() {
+        val user1 = userRepository.save(TestEntityFactory.createUser("user1", "u1"))
+        val user2 = userRepository.save(TestEntityFactory.createUser("user2", "u2"))
+        val roomEntity = chatRoomRepository.save(
+            TestEntityFactory.createChatRoomEntity("room", ChatRoomType.GROUP)
+        )
+        chatRoomUserRepository.save(TestEntityFactory.createChatRoomUser(roomEntity, user1))
+        chatRoomUserRepository.save(TestEntityFactory.createChatRoomUser(roomEntity, user2))
+
+        val rooms = loadChatRoomPersistenceAdapter.findByParticipantId(user1.id)
+        assertThat(rooms).hasSize(1)
+        assertThat(rooms[0].participants).contains(user1.id, user2.id)
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/adapter/persistence/chatroom/LoadPinnedRoomsPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/stark/shoot/adapter/persistence/chatroom/LoadPinnedRoomsPersistenceAdapterTest.kt
@@ -1,0 +1,42 @@
+package com.stark.shoot.adapter.persistence.chatroom
+
+import com.stark.shoot.adapter.out.persistence.postgres.adapter.chatroom.LoadPinnedRoomsPersistenceAdapter
+import com.stark.shoot.adapter.out.persistence.postgres.mapper.ChatRoomMapper
+import com.stark.shoot.adapter.out.persistence.postgres.repository.ChatRoomRepository
+import com.stark.shoot.adapter.out.persistence.postgres.repository.ChatRoomUserRepository
+import com.stark.shoot.adapter.out.persistence.postgres.repository.UserRepository
+import com.stark.shoot.domain.chat.room.ChatRoomType
+import com.stark.shoot.util.TestEntityFactory
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+
+@DataJpaTest
+@Import(LoadPinnedRoomsPersistenceAdapter::class, ChatRoomMapper::class)
+class LoadPinnedRoomsPersistenceAdapterTest @Autowired constructor(
+    private val chatRoomRepository: ChatRoomRepository,
+    private val chatRoomUserRepository: ChatRoomUserRepository,
+    private val userRepository: UserRepository,
+    private val loadPinnedRoomsPersistenceAdapter: LoadPinnedRoomsPersistenceAdapter
+) {
+
+    @Test
+    @DisplayName("사용자가 고정한 채팅방을 조회할 수 있다")
+    fun findPinnedRooms() {
+        val user1 = userRepository.save(TestEntityFactory.createUser("user1", "u1"))
+        val user2 = userRepository.save(TestEntityFactory.createUser("user2", "u2"))
+
+        val roomEntity = chatRoomRepository.save(
+            TestEntityFactory.createChatRoomEntity("room", ChatRoomType.GROUP)
+        )
+        chatRoomUserRepository.save(TestEntityFactory.createChatRoomUser(roomEntity, user1, isPinned = true))
+        chatRoomUserRepository.save(TestEntityFactory.createChatRoomUser(roomEntity, user2))
+
+        val rooms = loadPinnedRoomsPersistenceAdapter.findByUserId(user1.id)
+        assertThat(rooms).hasSize(1)
+        assertThat(rooms[0].pinnedParticipants).contains(user1.id)
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/adapter/persistence/chatroom/ReadStatusPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/stark/shoot/adapter/persistence/chatroom/ReadStatusPersistenceAdapterTest.kt
@@ -1,0 +1,35 @@
+package com.stark.shoot.adapter.persistence.chatroom
+
+import com.stark.shoot.adapter.out.persistence.postgres.adapter.chatroom.ReadStatusPersistenceAdapter
+import com.stark.shoot.adapter.out.persistence.postgres.repository.ChatRoomRepository
+import com.stark.shoot.adapter.out.persistence.postgres.repository.ChatRoomUserRepository
+import com.stark.shoot.adapter.out.persistence.postgres.repository.UserRepository
+import com.stark.shoot.util.TestEntityFactory
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+
+@DataJpaTest
+@Import(ReadStatusPersistenceAdapter::class)
+class ReadStatusPersistenceAdapterTest @Autowired constructor(
+    private val chatRoomRepository: ChatRoomRepository,
+    private val chatRoomUserRepository: ChatRoomUserRepository,
+    private val userRepository: UserRepository,
+    private val readStatusPersistenceAdapter: ReadStatusPersistenceAdapter
+) {
+
+    @Test
+    @DisplayName("마지막 읽은 메시지 ID를 업데이트할 수 있다")
+    fun updateLastReadMessageId() {
+        val user = userRepository.save(TestEntityFactory.createUser("user", "u1"))
+        val room = chatRoomRepository.save(TestEntityFactory.createChatRoomEntity("room"))
+        val cru = chatRoomUserRepository.save(TestEntityFactory.createChatRoomUser(room, user))
+
+        readStatusPersistenceAdapter.updateLastReadMessageId(room.id, user.id, "m1")
+        val updated = chatRoomUserRepository.findById(cru.id).get()
+        assertThat(updated.lastReadMessageId).isEqualTo("m1")
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/adapter/persistence/chatroom/SaveChatRoomPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/stark/shoot/adapter/persistence/chatroom/SaveChatRoomPersistenceAdapterTest.kt
@@ -1,0 +1,48 @@
+package com.stark.shoot.adapter.persistence.chatroom
+
+import com.stark.shoot.adapter.out.persistence.postgres.adapter.chatroom.SaveChatRoomPersistenceAdapter
+import com.stark.shoot.adapter.out.persistence.postgres.mapper.ChatRoomMapper
+import com.stark.shoot.adapter.out.persistence.postgres.repository.ChatRoomRepository
+import com.stark.shoot.adapter.out.persistence.postgres.repository.ChatRoomUserRepository
+import com.stark.shoot.adapter.out.persistence.postgres.repository.UserRepository
+import com.stark.shoot.domain.chat.room.ChatRoomType
+import com.stark.shoot.util.TestEntityFactory
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+
+@DataJpaTest
+@Import(SaveChatRoomPersistenceAdapter::class, ChatRoomMapper::class)
+class SaveChatRoomPersistenceAdapterTest @Autowired constructor(
+    private val chatRoomRepository: ChatRoomRepository,
+    private val chatRoomUserRepository: ChatRoomUserRepository,
+    private val userRepository: UserRepository,
+    private val saveChatRoomPersistenceAdapter: SaveChatRoomPersistenceAdapter
+) {
+
+    @Test
+    @DisplayName("새로운 채팅방을 저장하면 참여자 정보까지 함께 저장된다")
+    fun saveNewChatRoom() {
+        val user1 = userRepository.save(TestEntityFactory.createUser("user1", "u1"))
+        val user2 = userRepository.save(TestEntityFactory.createUser("user2", "u2"))
+
+        val domainRoom = TestEntityFactory.createChatRoomDomain(
+            participants = mutableSetOf(user1.id, user2.id),
+            pinned = mutableSetOf(user1.id),
+            type = ChatRoomType.GROUP,
+            title = "test"
+        )
+
+        val saved = saveChatRoomPersistenceAdapter.save(domainRoom)
+
+        assertThat(saved.id).isNotNull
+        assertThat(chatRoomRepository.count()).isEqualTo(1)
+        val participants = chatRoomUserRepository.findByChatRoomId(saved.id!!)
+        assertThat(participants).hasSize(2)
+        val pinned = participants.first { it.user.id == user1.id }
+        assertThat(pinned.isPinned).isTrue()
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/util/TestEntityFactory.kt
+++ b/src/test/kotlin/com/stark/shoot/util/TestEntityFactory.kt
@@ -1,0 +1,57 @@
+package com.stark.shoot.util
+
+import com.stark.shoot.adapter.out.persistence.postgres.entity.ChatRoomEntity
+import com.stark.shoot.adapter.out.persistence.postgres.entity.ChatRoomUserEntity
+import com.stark.shoot.adapter.out.persistence.postgres.entity.UserEntity
+import com.stark.shoot.adapter.out.persistence.postgres.entity.enumerate.ChatRoomUserRole
+import com.stark.shoot.domain.chat.room.ChatRoom
+import com.stark.shoot.domain.chat.room.ChatRoomType
+import java.time.Instant
+
+object TestEntityFactory {
+    fun createUser(username: String, userCode: String): UserEntity {
+        return UserEntity(
+            username = username,
+            nickname = username,
+            status = com.stark.shoot.domain.chat.user.UserStatus.ACTIVE,
+            userCode = userCode
+        )
+    }
+
+    fun createChatRoomEntity(
+        title: String?,
+        type: ChatRoomType = ChatRoomType.GROUP,
+        announcement: String? = null,
+        lastMessageId: Long? = null,
+        lastActiveAt: Instant = Instant.now()
+    ): ChatRoomEntity {
+        return ChatRoomEntity(title, type, announcement, lastMessageId, lastActiveAt)
+    }
+
+    fun createChatRoomUser(
+        room: ChatRoomEntity,
+        user: UserEntity,
+        isPinned: Boolean = false,
+        role: ChatRoomUserRole = ChatRoomUserRole.MEMBER
+    ): ChatRoomUserEntity {
+        return ChatRoomUserEntity(room, user, isPinned, role = role)
+    }
+
+    fun createChatRoomDomain(
+        participants: MutableSet<Long>,
+        pinned: MutableSet<Long> = mutableSetOf(),
+        type: ChatRoomType = ChatRoomType.GROUP,
+        title: String? = null
+    ): ChatRoom {
+        return ChatRoom(
+            type = type,
+            participants = participants,
+            pinnedParticipants = pinned,
+            title = title,
+            announcement = null,
+            lastMessageId = null,
+            lastActiveAt = Instant.now(),
+            createdAt = Instant.now()
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- add H2 dependency for JPA tests
- create helper factory for test entities
- add JPA tests for chat room adapters

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684aeb3ae9a08320ad170397e5de21f4