### PR TITLE
Add thread support for messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ data class ChatMessage(
     val senderId: String,                       // 발신자 ID
     val content: MessageContent,                // 메시지 내용
     val status: MessageStatus,                  // 메시지 상태 (SENDING, SENT, SAVED 등)
+    val threadId: String? = null,               // 스레드 ID (루트 메시지 ID)
     val replyToMessageId: String? = null,       // 답장할 메시지 ID
     val reactions: Map<String, Set<String>> = emptyMap(),  // 이모티콘 반응들
     val mentions: Set<String> = emptySet(),               // 멘션된 사용자 ID 목록

--- a/docs/ddd-architecture.md
+++ b/docs/ddd-architecture.md
@@ -67,6 +67,7 @@ Shoot 프로젝트는 DDD(Domain-Driven Design)와 헥사고날 아키텍처(Hex
 - id, roomId, senderId: 기본 식별자
 - content: 메시지 내용 (텍스트, 타입 등)
 - status: 메시지 상태 (SENDING, SAVED 등)
+- threadId: 스레드 ID (루트 메시지 ID)
 - messageReactions: 메시지에 대한 반응
 - mentions: 메시지 내 언급된 사용자
 - readBy: 메시지를 읽은 사용자 추적

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/message/ChatMessageMapperExtensions.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/message/ChatMessageMapperExtensions.kt
@@ -50,6 +50,7 @@ fun ChatMessageRequest.toDomain(): ChatMessage {
         roomId = this.roomId,
         senderId = this.senderId,
         content = content,
+        threadId = this.threadId,
         status = this.status ?: MessageStatus.SAVED,
         readBy = this.readBy?.mapKeys { it.key.toLong() }?.toMutableMap() ?: mutableMapOf(),
         metadata = metadata

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/message/ChatMessageRequest.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/message/ChatMessageRequest.kt
@@ -11,6 +11,7 @@ data class ChatMessageRequest(
     @JsonProperty("roomId") val roomId: Long,
     @JsonProperty("senderId") val senderId: Long,
     @JsonProperty("content") val content: MessageContentRequest,
+    @JsonProperty("threadId") val threadId: String? = null,
     @JsonProperty("status") var status: MessageStatus? = null,
     @JsonProperty("readBy") val readBy: Map<String, Boolean>? = null,
     @JsonProperty("metadata") var metadata: ChatMessageMetadataRequest = ChatMessageMetadataRequest()

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/message/MessageResponseDto.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/message/MessageResponseDto.kt
@@ -17,6 +17,7 @@ data class MessageResponseDto(
     val senderId: Long,
     val content: MessageContentResponseDto,  // content 객체 구조로 변경
     val status: MessageStatus,
+    val threadId: String? = null,
     val replyToMessageId: String? = null,
     val reactions: Map<String, Set<Long>> = emptyMap(),
     val mentions: Set<Long> = emptySet(),

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/document/message/ChatMessageDocument.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/document/message/ChatMessageDocument.kt
@@ -20,6 +20,7 @@ data class ChatMessageDocument(
     val content: MessageContentDocument,                    // 메시지 내용
     val status: MessageStatus = MessageStatus.SAVED,        // 메시지 상태 (e.g., SENT, READ 등)
     val readBy: MutableMap<Long, Boolean> = mutableMapOf(), // 읽음 상태 추가
+    val threadId: ObjectId? = null,                         // 스레드 ID (루트 메시지 ID)
     val replyToMessageId: ObjectId? = null,                 // 답장할 메시지 ID
     val reactions: Map<String, Set<Long>> = emptyMap(),     // 이모티콘 ID to 사용자 ID 목록
     val mentions: Set<Long> = emptySet(),                   // 멘션된 사용자 ID 목록

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/mapper/ChatMessageMapper.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/mapper/ChatMessageMapper.kt
@@ -22,6 +22,7 @@ class ChatMessageMapper {
             senderId = domain.senderId,
             content = toMessageContentDocument(domain.content),
             status = domain.status,
+            threadId = domain.threadId?.let { ObjectId(it) },
             replyToMessageId = domain.replyToMessageId?.let { ObjectId(it) },
             reactions = domain.reactions.mapValues { (_, userIds) ->
                 userIds.map { it }.toSet()
@@ -45,6 +46,7 @@ class ChatMessageMapper {
             senderId = document.senderId,
             content = toMessageContent(document.content),
             status = document.status,
+            threadId = document.threadId?.toString(),
             replyToMessageId = document.replyToMessageId?.toString(),
             messageReactions = MessageReactions(document.reactions.mapValues { (_, userIds) ->
                 userIds.map { it }.toSet()
@@ -150,6 +152,7 @@ class ChatMessageMapper {
                 urlPreview = message.content.metadata?.urlPreview?.let { toUrlPreviewDto(it) }
             ),
             status = message.status,
+            threadId = message.threadId,
             replyToMessageId = message.replyToMessageId,
             reactions = message.reactions,
             mentions = message.mentions,

--- a/src/main/kotlin/com/stark/shoot/application/service/message/SendMessageService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/message/SendMessageService.kt
@@ -71,6 +71,7 @@ class SendMessageService(
             senderId = messageRequest.senderId,
             contentText = messageRequest.content.text,
             contentType = messageRequest.content.type,
+            threadId = messageRequest.threadId,
             extractUrls = { text -> extractUrlPort.extractUrls(text) },
             getCachedPreview = { url -> cacheUrlPreviewPort.getCachedUrlPreview(url) }
         )

--- a/src/main/kotlin/com/stark/shoot/domain/service/message/MessageDomainService.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/service/message/MessageDomainService.kt
@@ -25,6 +25,7 @@ class MessageDomainService {
         senderId: Long,
         contentText: String,
         contentType: com.stark.shoot.domain.chat.message.type.MessageType,
+        threadId: String? = null,
         extractUrls: (String) -> List<String>,
         getCachedPreview: (String) -> UrlPreview?
     ): ChatMessage {
@@ -35,7 +36,8 @@ class MessageDomainService {
             senderId = senderId,
             text = contentText,
             type = contentType,
-            tempId = tempId
+            tempId = tempId,
+            threadId = threadId
         )
 
         // 2. URL 미리보기 처리 (도메인 로직 활용)


### PR DESCRIPTION
## Summary
- support threadId in `ChatMessageDocument`
- map threadId in `ChatMessageMapper`
- expose threadId via DTOs
- pass threadId when creating messages
- document threadId in README and architecture docs

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684bf2d2886c83208818c15594221f92