### PR TITLE
Add STOMP handlers for thread messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -763,6 +763,10 @@ fun scheduleMessage(
 | `/app/chat` | 메시지 전송 |
 | `/app/typing` | 타이핑 인디케이터 |
 | `/app/read` | 메시지 읽음 처리 |
+| `/app/thread` | 스레드 메시지 전송 |
+| `/app/thread/messages` | 스레드 메시지 조회 |
+| `/app/thread/detail` | 스레드 상세 조회 |
+| `/app/threads` | 채팅방 스레드 목록 조회 |
 | `/topic/messages/{roomId}` | 채팅방 메시지 구독 |
 | `/topic/message/status/{roomId}` | 메시지 상태 업데이트 구독 |
 | `/topic/typing/{roomId}` | 타이핑 인디케이터 구독 |

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/socket/dto/ThreadRequestDto.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/socket/dto/ThreadRequestDto.kt
@@ -1,0 +1,25 @@
+package com.stark.shoot.adapter.`in`.web.socket.dto
+
+/**
+ * 스레드 관련 STOMP 요청 DTO 모음
+ */
+data class ThreadListRequestDto(
+    val roomId: Long,
+    val userId: Long,
+    val lastThreadId: String? = null,
+    val limit: Int = 20,
+)
+
+data class ThreadMessagesRequestDto(
+    val threadId: String,
+    val userId: Long,
+    val lastMessageId: String? = null,
+    val limit: Int = 20,
+)
+
+data class ThreadDetailRequestDto(
+    val threadId: String,
+    val userId: Long,
+    val lastMessageId: String? = null,
+    val limit: Int = 20,
+)

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/socket/message/thread/GetThreadDetailStompHandler.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/socket/message/thread/GetThreadDetailStompHandler.kt
@@ -1,0 +1,22 @@
+package com.stark.shoot.adapter.`in`.web.socket.message.thread
+
+import com.stark.shoot.adapter.`in`.web.socket.dto.ThreadDetailRequestDto
+import com.stark.shoot.application.port.`in`.message.thread.GetThreadDetailUseCase
+import io.swagger.v3.oas.annotations.Operation
+import org.springframework.messaging.handler.annotation.MessageMapping
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.stereotype.Controller
+
+@Controller
+class GetThreadDetailStompHandler(
+    private val getThreadDetailUseCase: GetThreadDetailUseCase,
+    private val messagingTemplate: SimpMessagingTemplate,
+) {
+
+    @Operation(summary = "스레드 상세 조회 (WebSocket)")
+    @MessageMapping("/thread/detail")
+    fun handleGetThreadDetail(request: ThreadDetailRequestDto) {
+        val detail = getThreadDetailUseCase.getThreadDetail(request.threadId, request.lastMessageId, request.limit)
+        messagingTemplate.convertAndSendToUser(request.userId.toString(), "/queue/thread/detail", detail)
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/socket/message/thread/GetThreadMessagesStompHandler.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/socket/message/thread/GetThreadMessagesStompHandler.kt
@@ -1,0 +1,22 @@
+package com.stark.shoot.adapter.`in`.web.socket.message.thread
+
+import com.stark.shoot.adapter.`in`.web.socket.dto.ThreadMessagesRequestDto
+import com.stark.shoot.application.port.`in`.message.thread.GetThreadMessagesUseCase
+import io.swagger.v3.oas.annotations.Operation
+import org.springframework.messaging.handler.annotation.MessageMapping
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.stereotype.Controller
+
+@Controller
+class GetThreadMessagesStompHandler(
+    private val getThreadMessagesUseCase: GetThreadMessagesUseCase,
+    private val messagingTemplate: SimpMessagingTemplate,
+) {
+
+    @Operation(summary = "스레드 메시지 조회 (WebSocket)")
+    @MessageMapping("/thread/messages")
+    fun handleGetThreadMessages(request: ThreadMessagesRequestDto) {
+        val messages = getThreadMessagesUseCase.getThreadMessages(request.threadId, request.lastMessageId, request.limit)
+        messagingTemplate.convertAndSendToUser(request.userId.toString(), "/queue/thread/messages", messages)
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/socket/message/thread/GetThreadsStompHandler.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/socket/message/thread/GetThreadsStompHandler.kt
@@ -1,0 +1,22 @@
+package com.stark.shoot.adapter.`in`.web.socket.message.thread
+
+import com.stark.shoot.adapter.`in`.web.socket.dto.ThreadListRequestDto
+import com.stark.shoot.application.port.`in`.message.thread.GetThreadsUseCase
+import io.swagger.v3.oas.annotations.Operation
+import org.springframework.messaging.handler.annotation.MessageMapping
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.stereotype.Controller
+
+@Controller
+class GetThreadsStompHandler(
+    private val getThreadsUseCase: GetThreadsUseCase,
+    private val messagingTemplate: SimpMessagingTemplate,
+) {
+
+    @Operation(summary = "채팅방 스레드 목록 조회 (WebSocket)")
+    @MessageMapping("/threads")
+    fun handleGetThreads(request: ThreadListRequestDto) {
+        val threads = getThreadsUseCase.getThreads(request.roomId, request.lastThreadId, request.limit)
+        messagingTemplate.convertAndSendToUser(request.userId.toString(), "/queue/threads", threads)
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/socket/message/thread/SendThreadMessageStompHandler.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/socket/message/thread/SendThreadMessageStompHandler.kt
@@ -1,0 +1,19 @@
+package com.stark.shoot.adapter.`in`.web.socket.message.thread
+
+import com.stark.shoot.adapter.`in`.web.dto.message.ChatMessageRequest
+import com.stark.shoot.application.port.`in`.message.thread.SendThreadMessageUseCase
+import io.swagger.v3.oas.annotations.Operation
+import org.springframework.messaging.handler.annotation.MessageMapping
+import org.springframework.stereotype.Controller
+
+@Controller
+class SendThreadMessageStompHandler(
+    private val sendThreadMessageUseCase: SendThreadMessageUseCase,
+) {
+
+    @Operation(summary = "스레드 메시지 전송 (WebSocket)")
+    @MessageMapping("/thread")
+    fun handleSendThreadMessage(request: ChatMessageRequest) {
+        sendThreadMessageUseCase.sendThreadMessage(request)
+    }
+}


### PR DESCRIPTION
## Summary
- support thread-related websocket requests
- document new STOMP endpoints

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684d22ebabcc8320b10ec4621ba5c646