### PR TITLE
Include thread reply counts in message sync

### DIFF
--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/socket/dto/MessageSyncDto.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/socket/dto/MessageSyncDto.kt
@@ -29,7 +29,8 @@ data class MessageSyncInfoDto(
     val status: String,
     val content: MessageContentRequest? = null,  // 추가
     val readBy: Map<Long, Boolean>? = null,  // 추가
-    val reactions: List<ReactionDto> = emptyList()  // 리액션 추가
+    val reactions: List<ReactionDto> = emptyList(),  // 리액션 추가
+    val replyCount: Long? = null
 )
 
 data class ReactionDto(

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/socket/mapper/MessageSyncMapper.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/socket/mapper/MessageSyncMapper.kt
@@ -23,7 +23,7 @@ class MessageSyncMapper {
      * @param message ChatMessage 객체
      * @return MessageSyncInfoDto 객체
      */
-    fun toSyncInfoDto(message: ChatMessage): MessageSyncInfoDto {
+    fun toSyncInfoDto(message: ChatMessage, replyCount: Long? = null): MessageSyncInfoDto {
         logger.trace { "메시지 변환: messageId=${message.id}, senderId=${message.senderId}" }
 
         // 도메인 Attachment 객체를 ID 문자열로 변환
@@ -55,7 +55,8 @@ class MessageSyncMapper {
                 isDeleted = message.content.isDeleted
             ),
             readBy = message.readBy,
-            reactions = reactionDtos
+            reactions = reactionDtos,
+            replyCount = replyCount
         )
     }
 

--- a/src/main/kotlin/com/stark/shoot/application/service/message/PaginationMessageSyncService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/message/PaginationMessageSyncService.kt
@@ -53,7 +53,12 @@ class PaginationMessageSyncService(
                 throw e
             }
             .collect { message ->
-                emit(messageSyncMapper.toSyncInfoDto(message))
+                val replyCount = if (message.threadId == null && message.id != null) {
+                    loadMessagePort.countByThreadId(ObjectId(message.id))
+                } else {
+                    null
+                }
+                emit(messageSyncMapper.toSyncInfoDto(message, replyCount))
             }
     }
 


### PR DESCRIPTION
## Summary
- add `replyCount` to `MessageSyncInfoDto`
- update `MessageSyncMapper` to populate reply count
- enhance `PaginationMessageSyncService` to fetch reply counts when syncing

## Testing
- `./gradlew test -q` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684d266dfab8832082b27dd40ac9c905