### PR TITLE
Add thread message retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -746,6 +746,7 @@ fun scheduleMessage(
 | `/api/v1/messages/pin` | POST | 메시지 고정 | 예 |
 | `/api/v1/messages/pin/{messageId}` | DELETE | 메시지 고정 해제 | 예 |
 | `/api/v1/messages/pins/{roomId}` | GET | 고정된 메시지 목록 | 예 |
+| `/api/v1/messages/thread` | GET | 스레드 메시지 조회 | 예 |
 | `/api/v1/messages/reaction` | POST | 이모티콘 반응 추가 | 예 |
 | `/api/v1/messages/reaction` | DELETE | 이모티콘 반응 제거 | 예 |
 | `/api/v1/messages/schedule` | POST | 메시지 예약 | 예 |

--- a/docs/ddd-architecture.md
+++ b/docs/ddd-architecture.md
@@ -82,6 +82,7 @@ Shoot 프로젝트는 DDD(Domain-Driven Design)와 헥사고날 아키텍처(Hex
 - `markAsDeleted`: 메시지 삭제 처리
 - `toggleReaction`: 메시지에 대한 반응 토글
 - `setUrlPreview`/`markNeedsUrlPreview`: URL 미리보기 처리
+- `getThreadMessages`: 스레드에 속한 메시지 조회
 
 **팩토리 메서드**:
 - `create`: 새 메시지 생성

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/message/thread/ThreadMessageController.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/message/thread/ThreadMessageController.kt
@@ -1,0 +1,33 @@
+package com.stark.shoot.adapter.`in`.web.message.thread
+
+import com.stark.shoot.adapter.`in`.web.dto.ResponseDto
+import com.stark.shoot.adapter.`in`.web.dto.message.MessageResponseDto
+import com.stark.shoot.application.port.`in`.message.thread.GetThreadMessagesUseCase
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "스레드", description = "스레드 메시지 관련 API")
+@RequestMapping("/api/v1/messages")
+@RestController
+class ThreadMessageController(
+    private val getThreadMessagesUseCase: GetThreadMessagesUseCase
+) {
+
+    @Operation(
+        summary = "스레드 메시지 조회",
+        description = "특정 스레드에 속한 메시지들을 조회합니다."
+    )
+    @GetMapping("/thread")
+    fun getThreadMessages(
+        @RequestParam threadId: String,
+        @RequestParam(required = false) lastMessageId: String?,
+        @RequestParam(defaultValue = "20") limit: Int
+    ): ResponseDto<List<MessageResponseDto>> {
+        val messages = getThreadMessagesUseCase.getThreadMessages(threadId, lastMessageId, limit)
+        return ResponseDto.success(messages)
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/adapter/message/LoadMessageMongoAdapter.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/adapter/message/LoadMessageMongoAdapter.kt
@@ -142,6 +142,35 @@ class LoadMessageMongoAdapter(
             .map(chatMessageMapper::toDomain)
     }
 
+    override fun findByThreadId(
+        threadId: ObjectId,
+        limit: Int
+    ): List<ChatMessage> {
+        val pageable = PageRequest.of(
+            0,
+            limit,
+            Sort.by(Sort.Direction.ASC, "_id")
+        )
+
+        return chatMessageRepository.findByThreadId(threadId, pageable)
+            .map(chatMessageMapper::toDomain)
+    }
+
+    override fun findByThreadIdAndBeforeId(
+        threadId: ObjectId,
+        lastId: ObjectId,
+        limit: Int
+    ): List<ChatMessage> {
+        val pageable = PageRequest.of(
+            0,
+            limit,
+            Sort.by(Sort.Direction.DESC, "_id")
+        )
+
+        return chatMessageRepository.findByThreadIdAndIdBefore(threadId, lastId, pageable)
+            .map(chatMessageMapper::toDomain)
+    }
+
     /**
      * 채팅방 ID로 메시지 조회 (Flow)
      *

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/repository/ChatMessageMongoRepository.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/repository/ChatMessageMongoRepository.kt
@@ -31,4 +31,14 @@ interface ChatMessageMongoRepository : MongoRepository<ChatMessageDocument, Obje
     @Query("{ 'roomId': ?0, 'isPinned': true }")
     fun findPinnedMessagesByRoomId(roomId: Long, pageable: Pageable = Pageable.unpaged()): List<ChatMessageDocument>
 
+    @Query("{ 'threadId': ?0 }")
+    fun findByThreadId(threadId: ObjectId, pageable: Pageable = Pageable.unpaged()): List<ChatMessageDocument>
+
+    @Query("{ 'threadId': ?0, '_id': { \$lt: ?1 } }")
+    fun findByThreadIdAndIdBefore(
+        threadId: ObjectId,
+        lastId: ObjectId,
+        pageable: Pageable
+    ): List<ChatMessageDocument>
+
 }

--- a/src/main/kotlin/com/stark/shoot/application/port/in/message/thread/GetThreadMessagesUseCase.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/message/thread/GetThreadMessagesUseCase.kt
@@ -1,0 +1,7 @@
+package com.stark.shoot.application.port.`in`.message.thread
+
+import com.stark.shoot.adapter.`in`.web.dto.message.MessageResponseDto
+
+interface GetThreadMessagesUseCase {
+    fun getThreadMessages(threadId: String, lastMessageId: String?, limit: Int): List<MessageResponseDto>
+}

--- a/src/main/kotlin/com/stark/shoot/application/port/out/message/LoadMessagePort.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/out/message/LoadMessagePort.kt
@@ -20,6 +20,9 @@ interface LoadMessagePort {
     fun findUnreadByRoomId(roomId: Long, userId: Long, limit: Int = 100): List<ChatMessage>
     fun findPinnedMessagesByRoomId(roomId: Long, limit: Int): List<ChatMessage>
 
+    fun findByThreadId(threadId: ObjectId, limit: Int): List<ChatMessage>
+    fun findByThreadIdAndBeforeId(threadId: ObjectId, lastId: ObjectId, limit: Int): List<ChatMessage>
+
     fun findByRoomIdFlow(roomId: Long, limit: Int): Flow<ChatMessage>
     fun findByRoomIdAndBeforeIdFlow(roomId: Long, messageId: ObjectId, limit: Int): Flow<ChatMessage>
     fun findByRoomIdAndAfterIdFlow(roomId: Long, messageId: ObjectId, limit: Int): Flow<ChatMessage>

--- a/src/main/kotlin/com/stark/shoot/application/service/message/thread/GetThreadMessagesService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/message/thread/GetThreadMessagesService.kt
@@ -1,0 +1,24 @@
+package com.stark.shoot.application.service.message.thread
+
+import com.stark.shoot.adapter.`in`.web.dto.message.MessageResponseDto
+import com.stark.shoot.adapter.out.persistence.mongodb.mapper.ChatMessageMapper
+import com.stark.shoot.application.port.`in`.message.thread.GetThreadMessagesUseCase
+import com.stark.shoot.application.port.out.message.LoadMessagePort
+import com.stark.shoot.infrastructure.annotation.UseCase
+import com.stark.shoot.infrastructure.util.toObjectId
+
+@UseCase
+class GetThreadMessagesService(
+    private val loadMessagePort: LoadMessagePort,
+    private val chatMessageMapper: ChatMessageMapper,
+) : GetThreadMessagesUseCase {
+
+    override fun getThreadMessages(threadId: String, lastMessageId: String?, limit: Int): List<MessageResponseDto> {
+        val messages = if (lastMessageId != null) {
+            loadMessagePort.findByThreadIdAndBeforeId(threadId.toObjectId(), lastMessageId.toObjectId(), limit)
+        } else {
+            loadMessagePort.findByThreadId(threadId.toObjectId(), limit)
+        }
+        return chatMessageMapper.toDtoList(messages)
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/application/service/message/thread/GetThreadMessagesServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/application/service/message/thread/GetThreadMessagesServiceTest.kt
@@ -1,0 +1,72 @@
+package com.stark.shoot.application.service.message.thread
+
+import com.stark.shoot.adapter.out.persistence.mongodb.mapper.ChatMessageMapper
+import com.stark.shoot.application.port.out.message.LoadMessagePort
+import com.stark.shoot.domain.chat.message.ChatMessage
+import com.stark.shoot.domain.chat.message.MessageContent
+import com.stark.shoot.domain.chat.message.type.MessageStatus
+import com.stark.shoot.domain.chat.message.type.MessageType
+import com.stark.shoot.infrastructure.util.toObjectId
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.*
+import java.time.Instant
+
+@DisplayName("스레드 메시지 조회 서비스 테스트")
+class GetThreadMessagesServiceTest {
+
+    private val loadMessagePort = mock(LoadMessagePort::class.java)
+    private val chatMessageMapper = ChatMessageMapper()
+
+    private val getThreadMessagesService = GetThreadMessagesService(
+        loadMessagePort,
+        chatMessageMapper
+    )
+
+    @Nested
+    @DisplayName("스레드 메시지 조회 시")
+    inner class GetThreadMessages {
+
+        @Test
+        @DisplayName("스레드의 메시지를 조회할 수 있다")
+        fun `스레드의 메시지를 조회할 수 있다`() {
+            // given
+            val threadId = "5f9f1b9b9c9d1b9b9c9d1b9b"
+            val message = ChatMessage(
+                id = "5f9f1b9b9c9d1b9b9c9d1b9c",
+                roomId = 1L,
+                senderId = 2L,
+                content = MessageContent("hello", MessageType.TEXT),
+                status = MessageStatus.SAVED,
+                threadId = threadId,
+                createdAt = Instant.now()
+            )
+
+            `when`(loadMessagePort.findByThreadId(threadId.toObjectId(), 20)).thenReturn(listOf(message))
+
+            // when
+            val result = getThreadMessagesService.getThreadMessages(threadId, null, 20)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].id).isEqualTo(message.id)
+
+            verify(loadMessagePort).findByThreadId(threadId.toObjectId(), 20)
+        }
+
+        @Test
+        @DisplayName("스레드 메시지가 없는 경우 빈 목록을 반환한다")
+        fun `스레드 메시지가 없는 경우 빈 목록을 반환한다`() {
+            val threadId = "5f9f1b9b9c9d1b9b9c9d1b9b"
+            `when`(loadMessagePort.findByThreadId(threadId.toObjectId(), 20)).thenReturn(emptyList())
+
+            val result = getThreadMessagesService.getThreadMessages(threadId, null, 20)
+
+            assertThat(result).isEmpty()
+
+            verify(loadMessagePort).findByThreadId(threadId.toObjectId(), 20)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- support retrieving messages by thread id
- add thread message controller and service
- document thread API in README and architecture docs
- provide tests for GetThreadMessagesService

## Testing
- `./gradlew test` *(fails: unable to access internet for Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_684c0a47bdc08320b3fa38c5d99ccece