### PR TITLE
Refactor friend persistence flow

### DIFF
--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/user/friend/FriendPersistenceAdapter.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/user/friend/FriendPersistenceAdapter.kt
@@ -8,7 +8,6 @@ import com.stark.shoot.adapter.out.persistence.postgres.repository.FriendRequest
 import com.stark.shoot.adapter.out.persistence.postgres.repository.FriendshipMappingRepository
 import com.stark.shoot.adapter.out.persistence.postgres.repository.UserRepository
 import com.stark.shoot.application.port.out.user.friend.UpdateFriendPort
-import com.stark.shoot.domain.chat.user.User
 import com.stark.shoot.infrastructure.annotation.Adapter
 import com.stark.shoot.infrastructure.exception.web.ResourceNotFoundException
 import java.time.Instant
@@ -111,122 +110,11 @@ class FriendPersistenceAdapter(
         friendshipMappingRepository.save(friendship)
     }
 
-    override fun updateFriends(
-        user: User
-    ): User {
-        // 1. User 엔티티 조회
-        val userEntity = userRepository.findById(user.id!!)
-            .orElseThrow { ResourceNotFoundException("사용자를 찾을 수 없습니다: ${user.id}") }
-
-        // 2. 현재 데이터베이스에 저장된 친구 관계 조회
-        val currentFriendships = friendshipMappingRepository.findAllByUserId(user.id)
-        val currentFriendIds = currentFriendships.map { it.friend.id!! }.toSet()
-
-        // 3. 도메인 모델의 친구 ID와 비교하여 추가/삭제할 친구 관계 파악
-        val friendIdsToAdd = user.friendIds.filter { !currentFriendIds.contains(it) }
-        val friendIdsToRemove = currentFriendIds.filter { !user.friendIds.contains(it) }
-
-        // 4. 새로운 친구 관계 추가
-        friendIdsToAdd.forEach { friendId ->
-            addFriendRelation(user.id, friendId)
-        }
-
-        // 5. 제거할 친구 관계 삭제
-        friendIdsToRemove.forEach { friendId ->
-            removeFriendRelation(user.id, friendId)
-        }
-
-        // 6. 현재 데이터베이스에 저장된 받은 친구 요청 조회
-        val currentIncomingRequests = friendRequestRepository
-            .findAllByReceiverIdAndStatus(user.id, FriendRequestStatus.PENDING)
-        val currentIncomingRequestIds = currentIncomingRequests.map { it.sender.id!! }.toSet()
-
-        // 7. 도메인 모델의 받은 친구 요청 ID와 비교하여 제거할 요청 파악
-        val incomingRequestIdsToRemove = currentIncomingRequestIds.filter { !user.incomingFriendRequestIds.contains(it) }
-
-        // 8. 제거할 받은 친구 요청 삭제
-        incomingRequestIdsToRemove.forEach { senderId ->
-            removeIncomingFriendRequest(user.id, senderId)
-        }
-
-        // 9. 현재 데이터베이스에 저장된 보낸 친구 요청 조회
-        val currentOutgoingRequests = friendRequestRepository
-            .findAllBySenderIdAndStatus(user.id, FriendRequestStatus.PENDING)
-        val currentOutgoingRequestIds = currentOutgoingRequests.map { it.receiver.id!! }.toSet()
-
-        // 10. 도메인 모델의 보낸 친구 요청 ID와 비교하여 제거할 요청 파악
-        val outgoingRequestIdsToRemove = currentOutgoingRequestIds.filter { !user.outgoingFriendRequestIds.contains(it) }
-
-        // 11. 제거할 보낸 친구 요청 삭제
-        outgoingRequestIdsToRemove.forEach { receiverId ->
-            removeOutgoingFriendRequest(user.id, receiverId)
-        }
-
-        // 12. User 엔티티 저장
-        userRepository.save(userEntity)
-
-        // 13. 친구 관계 및 요청 갱신을 위해 도메인 객체를 다시 조회하여 반환
-        return loadUserWithRelationships(userEntity.id!!)
-    }
-
-    /**
-     * 친구 관계를 제거합니다.
-     * @param userId 사용자 ID
-     * @param friendId 친구 ID
-     */
     override fun removeFriendRelation(
         userId: Long,
         friendId: Long
     ) {
         friendshipMappingRepository.deleteByUserIdAndFriendId(userId, friendId)
-    }
-
-    /**
-     * 사용자 정보와 모든 관계(친구, 요청)를 함께 조회하여 도메인 객체로 변환
-     */
-    private fun loadUserWithRelationships(
-        userId: Long
-    ): User {
-        // 1. 기본 사용자 정보 조회
-        val userEntity = userRepository.findById(userId)
-            .orElseThrow { ResourceNotFoundException("사용자를 찾을 수 없습니다: $userId") }
-
-        // 2. 기본 User 도메인 객체 생성
-        val user = userMapper.toDomain(userEntity)
-
-        // 3. 친구 목록 로드 (양방향 관계 모두 조회)
-        val outgoingFriendIds = mutableSetOf<Long>()
-        val incomingFriendIds = mutableSetOf<Long>()
-
-        // 사용자가 추가한 친구들 (정방향 친구 관계)
-        friendshipMappingRepository.findAllByUserId(userId)
-            .forEach { friendship -> outgoingFriendIds.add(friendship.friend.id!!) }
-
-        // 사용자를 친구로 추가한 사용자들 (역방향 친구 관계)
-        friendshipMappingRepository.findAllByFriendId(userId)
-            .forEach { friendship -> incomingFriendIds.add(friendship.user.id!!) }
-
-        // 양방향 친구 관계를 합쳐서 전체 친구 목록 생성
-        val allFriendIds = outgoingFriendIds.union(incomingFriendIds)
-
-        // 4. 받은 친구 요청 로드
-        val incomingRequestIds = mutableSetOf<Long>()
-        friendRequestRepository
-            .findAllByReceiverIdAndStatus(userId, FriendRequestStatus.PENDING)
-            .forEach { request -> incomingRequestIds.add(request.sender.id!!) }
-
-        // 5. 보낸 친구 요청 로드
-        val outgoingRequestIds = mutableSetOf<Long>()
-        friendRequestRepository
-            .findAllBySenderIdAndStatus(userId, FriendRequestStatus.PENDING)
-            .forEach { request -> outgoingRequestIds.add(request.receiver.id!!) }
-
-        // 6. 관계 정보를 도메인 객체에 설정
-        user.friendIds = allFriendIds
-        user.incomingFriendRequestIds = incomingRequestIds
-        user.outgoingFriendRequestIds = outgoingRequestIds
-
-        return user
     }
 
 }

