### PR TITLE
Refactor friend request validation into domain

### DIFF
--- a/src/main/kotlin/com/stark/shoot/application/service/user/friend/FriendReceiveService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/user/friend/FriendReceiveService.kt
@@ -114,10 +114,7 @@ class FriendReceiveService(
 
         // 도메인 서비스를 사용하여 친구 요청 유효성 검증
         try {
-            // 친구 요청이 존재하는지 확인
-            if (!currentUser.incomingFriendRequestIds.contains(requesterId)) {
-                throw IllegalArgumentException("해당 친구 요청이 존재하지 않습니다.")
-            }
+            friendDomainService.validateFriendAccept(currentUser, requesterId)
         } catch (e: IllegalArgumentException) {
             throw InvalidInputException(e.message ?: validationErrorMessage)
         }


### PR DESCRIPTION
## Summary
- shift friend request validation from application service into `FriendDomainService`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684e859472708320b84c167b0d2f29df