### PR TITLE
Refactor chatroom participant management

### DIFF
--- a/src/main/kotlin/com/stark/shoot/domain/service/chatroom/ChatRoomParticipantDomainService.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/service/chatroom/ChatRoomParticipantDomainService.kt
@@ -1,0 +1,31 @@
+package com.stark.shoot.domain.service.chatroom
+
+import com.stark.shoot.domain.chat.room.ChatRoom
+
+/**
+ * 채팅방 참여자 관리 도메인 서비스
+ */
+class ChatRoomParticipantDomainService {
+
+    data class RemovalResult(
+        val chatRoom: ChatRoom,
+        val shouldDeleteRoom: Boolean
+    )
+
+    /**
+     * 채팅방에 참여자를 추가합니다.
+     * 단일 채팅방 엔티티의 addParticipant 로직을 래핑합니다.
+     */
+    fun addParticipant(chatRoom: ChatRoom, userId: Long): ChatRoom {
+        return chatRoom.addParticipant(userId)
+    }
+
+    /**
+     * 채팅방에서 참여자를 제거하고 삭제 필요 여부를 반환합니다.
+     */
+    fun removeParticipant(chatRoom: ChatRoom, userId: Long): RemovalResult {
+        val updatedRoom = chatRoom.removeParticipant(userId)
+        val shouldDelete = updatedRoom.shouldBeDeleted()
+        return RemovalResult(updatedRoom, shouldDelete)
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `ChatRoomParticipantDomainService` for participant operations
- delegate add/remove participant logic from `ManageChatRoomService` to domain service

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685012dabbf883209f5d1264dcf5e644