--- a/src/main/kotlin/com/stark/shoot/application/port/out/user/friend/UpdateFriendPort.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/out/user/friend/UpdateFriendPort.kt
@@ -1,12 +1,9 @@
 package com.stark.shoot.application.port.out.user.friend
 
-import com.stark.shoot.domain.chat.user.User
-
 interface UpdateFriendPort {
     fun addOutgoingFriendRequest(userId: Long, targetUserId: Long)
     fun removeOutgoingFriendRequest(userId: Long, targetUserId: Long)
     fun removeIncomingFriendRequest(userId: Long, fromUserId: Long)
     fun addFriendRelation(userId: Long, friendId: Long)
-    fun updateFriends(user: User): User
     fun removeFriendRelation(userId: Long, friendId: Long)
 }

--- a/src/main/kotlin/com/stark/shoot/application/service/user/friend/FriendReceiveService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/user/friend/FriendReceiveService.kt
@@ -46,8 +46,10 @@ class FriendReceiveService(
         )
 
         // 업데이트된 사용자 정보 저장
-        updateFriendPort.updateFriends(result.updatedCurrentUser)
-        updateFriendPort.updateFriends(result.updatedRequester)
+        updateFriendPort.removeIncomingFriendRequest(currentUserId, requesterId)
+        updateFriendPort.removeOutgoingFriendRequest(requesterId, currentUserId)
+        updateFriendPort.addFriendRelation(currentUserId, requesterId)
+        updateFriendPort.addFriendRelation(requesterId, currentUserId)
 
         // 이벤트 발행
         result.events.forEach { event ->
@@ -83,8 +85,8 @@ class FriendReceiveService(
         )
 
         // 업데이트된 사용자 정보 저장
-        updateFriendPort.updateFriends(result.updatedCurrentUser)
-        updateFriendPort.updateFriends(result.updatedRequester)
+        updateFriendPort.removeIncomingFriendRequest(currentUserId, requesterId)
+        updateFriendPort.removeOutgoingFriendRequest(requesterId, currentUserId)
 
         // 캐시 무효화
         friendCacheManager.invalidateFriendshipCaches(currentUserId, requesterId)

--- a/src/main/kotlin/com/stark/shoot/application/service/user/friend/FriendRemoveService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/user/friend/FriendRemoveService.kt
@@ -43,8 +43,8 @@ class FriendRemoveService(
         )
 
         // 업데이트된 사용자 정보 저장
-        updateFriendPort.updateFriends(result.updatedCurrentUser)
-        updateFriendPort.updateFriends(result.updatedFriend)
+        updateFriendPort.removeFriendRelation(userId, friendId)
+        updateFriendPort.removeFriendRelation(friendId, userId)
 
         // 캐시 무효화 (FriendCacheManager 사용)
         friendCacheManager.invalidateFriendshipCaches(userId, friendId)

--- a/src/main/kotlin/com/stark/shoot/application/service/user/friend/FriendRequestService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/user/friend/FriendRequestService.kt
@@ -2,12 +2,10 @@ package com.stark.shoot.application.service.user.friend
 
 import com.stark.shoot.application.port.`in`.user.friend.FriendRequestUseCase
 import com.stark.shoot.application.port.out.user.FindUserPort
-import com.stark.shoot.application.port.out.user.friend.FriendCachePort
 import com.stark.shoot.application.port.out.user.friend.UpdateFriendPort
 import com.stark.shoot.infrastructure.annotation.UseCase
 import com.stark.shoot.infrastructure.exception.web.InvalidInputException
 import com.stark.shoot.infrastructure.exception.web.ResourceNotFoundException
-import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.transaction.annotation.Transactional
 
 @Transactional
@@ -68,31 +66,21 @@ class FriendRequestService(
         currentUserId: Long,
         targetUserId: Long
     ) {
-        // 사용자 조회 (친구 요청 정보 포함)
-        val currentUser = findUserPort.findUserWithFriendRequestsById(currentUserId)
-            ?: throw ResourceNotFoundException("사용자를 찾을 수 없습니다: $currentUserId")
-
-        val targetUser = findUserPort.findUserById(targetUserId)
-            ?: throw ResourceNotFoundException("사용자를 찾을 수 없습니다: $targetUserId")
+        // 두 사용자 존재 여부 확인
+        if (!findUserPort.existsById(currentUserId)) {
+            throw ResourceNotFoundException("사용자를 찾을 수 없습니다: $currentUserId")
+        }
+        if (!findUserPort.existsById(targetUserId)) {
+            throw ResourceNotFoundException("사용자를 찾을 수 없습니다: $targetUserId")
+        }
 
         // 친구 요청 존재 여부 확인
         if (!findUserPort.checkOutgoingFriendRequest(currentUserId, targetUserId)) {
             throw InvalidInputException("해당 친구 요청이 존재하지 않습니다.")
         }
 
-        // 도메인 서비스를 사용하여 친구 요청 거절 처리
-        val result = friendDomainService.processFriendReject(
-            currentUser = targetUser, // 대상 사용자가 현재 사용자의 요청을 거절하는 것과 동일
-            requester = currentUser,  // 현재 사용자가 요청자
-            requesterId = currentUserId
-        )
-
-        // 업데이트된 사용자 정보 저장
-        updateFriendPort.updateFriends(result.updatedCurrentUser)
-        updateFriendPort.updateFriends(result.updatedRequester)
-
-        // 실제 친구 요청 데이터 삭제 - 중복 상태 변경 방지
-        // updateFriendPort.removeOutgoingFriendRequest(currentUserId, targetUserId)
+        // 단순히 요청 상태를 취소로 변경
+        updateFriendPort.removeOutgoingFriendRequest(currentUserId, targetUserId)
 
         // 캐시 무효화 (FriendCacheManager 사용)
         friendCacheManager.invalidateFriendshipCaches(currentUserId, targetUserId)


### PR DESCRIPTION
## Summary
- remove aggregate update method from UpdateFriendPort
- delete related logic from FriendPersistenceAdapter
- adjust FriendReceiveService and FriendRemoveService to use granular persistence calls

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684bd2c016848320a6b3cf526ec15445