### PR TITLE
Add thread message send endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -747,6 +747,7 @@ fun scheduleMessage(
 | `/api/v1/messages/pin/{messageId}` | DELETE | 메시지 고정 해제 | 예 |
 | `/api/v1/messages/pins/{roomId}` | GET | 고정된 메시지 목록 | 예 |
 | `/api/v1/messages/thread` | GET | 스레드 메시지 조회 | 예 |
+| `/api/v1/messages/thread` | POST | 스레드 메시지 전송 | 예 |
 | `/api/v1/messages/reaction` | POST | 이모티콘 반응 추가 | 예 |
 | `/api/v1/messages/reaction` | DELETE | 이모티콘 반응 제거 | 예 |
 | `/api/v1/messages/schedule` | POST | 메시지 예약 | 예 |

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/message/thread/ThreadMessageController.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/message/thread/ThreadMessageController.kt
@@ -2,7 +2,9 @@ package com.stark.shoot.adapter.`in`.web.message.thread
 
 import com.stark.shoot.adapter.`in`.web.dto.ResponseDto
 import com.stark.shoot.adapter.`in`.web.dto.message.MessageResponseDto
+import com.stark.shoot.adapter.`in`.web.dto.message.ChatMessageRequest
 import com.stark.shoot.application.port.`in`.message.thread.GetThreadMessagesUseCase
+import com.stark.shoot.application.port.`in`.message.thread.SendThreadMessageUseCase
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.GetMapping
@@ -14,7 +16,8 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/v1/messages")
 @RestController
 class ThreadMessageController(
-    private val getThreadMessagesUseCase: GetThreadMessagesUseCase
+    private val getThreadMessagesUseCase: GetThreadMessagesUseCase,
+    private val sendThreadMessageUseCase: SendThreadMessageUseCase,
 ) {
 
     @Operation(
@@ -29,5 +32,17 @@ class ThreadMessageController(
     ): ResponseDto<List<MessageResponseDto>> {
         val messages = getThreadMessagesUseCase.getThreadMessages(threadId, lastMessageId, limit)
         return ResponseDto.success(messages)
+    }
+
+    @Operation(
+        summary = "스레드 메시지 전송",
+        description = "스레드에 새로운 메시지를 작성합니다."
+    )
+    @PostMapping("/thread")
+    fun sendThreadMessage(
+        @RequestBody request: ChatMessageRequest
+    ): ResponseDto<Void> {
+        sendThreadMessageUseCase.sendThreadMessage(request)
+        return ResponseDto.success(null)
     }
 }

--- a/src/main/kotlin/com/stark/shoot/application/port/in/message/thread/SendThreadMessageUseCase.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/message/thread/SendThreadMessageUseCase.kt
@@ -1,0 +1,10 @@
+package com.stark.shoot.application.port.`in`.message.thread
+
+import com.stark.shoot.adapter.`in`.web.dto.message.ChatMessageRequest
+
+/**
+ * 스레드에 메시지를 전송하기 위한 UseCase
+ */
+interface SendThreadMessageUseCase {
+    fun sendThreadMessage(request: ChatMessageRequest)
+}

--- a/src/main/kotlin/com/stark/shoot/application/service/message/thread/SendThreadMessageService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/message/thread/SendThreadMessageService.kt
@@ -1,0 +1,26 @@
+package com.stark.shoot.application.service.message.thread
+
+import com.stark.shoot.adapter.`in`.web.dto.message.ChatMessageRequest
+import com.stark.shoot.application.port.`in`.message.SendMessageUseCase
+import com.stark.shoot.application.port.`in`.message.thread.SendThreadMessageUseCase
+import com.stark.shoot.application.port.out.message.LoadMessagePort
+import com.stark.shoot.infrastructure.annotation.UseCase
+import com.stark.shoot.infrastructure.exception.web.ResourceNotFoundException
+import com.stark.shoot.infrastructure.util.toObjectId
+
+@UseCase
+class SendThreadMessageService(
+    private val loadMessagePort: LoadMessagePort,
+    private val sendMessageUseCase: SendMessageUseCase,
+) : SendThreadMessageUseCase {
+
+    override fun sendThreadMessage(request: ChatMessageRequest) {
+        val threadId = request.threadId
+            ?: throw IllegalArgumentException("threadId must not be null")
+
+        loadMessagePort.findById(threadId.toObjectId())
+            ?: throw ResourceNotFoundException("스레드 루트 메시지를 찾을 수 없습니다: threadId=$threadId")
+
+        sendMessageUseCase.sendMessage(request)
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/application/service/message/thread/SendThreadMessageServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/application/service/message/thread/SendThreadMessageServiceTest.kt
@@ -1,0 +1,77 @@
+package com.stark.shoot.application.service.message.thread
+
+import com.stark.shoot.adapter.`in`.web.dto.message.ChatMessageRequest
+import com.stark.shoot.adapter.`in`.web.dto.message.MessageContentRequest
+import com.stark.shoot.application.port.`in`.message.SendMessageUseCase
+import com.stark.shoot.application.port.out.message.LoadMessagePort
+import com.stark.shoot.domain.chat.message.ChatMessage
+import com.stark.shoot.domain.chat.message.MessageContent
+import com.stark.shoot.domain.chat.message.type.MessageStatus
+import com.stark.shoot.domain.chat.message.type.MessageType
+import com.stark.shoot.infrastructure.exception.web.ResourceNotFoundException
+import com.stark.shoot.infrastructure.util.toObjectId
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.*
+import java.time.Instant
+
+@DisplayName("스레드 메시지 전송 서비스 테스트")
+class SendThreadMessageServiceTest {
+
+    private val loadMessagePort = mock(LoadMessagePort::class.java)
+    private val sendMessageUseCase = mock(SendMessageUseCase::class.java)
+
+    private val sendThreadMessageService = SendThreadMessageService(
+        loadMessagePort,
+        sendMessageUseCase
+    )
+
+    @Test
+    @DisplayName("존재하지 않는 스레드에 메시지를 보내면 예외가 발생한다")
+    fun `존재하지 않는 스레드에 메시지를 보내면 예외가 발생한다`() {
+        val request = ChatMessageRequest(
+            roomId = 1L,
+            senderId = 2L,
+            content = MessageContentRequest("hi", MessageType.TEXT),
+            threadId = "5f9f1b9b9c9d1b9b9c9d1b9b"
+        )
+
+        `when`(loadMessagePort.findById(request.threadId!!.toObjectId())).thenReturn(null)
+
+        assertThrows<ResourceNotFoundException> {
+            sendThreadMessageService.sendThreadMessage(request)
+        }
+
+        verify(loadMessagePort).findById(request.threadId!!.toObjectId())
+        verifyNoInteractions(sendMessageUseCase)
+    }
+
+    @Test
+    @DisplayName("스레드 메시지를 전송할 수 있다")
+    fun `스레드 메시지를 전송할 수 있다`() {
+        val threadId = "5f9f1b9b9c9d1b9b9c9d1b9b"
+        val request = ChatMessageRequest(
+            roomId = 1L,
+            senderId = 2L,
+            content = MessageContentRequest("hi", MessageType.TEXT),
+            threadId = threadId
+        )
+
+        val rootMessage = ChatMessage(
+            id = threadId,
+            roomId = 1L,
+            senderId = 3L,
+            content = MessageContent("root", MessageType.TEXT),
+            status = MessageStatus.SAVED,
+            createdAt = Instant.now()
+        )
+
+        `when`(loadMessagePort.findById(threadId.toObjectId())).thenReturn(rootMessage)
+
+        sendThreadMessageService.sendThreadMessage(request)
+
+        verify(loadMessagePort).findById(threadId.toObjectId())
+        verify(sendMessageUseCase).sendMessage(request)
+    }
+}


### PR DESCRIPTION
## Summary
- allow sending thread messages via REST
- implement `SendThreadMessageService` and use case
- extend thread message controller with POST endpoint
- document new endpoint
- add unit tests

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684c3a697b9083209f1e5f7d9a965764