### PR TITLE
Implement message expiration and user notification preferences

### DIFF
--- a/src/main/kotlin/com/stark/shoot/domain/chat/message/ChatMessage.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/message/ChatMessage.kt
@@ -13,6 +13,8 @@ data class ChatMessage(
     val content: MessageContent,
     val status: MessageStatus,
     val replyToMessageId: String? = null,
+    val threadId: String? = null,
+    val expiresAt: Instant? = null,
     val messageReactions: MessageReactions = MessageReactions(),
     val mentions: Set<Long> = emptySet(),
     val createdAt: Instant? = Instant.now(),
@@ -47,6 +49,26 @@ data class ChatMessage(
             readBy = updatedReadBy,
             metadata = this.metadata.copy(readAt = Instant.now())
         )
+    }
+
+    /**
+     * 메시지가 만료되었는지 확인합니다.
+     *
+     * @param now 기준 시간 (기본값: 현재 시간)
+     * @return 만료 여부
+     */
+    fun isExpired(now: Instant = Instant.now()): Boolean {
+        return expiresAt?.isBefore(now) ?: false
+    }
+
+    /**
+     * 메시지 만료 시간을 설정합니다.
+     *
+     * @param instant 만료 시각
+     * @return 업데이트된 ChatMessage 객체
+     */
+    fun setExpiration(instant: Instant?): ChatMessage {
+        return this.copy(expiresAt = instant, updatedAt = Instant.now())
     }
 
     /**
@@ -278,7 +300,9 @@ data class ChatMessage(
             senderId: Long,
             text: String,
             type: MessageType = MessageType.TEXT,
-            tempId: String? = null
+            tempId: String? = null,
+            threadId: String? = null,
+            expiresAt: Instant? = null
         ): ChatMessage {
             val content = MessageContent(
                 text = text,
@@ -294,7 +318,9 @@ data class ChatMessage(
                 senderId = senderId,
                 content = content,
                 status = MessageStatus.SENDING,
-                metadata = metadata
+                metadata = metadata,
+                threadId = threadId,
+                expiresAt = expiresAt
             )
         }
 

--- a/src/main/kotlin/com/stark/shoot/domain/notification/NotificationSettings.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/notification/NotificationSettings.kt
@@ -1,0 +1,32 @@
+package com.stark.shoot.domain.notification
+
+import java.time.Instant
+
+/**
+ * 사용자별 알림 설정을 관리하는 애그리게이트
+ */
+data class NotificationSettings(
+    val userId: Long,
+    val preferences: Map<NotificationType, Boolean> = emptyMap(),
+    val createdAt: Instant = Instant.now(),
+    val updatedAt: Instant? = null,
+) {
+    /** 특정 알림 타입이 활성화되어 있는지 확인한다 */
+    fun isEnabled(type: NotificationType): Boolean {
+        return preferences[type] ?: true
+    }
+
+    /** 알림 타입의 활성화 여부를 변경한다 */
+    fun updatePreference(type: NotificationType, enabled: Boolean): NotificationSettings {
+        val updated = preferences.toMutableMap()
+        updated[type] = enabled
+        return copy(preferences = updated, updatedAt = Instant.now())
+    }
+
+    /** 여러 알림 타입의 설정을 한번에 업데이트한다 */
+    fun updateAll(prefs: Map<NotificationType, Boolean>): NotificationSettings {
+        val updated = preferences.toMutableMap()
+        updated.putAll(prefs)
+        return copy(preferences = updated, updatedAt = Instant.now())
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/domain/chat/message/ChatMessageTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/chat/message/ChatMessageTest.kt
@@ -439,4 +439,35 @@ class ChatMessageTest {
             assertThat(updatedMessage.updatedAt).isNotNull()
         }
     }
+
+    @Nested
+    @DisplayName("메시지 만료 설정 시")
+    inner class Expiration {
+
+        @Test
+        @DisplayName("만료 시간이 지나면 만료로 판단한다")
+        fun `만료 시간이 지나면 만료로 판단한다`() {
+            val expireAt = Instant.now().minusSeconds(10)
+            val message = ChatMessage.create(
+                roomId = 1L,
+                senderId = 2L,
+                text = "hi",
+                expiresAt = expireAt
+            )
+            assertThat(message.isExpired()).isTrue()
+        }
+
+        @Test
+        @DisplayName("미래의 만료 시간은 만료되지 않은 것으로 판단한다")
+        fun `미래의 만료 시간은 만료되지 않은 것으로 판단한다`() {
+            val expireAt = Instant.now().plusSeconds(60)
+            val message = ChatMessage.create(
+                roomId = 1L,
+                senderId = 2L,
+                text = "hi",
+                expiresAt = expireAt
+            )
+            assertThat(message.isExpired()).isFalse()
+        }
+    }
 }

--- a/src/test/kotlin/com/stark/shoot/domain/notification/NotificationSettingsTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/notification/NotificationSettingsTest.kt
@@ -1,0 +1,28 @@
+package com.stark.shoot.domain.notification
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class NotificationSettingsTest {
+    @Test
+    fun defaultAllEnabled() {
+        val settings = NotificationSettings(userId = 1L)
+        assertTrue(settings.isEnabled(NotificationType.NEW_MESSAGE))
+    }
+
+    @Test
+    fun updatePreference() {
+        val settings = NotificationSettings(userId = 1L)
+            .updatePreference(NotificationType.NEW_MESSAGE, false)
+        assertFalse(settings.isEnabled(NotificationType.NEW_MESSAGE))
+    }
+
+    @Test
+    fun updateAll() {
+        val settings = NotificationSettings(userId = 1L)
+            .updateAll(mapOf(NotificationType.MENTION to false))
+        assertFalse(settings.isEnabled(NotificationType.MENTION))
+        assertTrue(settings.isEnabled(NotificationType.NEW_MESSAGE))
+    }
+}


### PR DESCRIPTION
## Summary
- allow `ChatMessage` to belong to threads and expire
- add expiration checks with helper to set expiry
- introduce `NotificationSettings` aggregate for per-user preferences
- test new notification settings
- test message expiration behaviour

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684beb41bfe4832082bcf5d9d36ca992