### PR TITLE
Improve DDD domain services

### DIFF
--- a/src/main/kotlin/com/stark/shoot/domain/notification/service/NotificationDomainService.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/notification/service/NotificationDomainService.kt
@@ -1,6 +1,7 @@
 package com.stark.shoot.domain.notification.service
 
 import com.stark.shoot.domain.notification.Notification
+import com.stark.shoot.domain.notification.event.NotificationEvent
 
 /**
  * 알림 도메인 서비스
@@ -44,6 +45,20 @@ class NotificationDomainService {
         notifications: List<Notification>
     ): List<Notification> {
         return notifications.filter { !it.isRead }
+    }
+
+    /**
+     * 도메인 이벤트로부터 알림 목록을 생성합니다.
+     *
+     * @param event 알림 이벤트
+     * @return 수신자별로 생성된 알림 목록
+     */
+    fun createNotificationsFromEvent(event: NotificationEvent): List<Notification> {
+        val recipients = event.getRecipients()
+        if (recipients.isEmpty()) return emptyList()
+        return recipients.map { recipientId ->
+            Notification.fromEvent(event, recipientId)
+        }
     }
 
 }

--- a/src/main/kotlin/com/stark/shoot/domain/service/chatroom/ChatRoomParticipantDomainService.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/service/chatroom/ChatRoomParticipantDomainService.kt
@@ -28,4 +28,30 @@ class ChatRoomParticipantDomainService {
         val shouldDelete = updatedRoom.shouldBeDeleted()
         return RemovalResult(updatedRoom, shouldDelete)
     }
+
+    /**
+     * 참여자 변경 정보를 적용합니다.
+     *
+     * @param chatRoom 대상 채팅방
+     * @param changes 변경 정보
+     * @param pinnedCountProvider 사용자의 핀 채팅방 수 조회 함수
+     * @return 업데이트된 채팅방
+     */
+    fun applyChanges(
+        chatRoom: ChatRoom,
+        changes: ChatRoom.ParticipantChanges,
+        pinnedCountProvider: (Long) -> Int
+    ): ChatRoom {
+        var room = chatRoom
+        if (changes.participantsToAdd.isNotEmpty()) {
+            room = room.addParticipants(changes.participantsToAdd)
+        }
+        if (changes.participantsToRemove.isNotEmpty()) {
+            room = room.removeParticipants(changes.participantsToRemove)
+        }
+        changes.pinnedStatusChanges.forEach { (userId, isPinned) ->
+            room = room.updateFavoriteStatus(userId, isPinned, pinnedCountProvider(userId))
+        }
+        return room
+    }
 }

--- a/src/test/kotlin/com/stark/shoot/domain/notification/service/NotificationDomainServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/notification/service/NotificationDomainServiceTest.kt
@@ -3,6 +3,7 @@ package com.stark.shoot.domain.notification.service
 import com.stark.shoot.domain.notification.Notification
 import com.stark.shoot.domain.notification.NotificationType
 import com.stark.shoot.domain.notification.SourceType
+import com.stark.shoot.domain.notification.event.NotificationEvent
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -23,5 +24,22 @@ class NotificationDomainServiceTest {
         val n2 = n1.markAsRead()
         val unread = service.filterUnread(listOf(n1, n2))
         assertEquals(1, unread.size)
+    }
+
+    @Test
+    fun createNotificationsFromEvent() {
+        val event = object : NotificationEvent(
+            type = NotificationType.NEW_MESSAGE,
+            sourceId = "1",
+            sourceType = SourceType.CHAT
+        ) {
+            override fun getRecipients(): Set<Long> = setOf(1L, 2L)
+            override fun getTitle(): String = "title"
+            override fun getMessage(): String = "msg"
+        }
+
+        val result = service.createNotificationsFromEvent(event)
+        assertEquals(2, result.size)
+        assertEquals(setOf(1L, 2L), result.map { it.userId }.toSet())
     }
 }

--- a/src/test/kotlin/com/stark/shoot/domain/service/chatroom/ChatRoomParticipantDomainServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/service/chatroom/ChatRoomParticipantDomainServiceTest.kt
@@ -1,0 +1,28 @@
+package com.stark.shoot.domain.service.chatroom
+
+import com.stark.shoot.domain.chat.room.ChatRoom
+import com.stark.shoot.domain.chat.room.ChatRoomType
+import com.stark.shoot.domain.service.chatroom.ChatRoomParticipantDomainService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("채팅방 참여자 도메인 서비스 테스트")
+class ChatRoomParticipantDomainServiceTest {
+    private val service = ChatRoomParticipantDomainService()
+
+    @Test
+    fun `참여자 변경 정보를 적용할 수 있다`() {
+        val room = ChatRoom(id = 1L, title = "room", type = ChatRoomType.GROUP, participants = mutableSetOf(1L, 2L))
+        val changes = ChatRoom.ParticipantChanges(
+            participantsToAdd = setOf(3L),
+            participantsToRemove = setOf(2L),
+            pinnedStatusChanges = mapOf(1L to true)
+        )
+
+        val updated = service.applyChanges(room, changes) { 0 }
+
+        assertThat(updated.participants).containsExactlyInAnyOrder(1L, 3L)
+        assertThat(updated.pinnedParticipants).containsExactly(1L)
+    }
+}


### PR DESCRIPTION
## Summary
- provide `createNotificationsFromEvent` to turn NotificationEvents into domain notifications
- apply chat room participant changes through a new domain service method
- cover new logic with tests

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68540386863c8320b48aa53d849c1c73