### PR TITLE
Add thread detail retrieval

### DIFF
--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/message/thread/ThreadDetailDto.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/message/thread/ThreadDetailDto.kt
@@ -1,0 +1,10 @@
+package com.stark.shoot.adapter.`in`.web.dto.message.thread
+
+import com.stark.shoot.adapter.`in`.web.dto.message.MessageResponseDto
+import com.stark.shoot.infrastructure.annotation.ApplicationDto
+
+@ApplicationDto
+data class ThreadDetailDto(
+    val rootMessage: MessageResponseDto,
+    val messages: List<MessageResponseDto>
+)

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/message/thread/ThreadMessageController.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/message/thread/ThreadMessageController.kt
@@ -4,7 +4,9 @@ import com.stark.shoot.adapter.`in`.web.dto.ResponseDto
 import com.stark.shoot.adapter.`in`.web.dto.message.ChatMessageRequest
 import com.stark.shoot.adapter.`in`.web.dto.message.MessageResponseDto
 import com.stark.shoot.application.port.`in`.message.thread.GetThreadMessagesUseCase
+import com.stark.shoot.application.port.`in`.message.thread.GetThreadDetailUseCase
 import com.stark.shoot.application.port.`in`.message.thread.SendThreadMessageUseCase
+import com.stark.shoot.adapter.`in`.web.dto.message.thread.ThreadDetailDto
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.*
@@ -14,6 +16,7 @@ import org.springframework.web.bind.annotation.*
 @RestController
 class ThreadMessageController(
     private val getThreadMessagesUseCase: GetThreadMessagesUseCase,
+    private val getThreadDetailUseCase: GetThreadDetailUseCase,
     private val sendThreadMessageUseCase: SendThreadMessageUseCase,
 ) {
 
@@ -29,6 +32,20 @@ class ThreadMessageController(
     ): ResponseDto<List<MessageResponseDto>> {
         val messages = getThreadMessagesUseCase.getThreadMessages(threadId, lastMessageId, limit)
         return ResponseDto.success(messages)
+    }
+
+    @Operation(
+        summary = "스레드 상세 조회",
+        description = "루트 메시지와 스레드 메시지를 함께 조회합니다."
+    )
+    @GetMapping("/thread/detail")
+    fun getThreadDetail(
+        @RequestParam threadId: String,
+        @RequestParam(required = false) lastMessageId: String?,
+        @RequestParam(defaultValue = "20") limit: Int
+    ): ResponseDto<ThreadDetailDto> {
+        val detail = getThreadDetailUseCase.getThreadDetail(threadId, lastMessageId, limit)
+        return ResponseDto.success(detail)
     }
 
     @Operation(

--- a/src/main/kotlin/com/stark/shoot/application/port/in/message/thread/GetThreadDetailUseCase.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/message/thread/GetThreadDetailUseCase.kt
@@ -1,0 +1,7 @@
+package com.stark.shoot.application.port.`in`.message.thread
+
+import com.stark.shoot.adapter.`in`.web.dto.message.thread.ThreadDetailDto
+
+interface GetThreadDetailUseCase {
+    fun getThreadDetail(threadId: String, lastMessageId: String?, limit: Int): ThreadDetailDto
+}

--- a/src/main/kotlin/com/stark/shoot/application/service/message/thread/GetThreadDetailService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/message/thread/GetThreadDetailService.kt
@@ -1,0 +1,32 @@
+package com.stark.shoot.application.service.message.thread
+
+import com.stark.shoot.adapter.`in`.web.dto.message.thread.ThreadDetailDto
+import com.stark.shoot.adapter.out.persistence.mongodb.mapper.ChatMessageMapper
+import com.stark.shoot.application.port.`in`.message.thread.GetThreadDetailUseCase
+import com.stark.shoot.application.port.out.message.LoadMessagePort
+import com.stark.shoot.infrastructure.annotation.UseCase
+import com.stark.shoot.infrastructure.exception.web.ResourceNotFoundException
+import com.stark.shoot.infrastructure.util.toObjectId
+
+@UseCase
+class GetThreadDetailService(
+    private val loadMessagePort: LoadMessagePort,
+    private val chatMessageMapper: ChatMessageMapper,
+) : GetThreadDetailUseCase {
+
+    override fun getThreadDetail(threadId: String, lastMessageId: String?, limit: Int): ThreadDetailDto {
+        val rootMessage = loadMessagePort.findById(threadId.toObjectId())
+            ?: throw ResourceNotFoundException("스레드 루트 메시지를 찾을 수 없습니다: threadId=$threadId")
+
+        val messages = if (lastMessageId != null) {
+            loadMessagePort.findByThreadIdAndBeforeId(threadId.toObjectId(), lastMessageId.toObjectId(), limit)
+        } else {
+            loadMessagePort.findByThreadId(threadId.toObjectId(), limit)
+        }
+
+        return ThreadDetailDto(
+            rootMessage = chatMessageMapper.toDto(rootMessage),
+            messages = chatMessageMapper.toDtoList(messages)
+        )
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/application/service/message/thread/GetThreadDetailServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/application/service/message/thread/GetThreadDetailServiceTest.kt
@@ -1,0 +1,81 @@
+package com.stark.shoot.application.service.message.thread
+
+import com.stark.shoot.adapter.out.persistence.mongodb.mapper.ChatMessageMapper
+import com.stark.shoot.application.port.out.message.LoadMessagePort
+import com.stark.shoot.domain.chat.message.ChatMessage
+import com.stark.shoot.domain.chat.message.MessageContent
+import com.stark.shoot.domain.chat.message.type.MessageStatus
+import com.stark.shoot.domain.chat.message.type.MessageType
+import com.stark.shoot.infrastructure.exception.web.ResourceNotFoundException
+import com.stark.shoot.infrastructure.util.toObjectId
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.*
+import java.time.Instant
+
+@DisplayName("스레드 상세 조회 서비스 테스트")
+class GetThreadDetailServiceTest {
+
+    private val loadMessagePort = mock(LoadMessagePort::class.java)
+    private val chatMessageMapper = ChatMessageMapper()
+
+    private val getThreadDetailService = GetThreadDetailService(
+        loadMessagePort,
+        chatMessageMapper
+    )
+
+    @Nested
+    @DisplayName("스레드 상세 조회 시")
+    inner class GetThreadDetail {
+
+        @Test
+        @DisplayName("루트 메시지와 스레드 메시지를 함께 조회할 수 있다")
+        fun `루트 메시지와 스레드 메시지를 함께 조회할 수 있다`() {
+            val threadId = "5f9f1b9b9c9d1b9b9c9d1b9b"
+            val rootMessage = ChatMessage(
+                id = threadId,
+                roomId = 1L,
+                senderId = 2L,
+                content = MessageContent("root", MessageType.TEXT),
+                status = MessageStatus.SAVED,
+                createdAt = Instant.now()
+            )
+            val reply = ChatMessage(
+                id = "5f9f1b9b9c9d1b9b9c9d1b9c",
+                roomId = 1L,
+                senderId = 3L,
+                content = MessageContent("reply", MessageType.TEXT),
+                status = MessageStatus.SAVED,
+                threadId = threadId,
+                createdAt = Instant.now()
+            )
+
+            `when`(loadMessagePort.findById(threadId.toObjectId())).thenReturn(rootMessage)
+            `when`(loadMessagePort.findByThreadId(threadId.toObjectId(), 20)).thenReturn(listOf(reply))
+
+            val result = getThreadDetailService.getThreadDetail(threadId, null, 20)
+
+            assertThat(result.rootMessage.id).isEqualTo(threadId)
+            assertThat(result.messages).hasSize(1)
+            verify(loadMessagePort).findById(threadId.toObjectId())
+            verify(loadMessagePort).findByThreadId(threadId.toObjectId(), 20)
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 스레드는 예외를 발생시킨다")
+        fun `존재하지 않는 스레드는 예외를 발생시킨다`() {
+            val threadId = "5f9f1b9b9c9d1b9b9c9d1b9b"
+            `when`(loadMessagePort.findById(threadId.toObjectId())).thenReturn(null)
+
+            assertThrows<ResourceNotFoundException> {
+                getThreadDetailService.getThreadDetail(threadId, null, 20)
+            }
+
+            verify(loadMessagePort).findById(threadId.toObjectId())
+            verify(loadMessagePort, never()).findByThreadId(any(), anyInt())
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `ThreadDetailDto`
- introduce `GetThreadDetailUseCase` and `GetThreadDetailService`
- extend `ThreadMessageController` with `/thread/detail` endpoint
- add unit tests for thread detail service

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684d0573fd988320856cb3d9da904a26