### PR TITLE
Fix domain event timestamp

### DIFF
--- a/src/main/kotlin/com/stark/shoot/domain/chat/event/ChatBulkReadEvent.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/event/ChatBulkReadEvent.kt
@@ -5,7 +5,8 @@ import com.stark.shoot.domain.common.DomainEvent
 data class ChatBulkReadEvent(
     val roomId: Long,
     val messageIds: List<String>,
-    val userId: Long
+    val userId: Long,
+    override val occurredOn: Long = System.currentTimeMillis()
 ) : DomainEvent {
     companion object {
         /**

--- a/src/main/kotlin/com/stark/shoot/domain/chat/event/ChatRoomCreatedEvent.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/event/ChatRoomCreatedEvent.kt
@@ -5,7 +5,8 @@ import com.stark.shoot.domain.common.DomainEvent
 // 새 이벤트 정의
 data class ChatRoomCreatedEvent(
     val roomId: Long,
-    val userId: Long
+    val userId: Long,
+    override val occurredOn: Long = System.currentTimeMillis()
 ) : DomainEvent {
     companion object {
         /**

--- a/src/main/kotlin/com/stark/shoot/domain/chat/event/ChatUnreadCountUpdatedEvent.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/event/ChatUnreadCountUpdatedEvent.kt
@@ -11,7 +11,8 @@ import com.stark.shoot.domain.common.DomainEvent
 data class ChatUnreadCountUpdatedEvent(
     val roomId: Long,
     val unreadCounts: Map<Long, Int>,
-    val lastMessage: String? = null
+    val lastMessage: String? = null,
+    override val occurredOn: Long = System.currentTimeMillis()
 ) : DomainEvent {
     companion object {
         /**

--- a/src/main/kotlin/com/stark/shoot/domain/chat/event/FriendAddedEvent.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/event/FriendAddedEvent.kt
@@ -4,7 +4,8 @@ import com.stark.shoot.domain.common.DomainEvent
 
 data class FriendAddedEvent(
     val userId: Long,
-    val friendId: Long
+    val friendId: Long,
+    override val occurredOn: Long = System.currentTimeMillis()
 ) : DomainEvent {
     companion object {
         /**

--- a/src/main/kotlin/com/stark/shoot/domain/chat/event/FriendRemovedEvent.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/event/FriendRemovedEvent.kt
@@ -7,7 +7,8 @@ import com.stark.shoot.domain.common.DomainEvent
  */
 data class FriendRemovedEvent(
     val userId: Long,
-    val friendId: Long
+    val friendId: Long,
+    override val occurredOn: Long = System.currentTimeMillis()
 ) : DomainEvent {
     companion object {
         /**

--- a/src/main/kotlin/com/stark/shoot/domain/chat/event/MessagePinEvent.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/event/MessagePinEvent.kt
@@ -6,7 +6,8 @@ data class MessagePinEvent(
     val messageId: String,
     val roomId: Long,
     val isPinned: Boolean,
-    val userId: Long
+    val userId: Long,
+    override val occurredOn: Long = System.currentTimeMillis()
 ) : DomainEvent {
     companion object {
         /**

--- a/src/main/kotlin/com/stark/shoot/domain/chat/event/MessageReactionEvent.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/event/MessageReactionEvent.kt
@@ -8,7 +8,8 @@ data class MessageReactionEvent(
     val userId: String,
     val reactionType: String,
     val isAdded: Boolean,  // true: 추가, false: 제거
-    val isReplacement: Boolean = false  // true: 리액션 교체의 일부, false: 일반 추가/제거
+    val isReplacement: Boolean = false,  // true: 리액션 교체의 일부, false: 일반 추가/제거
+    override val occurredOn: Long = System.currentTimeMillis()
 ) : DomainEvent {
     companion object {
         /**

--- a/src/main/kotlin/com/stark/shoot/domain/common/DomainEvent.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/common/DomainEvent.kt
@@ -1,6 +1,8 @@
 package com.stark.shoot.domain.common
 
 interface DomainEvent {
+    /**
+     * 이벤트가 발생한 시각(밀리초)
+     */
     val occurredOn: Long
-        get() = System.currentTimeMillis()
 }


### PR DESCRIPTION
## Summary
- refactor `DomainEvent` interface to require explicit timestamp
- capture occurrence time in domain event implementations

## Testing
- `./gradlew test --no-daemon --quiet` *(fails: unable to download gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_685175656fa083209581a68a4570316f