### PR TITLE
Refactor message publish path

### DIFF
--- a/src/main/kotlin/com/stark/shoot/adapter/out/redis/message/RedisMessagePublishAdapter.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/redis/message/RedisMessagePublishAdapter.kt
@@ -1,0 +1,33 @@
+package com.stark.shoot.adapter.out.redis.message
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.stark.shoot.adapter.`in`.web.dto.message.ChatMessageRequest
+import com.stark.shoot.application.port.out.message.PublishMessagePort
+import com.stark.shoot.infrastructure.annotation.Adapter
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.data.redis.connection.stream.StreamRecords
+
+@Adapter
+class RedisMessagePublishAdapter(
+    private val redisTemplate: StringRedisTemplate,
+    private val objectMapper: ObjectMapper
+) : PublishMessagePort {
+
+    private val logger = KotlinLogging.logger {}
+
+    override suspend fun publish(message: ChatMessageRequest) {
+        val streamKey = generateStreamKey(message.roomId)
+        val messageJson = objectMapper.writeValueAsString(message)
+        val map = mapOf("message" to messageJson)
+        val record = StreamRecords.newRecord()
+            .ofMap(map)
+            .withStreamKey(streamKey)
+        val id = redisTemplate.opsForStream<String, String>().add(record)
+        logger.debug { "Redis Stream publish: key=$streamKey id=$id tempId=${message.tempId}" }
+    }
+
+    private fun generateStreamKey(roomId: Long): String {
+        return "stream:chat:room:$roomId"
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/application/port/out/message/PublishMessagePort.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/out/message/PublishMessagePort.kt
@@ -1,0 +1,7 @@
+package com.stark.shoot.application.port.out.message
+
+import com.stark.shoot.adapter.`in`.web.dto.message.ChatMessageRequest
+
+interface PublishMessagePort {
+    suspend fun publish(message: ChatMessageRequest)
+}


### PR DESCRIPTION
## Summary
- introduce `PublishMessagePort` to abstract Redis interaction
- implement `RedisMessagePublishAdapter` for the new port
- update `SendMessageService` to use the port

## Testing
- `./gradlew test --console=plain` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6850239b7da08320bdca87809e27b0a5