### PR TITLE
Add friend removal domain event

### DIFF
--- a/src/main/kotlin/com/stark/shoot/adapter/in/event/listener/sse/FriendRemovedEventListener.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/event/listener/sse/FriendRemovedEventListener.kt
@@ -1,0 +1,17 @@
+package com.stark.shoot.adapter.`in`.event.listener.sse
+
+import com.stark.shoot.application.port.`in`.chatroom.SseEmitterUseCase
+import com.stark.shoot.domain.chat.event.FriendRemovedEvent
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Service
+
+@Service
+class FriendRemovedEventListener(
+    private val sseEmitterUseCase: SseEmitterUseCase
+) {
+
+    @EventListener
+    fun handleFriendRemovedEvent(event: FriendRemovedEvent) {
+        sseEmitterUseCase.sendFriendRemovedEvent(event)
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/application/port/in/chatroom/SseEmitterUseCase.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/chatroom/SseEmitterUseCase.kt
@@ -2,6 +2,7 @@ package com.stark.shoot.application.port.`in`.chatroom
 
 import com.stark.shoot.domain.chat.event.ChatRoomCreatedEvent
 import com.stark.shoot.domain.chat.event.FriendAddedEvent
+import com.stark.shoot.domain.chat.event.FriendRemovedEvent
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 
 interface SseEmitterUseCase {
@@ -9,4 +10,5 @@ interface SseEmitterUseCase {
     fun sendUpdate(userId: Long, roomId: Long, unreadCount: Int, lastMessage: String?)
     fun sendChatRoomCreatedEvent(event: ChatRoomCreatedEvent)
     fun sendFriendAddedEvent(event: FriendAddedEvent)
+    fun sendFriendRemovedEvent(event: FriendRemovedEvent)
 }

--- a/src/main/kotlin/com/stark/shoot/application/service/sse/SseEmitterService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/sse/SseEmitterService.kt
@@ -3,6 +3,7 @@ package com.stark.shoot.application.service.sse
 import com.stark.shoot.application.port.`in`.chatroom.SseEmitterUseCase
 import com.stark.shoot.domain.chat.event.ChatRoomCreatedEvent
 import com.stark.shoot.domain.chat.event.FriendAddedEvent
+import com.stark.shoot.domain.chat.event.FriendRemovedEvent
 import com.stark.shoot.infrastructure.annotation.UseCase
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.annotation.PreDestroy
@@ -324,6 +325,25 @@ class SseEmitterService : SseEmitterUseCase {
             eventName = "friendAdded",
             data = data,
             logMessage = "Sent friendAdded event to user: $userId, friendId: ${event.friendId}"
+        )
+    }
+
+    /**
+     * 친구 삭제 이벤트 전송
+     */
+    override fun sendFriendRemovedEvent(event: FriendRemovedEvent) {
+        val userId = event.userId
+        val data = mapOf(
+            "type" to "friend_removed",
+            "friendId" to event.friendId,
+            "timestamp" to System.currentTimeMillis()
+        )
+
+        sendEvent(
+            userId = userId,
+            eventName = "friendRemoved",
+            data = data,
+            logMessage = "Sent friendRemoved event to user: $userId, friendId: ${event.friendId}"
         )
     }
 

--- a/src/main/kotlin/com/stark/shoot/application/service/user/friend/FriendRemoveService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/user/friend/FriendRemoveService.kt
@@ -2,13 +2,12 @@ package com.stark.shoot.application.service.user.friend
 
 import com.stark.shoot.application.port.`in`.user.friend.FriendRemoveUseCase
 import com.stark.shoot.application.port.out.user.FindUserPort
-import com.stark.shoot.application.port.out.user.friend.FriendCachePort
+import com.stark.shoot.application.port.out.event.EventPublisher
 import com.stark.shoot.application.port.out.user.friend.UpdateFriendPort
 import com.stark.shoot.domain.chat.user.User
 import com.stark.shoot.domain.service.user.FriendDomainService
 import com.stark.shoot.infrastructure.annotation.UseCase
 import com.stark.shoot.infrastructure.exception.web.ResourceNotFoundException
-import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.transaction.annotation.Transactional
 
 @Transactional
@@ -16,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional
 class FriendRemoveService(
     private val findUserPort: FindUserPort,
     private val updateFriendPort: UpdateFriendPort,
+    private val eventPublisher: EventPublisher,
     private val friendDomainService: FriendDomainService,
     private val friendCacheManager: FriendCacheManager
 ) : FriendRemoveUseCase {
@@ -41,6 +41,11 @@ class FriendRemoveService(
             friend = friend,
             friendId = friendId
         )
+
+        // 이벤트 발행
+        result.events.forEach { event ->
+            eventPublisher.publish(event)
+        }
 
         // 업데이트된 사용자 정보 저장
         updateFriendPort.removeFriendRelation(userId, friendId)

--- a/src/main/kotlin/com/stark/shoot/domain/chat/event/FriendRemovedEvent.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/event/FriendRemovedEvent.kt
@@ -1,0 +1,26 @@
+package com.stark.shoot.domain.chat.event
+
+import com.stark.shoot.domain.common.DomainEvent
+
+/**
+ * 친구 삭제 도메인 이벤트
+ */
+data class FriendRemovedEvent(
+    val userId: Long,
+    val friendId: Long
+) : DomainEvent {
+    companion object {
+        /**
+         * FriendRemovedEvent 생성 팩토리 메서드
+         */
+        fun create(
+            userId: Long,
+            friendId: Long
+        ): FriendRemovedEvent {
+            return FriendRemovedEvent(
+                userId = userId,
+                friendId = friendId
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/domain/service/user/FriendDomainService.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/service/user/FriendDomainService.kt
@@ -1,6 +1,7 @@
 package com.stark.shoot.domain.service.user
 
 import com.stark.shoot.domain.chat.event.FriendAddedEvent
+import com.stark.shoot.domain.chat.event.FriendRemovedEvent
 import com.stark.shoot.domain.chat.user.User
 
 /**
@@ -140,9 +141,16 @@ class FriendDomainService {
         // 친구의 친구 목록에서도 현재 사용자 제거
         val updatedFriend = friend.removeFriend(currentUser.id!!)
 
+        // 이벤트 생성 (양쪽 사용자에게 친구 제거 알림)
+        val events = listOf(
+            FriendRemovedEvent.create(userId = currentUser.id!!, friendId = friendId),
+            FriendRemovedEvent.create(userId = friendId, friendId = currentUser.id!!)
+        )
+
         return FriendRemovalResult(
             updatedCurrentUser = updatedCurrentUser,
-            updatedFriend = updatedFriend
+            updatedFriend = updatedFriend,
+            events = events
         )
     }
 

--- a/src/main/kotlin/com/stark/shoot/domain/service/user/FriendRemovalResult.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/service/user/FriendRemovalResult.kt
@@ -1,11 +1,13 @@
 package com.stark.shoot.domain.service.user
 
 import com.stark.shoot.domain.chat.user.User
+import com.stark.shoot.domain.chat.event.FriendRemovedEvent
 
 /**
  * 친구 관계 제거 결과
  */
 data class FriendRemovalResult(
     val updatedCurrentUser: User,
-    val updatedFriend: User
+    val updatedFriend: User,
+    val events: List<FriendRemovedEvent>
 )

--- a/src/test/kotlin/com/stark/shoot/domain/chat/event/EventFactoryTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/chat/event/EventFactoryTest.kt
@@ -2,6 +2,7 @@ package com.stark.shoot.domain.chat.event
 
 import com.stark.shoot.domain.chat.message.ChatMessage
 import com.stark.shoot.domain.chat.message.type.MessageType
+import com.stark.shoot.domain.chat.event.FriendRemovedEvent
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -34,6 +35,12 @@ class EventFactoryTest {
     fun `FriendAddedEvent create 함수는 주어진 값으로 이벤트를 생성한다`() {
         val event = FriendAddedEvent.create(1L, 2L)
         assertThat(event).isEqualTo(FriendAddedEvent(1L, 2L))
+    }
+
+    @Test
+    fun `FriendRemovedEvent create 함수는 주어진 값으로 이벤트를 생성한다`() {
+        val event = FriendRemovedEvent.create(1L, 2L)
+        assertThat(event).isEqualTo(FriendRemovedEvent(1L, 2L))
     }
 
     @Test

--- a/src/test/kotlin/com/stark/shoot/domain/service/user/FriendDomainServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/service/user/FriendDomainServiceTest.kt
@@ -1,6 +1,7 @@
 package com.stark.shoot.domain.service.user
 
 import com.stark.shoot.domain.chat.event.FriendAddedEvent
+import com.stark.shoot.domain.chat.event.FriendRemovedEvent
 import com.stark.shoot.domain.chat.user.User
 import com.stark.shoot.domain.chat.user.UserStatus
 import org.assertj.core.api.Assertions.assertThat
@@ -32,6 +33,18 @@ class FriendDomainServiceTest {
         assertThat(result.updatedRequester.friendIds).contains(1L)
         assertThat(result.events).containsExactly(
             FriendAddedEvent.create(1L,2L), FriendAddedEvent.create(2L,1L)
+        )
+    }
+
+    @Test
+    fun `친구 관계 삭제를 처리할 수 있다`() {
+        val current = User(id=1L, username="a", nickname="A", userCode="A1", friendIds=setOf(2L))
+        val friend = User(id=2L, username="b", nickname="B", userCode="B1", friendIds=setOf(1L))
+        val result = service.processFriendRemoval(current, friend, 2L)
+        assertThat(result.updatedCurrentUser.friendIds).doesNotContain(2L)
+        assertThat(result.updatedFriend.friendIds).doesNotContain(1L)
+        assertThat(result.events).containsExactly(
+            FriendRemovedEvent.create(1L,2L), FriendRemovedEvent.create(2L,1L)
         )
     }
 }


### PR DESCRIPTION
## Summary
- emit FriendRemovedEvent when removing a friend
- publish the event through EventPublisher
- deliver the event using SSE
- cover new domain event in tests

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68500f1340d08320ae60f1f33559b7cf