### PR TITLE
Add thread list API

### DIFF
--- a/README.md
+++ b/README.md
@@ -748,6 +748,7 @@ fun scheduleMessage(
 | `/api/v1/messages/pins/{roomId}` | GET | 고정된 메시지 목록 | 예 |
 | `/api/v1/messages/thread` | GET | 스레드 메시지 조회 | 예 |
 | `/api/v1/messages/thread` | POST | 스레드 메시지 전송 | 예 |
+| `/api/v1/messages/threads` | GET | 채팅방의 스레드 목록 조회 | 예 |
 | `/api/v1/messages/reaction` | POST | 이모티콘 반응 추가 | 예 |
 | `/api/v1/messages/reaction` | DELETE | 이모티콘 반응 제거 | 예 |
 | `/api/v1/messages/schedule` | POST | 메시지 예약 | 예 |

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/message/thread/ThreadSummaryDto.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/message/thread/ThreadSummaryDto.kt
@@ -1,0 +1,10 @@
+package com.stark.shoot.adapter.`in`.web.dto.message.thread
+
+import com.stark.shoot.adapter.`in`.web.dto.message.MessageResponseDto
+import com.stark.shoot.infrastructure.annotation.ApplicationDto
+
+@ApplicationDto
+data class ThreadSummaryDto(
+    val rootMessage: MessageResponseDto,
+    val replyCount: Long
+)

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/message/thread/ThreadController.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/message/thread/ThreadController.kt
@@ -1,0 +1,33 @@
+package com.stark.shoot.adapter.`in`.web.message.thread
+
+import com.stark.shoot.adapter.`in`.web.dto.ResponseDto
+import com.stark.shoot.adapter.`in`.web.dto.message.thread.ThreadSummaryDto
+import com.stark.shoot.application.port.`in`.message.thread.GetThreadsUseCase
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "스레드", description = "스레드 메시지 관련 API")
+@RequestMapping("/api/v1/messages")
+@RestController
+class ThreadController(
+    private val getThreadsUseCase: GetThreadsUseCase,
+) {
+
+    @Operation(
+        summary = "채팅방 스레드 목록 조회",
+        description = "채팅방의 루트 메시지를 기반으로 스레드 목록을 조회합니다."
+    )
+    @GetMapping("/threads")
+    fun getThreads(
+        @RequestParam roomId: Long,
+        @RequestParam(required = false) lastThreadId: String?,
+        @RequestParam(defaultValue = "20") limit: Int
+    ): ResponseDto<List<ThreadSummaryDto>> {
+        val threads = getThreadsUseCase.getThreads(roomId, lastThreadId, limit)
+        return ResponseDto.success(threads)
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/adapter/message/LoadMessageMongoAdapter.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/adapter/message/LoadMessageMongoAdapter.kt
@@ -171,6 +171,39 @@ class LoadMessageMongoAdapter(
             .map(chatMessageMapper::toDomain)
     }
 
+    override fun findThreadRootsByRoomId(
+        roomId: Long,
+        limit: Int
+    ): List<ChatMessage> {
+        val pageable = PageRequest.of(
+            0,
+            limit,
+            Sort.by(Sort.Direction.DESC, "_id")
+        )
+
+        return chatMessageRepository.findThreadRootsByRoomId(roomId, pageable)
+            .map(chatMessageMapper::toDomain)
+    }
+
+    override fun findThreadRootsByRoomIdAndBeforeId(
+        roomId: Long,
+        lastId: ObjectId,
+        limit: Int
+    ): List<ChatMessage> {
+        val pageable = PageRequest.of(
+            0,
+            limit,
+            Sort.by(Sort.Direction.DESC, "_id")
+        )
+
+        return chatMessageRepository.findThreadRootsByRoomIdAndIdBefore(roomId, lastId, pageable)
+            .map(chatMessageMapper::toDomain)
+    }
+
+    override fun countByThreadId(threadId: ObjectId): Long {
+        return chatMessageRepository.countByThreadId(threadId)
+    }
+
     /**
      * 채팅방 ID로 메시지 조회 (Flow)
      *

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/repository/ChatMessageMongoRepository.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/repository/ChatMessageMongoRepository.kt
@@ -41,4 +41,16 @@ interface ChatMessageMongoRepository : MongoRepository<ChatMessageDocument, Obje
         pageable: Pageable
     ): List<ChatMessageDocument>
 
+    @Query("{ 'roomId': ?0, 'threadId': null }")
+    fun findThreadRootsByRoomId(roomId: Long, pageable: Pageable = Pageable.unpaged()): List<ChatMessageDocument>
+
+    @Query("{ 'roomId': ?0, '_id': { \$lt: ?1 }, 'threadId': null }")
+    fun findThreadRootsByRoomIdAndIdBefore(
+        roomId: Long,
+        lastId: ObjectId,
+        pageable: Pageable
+    ): List<ChatMessageDocument>
+
+    fun countByThreadId(threadId: ObjectId): Long
+
 }

--- a/src/main/kotlin/com/stark/shoot/application/port/in/message/thread/GetThreadsUseCase.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/message/thread/GetThreadsUseCase.kt
@@ -1,0 +1,7 @@
+package com.stark.shoot.application.port.`in`.message.thread
+
+import com.stark.shoot.adapter.`in`.web.dto.message.thread.ThreadSummaryDto
+
+interface GetThreadsUseCase {
+    fun getThreads(roomId: Long, lastThreadId: String?, limit: Int): List<ThreadSummaryDto>
+}

--- a/src/main/kotlin/com/stark/shoot/application/port/out/message/LoadMessagePort.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/out/message/LoadMessagePort.kt
@@ -23,6 +23,10 @@ interface LoadMessagePort {
     fun findByThreadId(threadId: ObjectId, limit: Int): List<ChatMessage>
     fun findByThreadIdAndBeforeId(threadId: ObjectId, lastId: ObjectId, limit: Int): List<ChatMessage>
 
+    fun findThreadRootsByRoomId(roomId: Long, limit: Int): List<ChatMessage>
+    fun findThreadRootsByRoomIdAndBeforeId(roomId: Long, lastId: ObjectId, limit: Int): List<ChatMessage>
+    fun countByThreadId(threadId: ObjectId): Long
+
     fun findByRoomIdFlow(roomId: Long, limit: Int): Flow<ChatMessage>
     fun findByRoomIdAndBeforeIdFlow(roomId: Long, messageId: ObjectId, limit: Int): Flow<ChatMessage>
     fun findByRoomIdAndAfterIdFlow(roomId: Long, messageId: ObjectId, limit: Int): Flow<ChatMessage>

--- a/src/main/kotlin/com/stark/shoot/application/service/message/thread/GetThreadsService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/message/thread/GetThreadsService.kt
@@ -1,0 +1,31 @@
+package com.stark.shoot.application.service.message.thread
+
+import com.stark.shoot.adapter.`in`.web.dto.message.thread.ThreadSummaryDto
+import com.stark.shoot.adapter.out.persistence.mongodb.mapper.ChatMessageMapper
+import com.stark.shoot.application.port.`in`.message.thread.GetThreadsUseCase
+import com.stark.shoot.application.port.out.message.LoadMessagePort
+import com.stark.shoot.infrastructure.annotation.UseCase
+import com.stark.shoot.infrastructure.util.toObjectId
+
+@UseCase
+class GetThreadsService(
+    private val loadMessagePort: LoadMessagePort,
+    private val chatMessageMapper: ChatMessageMapper,
+) : GetThreadsUseCase {
+
+    override fun getThreads(roomId: Long, lastThreadId: String?, limit: Int): List<ThreadSummaryDto> {
+        val rootMessages = if (lastThreadId != null) {
+            loadMessagePort.findThreadRootsByRoomIdAndBeforeId(roomId, lastThreadId.toObjectId(), limit)
+        } else {
+            loadMessagePort.findThreadRootsByRoomId(roomId, limit)
+        }
+
+        return rootMessages.map { message ->
+            val count = loadMessagePort.countByThreadId(message.id!!.toObjectId())
+            ThreadSummaryDto(
+                rootMessage = chatMessageMapper.toDto(message),
+                replyCount = count
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `GetThreadsUseCase` and service implementation
- expose `/api/v1/messages/threads` endpoint
- extend `LoadMessagePort` and Mongo adapters for thread queries
- document thread list endpoint

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684c3dc42e0c832085a1502b7733326e