### PR TITLE
Introduce UserCode value object

### DIFF
--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/user/UserDTO.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/user/UserDTO.kt
@@ -58,6 +58,6 @@ fun User.toResponse() = UserResponse(
     profileImageUrl = profileImageUrl,
     backgroundImageUrl = backgroundImageUrl,
     bio = bio,
-    userCode = userCode,
+    userCode = userCode.value,
     lastSeenAt = lastSeenAt
 )

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/user/UserCodePersistenceAdapter.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/user/UserCodePersistenceAdapter.kt
@@ -27,7 +27,7 @@ class UserCodePersistenceAdapter(
             }
 
             // JPQL 쿼리로 userCode 필드만 업데이트
-            userRepository.updateUserCode(userId, user.userCode)
+            userRepository.updateUserCode(userId, user.userCode.value)
         } ?: throw IllegalArgumentException("User ID cannot be null for update operation")
     }
 

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/mapper/UserMapper.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/mapper/UserMapper.kt
@@ -2,6 +2,7 @@ package com.stark.shoot.adapter.out.persistence.postgres.mapper
 
 import com.stark.shoot.adapter.out.persistence.postgres.entity.UserEntity
 import com.stark.shoot.domain.chat.user.User
+import com.stark.shoot.domain.chat.user.UserCode
 import org.springframework.stereotype.Component
 
 @Component
@@ -12,7 +13,7 @@ class UserMapper {
             username = user.username,
             nickname = user.nickname,
             status = user.status,
-            userCode = user.userCode,
+            userCode = user.userCode.value,
             profileImageUrl = user.profileImageUrl,
             backgroundImageUrl = user.backgroundImageUrl,
             lastSeenAt = user.lastSeenAt,
@@ -40,7 +41,7 @@ class UserMapper {
             incomingFriendRequestIds = emptySet(),
             outgoingFriendRequestIds = emptySet(),
             blockedUserIds = emptySet(),
-            userCode = userEntity.userCode
+            userCode = UserCode.from(userEntity.userCode)
         )
     }
 

--- a/src/main/kotlin/com/stark/shoot/domain/chat/user/User.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/user/User.kt
@@ -2,7 +2,9 @@ package com.stark.shoot.domain.chat.user
 
 import com.stark.shoot.domain.exception.InvalidUserDataException
 import java.time.Instant
-import java.util.*
+
+// 값 객체
+import com.stark.shoot.domain.chat.user.UserCode
 
 data class User(
     val id: Long? = null,
@@ -10,7 +12,7 @@ data class User(
     var nickname: String,
     var status: UserStatus = UserStatus.OFFLINE,
     var passwordHash: String? = null,
-    var userCode: String,
+    var userCode: UserCode,
     val createdAt: Instant = Instant.now(),
 
     // 필요한 경우에만 남길 선택적 필드
@@ -58,7 +60,7 @@ data class User(
                 username = username,
                 nickname = nickname,
                 passwordHash = passwordEncoder(rawPassword),
-                userCode = generateUserCode(),
+                userCode = UserCode.generate(),
                 bio = bio,
                 profileImageUrl = profileImageUrl
             )
@@ -69,8 +71,8 @@ data class User(
          *
          * @return 생성된 8자리 사용자 코드
          */
-        private fun generateUserCode(): String {
-            return UUID.randomUUID().toString().substring(0, 8).uppercase()
+        private fun generateUserCode(): UserCode {
+            return UserCode.generate()
         }
 
         /**

--- a/src/main/kotlin/com/stark/shoot/domain/chat/user/UserCode.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/user/UserCode.kt
@@ -1,0 +1,34 @@
+package com.stark.shoot.domain.chat.user
+
+import java.util.UUID
+
+/**
+ * 사용자 코드를 나타내는 값 객체
+ */
+@JvmInline
+value class UserCode private constructor(val value: String) {
+    companion object {
+        private val CODE_REGEX = Regex("^[A-Z0-9]{4,12}$")
+
+        /**
+         * 문자열로부터 UserCode 생성
+         */
+        fun from(code: String): UserCode {
+            require(CODE_REGEX.matches(code)) { "유저 코드는 영문 대문자와 숫자로 4~12자여야 합니다." }
+            return UserCode(code)
+        }
+
+        /**
+         * 랜덤 UserCode 생성 (8자리)
+         */
+        fun generate(): UserCode {
+            val random = UUID.randomUUID().toString()
+                .replace("-", "")
+                .substring(0, 8)
+                .uppercase()
+            return UserCode(random)
+        }
+    }
+
+    override fun toString(): String = value
+}

--- a/src/test/kotlin/com/stark/shoot/domain/chat/user/UserTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/chat/user/UserTest.kt
@@ -1,6 +1,7 @@
 package com.stark.shoot.domain.chat.user
 
 import com.stark.shoot.domain.chat.user.UserStatus
+import com.stark.shoot.domain.chat.user.UserCode
 import com.stark.shoot.domain.exception.InvalidUserDataException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
@@ -39,8 +40,8 @@ class UserTest {
             assertThat(user.nickname).isEqualTo(nickname)
             assertThat(user.passwordHash).isEqualTo("encoded_$rawPassword")
             assertThat(user.status).isEqualTo(UserStatus.OFFLINE)
-            assertThat(user.userCode).isNotEmpty()
-            assertThat(user.userCode.length).isEqualTo(8)
+            assertThat(user.userCode.value).isNotEmpty()
+            assertThat(user.userCode.value.length).isEqualTo(8)
             assertThat(user.createdAt).isNotNull()
             assertThat(user.isDeleted).isFalse()
             assertThat(user.friendIds).isEmpty()
@@ -266,7 +267,7 @@ class UserTest {
                 id = 1L,
                 username = "testuser",
                 nickname = "테스트유저",
-                userCode = "ABCD1234"
+                userCode = UserCode.from("ABCD1234")
             )
             val friendId = 2L
             
@@ -286,7 +287,7 @@ class UserTest {
                 id = 1L,
                 username = "testuser",
                 nickname = "테스트유저",
-                userCode = "ABCD1234",
+                userCode = UserCode.from("ABCD1234"),
                 outgoingFriendRequestIds = setOf(2L, 3L),
                 incomingFriendRequestIds = setOf(2L, 4L)
             )
@@ -311,7 +312,7 @@ class UserTest {
                 id = 1L,
                 username = "testuser",
                 nickname = "테스트유저",
-                userCode = "ABCD1234",
+                userCode = UserCode.from("ABCD1234"),
                 incomingFriendRequestIds = setOf(2L, 3L)
             )
             val requesterId = 2L
@@ -334,7 +335,7 @@ class UserTest {
                 id = 1L,
                 username = "testuser",
                 nickname = "테스트유저",
-                userCode = "ABCD1234",
+                userCode = UserCode.from("ABCD1234"),
                 incomingFriendRequestIds = setOf(2L, 3L)
             )
             val nonExistingRequesterId = 4L
@@ -354,7 +355,7 @@ class UserTest {
                 id = 1L,
                 username = "testuser",
                 nickname = "테스트유저",
-                userCode = "ABCD1234",
+                userCode = UserCode.from("ABCD1234"),
                 incomingFriendRequestIds = setOf(2L, 3L)
             )
             val requesterId = 2L
@@ -377,7 +378,7 @@ class UserTest {
                 id = 1L,
                 username = "testuser",
                 nickname = "테스트유저",
-                userCode = "ABCD1234",
+                userCode = UserCode.from("ABCD1234"),
                 outgoingFriendRequestIds = setOf(2L, 3L)
             )
             val targetUserId = 2L
@@ -404,7 +405,7 @@ class UserTest {
                 id = 1L,
                 username = "testuser",
                 nickname = "테스트유저",
-                userCode = "ABCD1234",
+                userCode = UserCode.from("ABCD1234"),
                 status = UserStatus.ONLINE
             )
             

--- a/src/test/kotlin/com/stark/shoot/domain/service/user/FriendDomainServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/service/user/FriendDomainServiceTest.kt
@@ -3,6 +3,7 @@ package com.stark.shoot.domain.service.user
 import com.stark.shoot.domain.chat.event.FriendAddedEvent
 import com.stark.shoot.domain.chat.event.FriendRemovedEvent
 import com.stark.shoot.domain.chat.user.User
+import com.stark.shoot.domain.chat.user.UserCode
 import com.stark.shoot.domain.chat.user.UserStatus
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
@@ -26,8 +27,8 @@ class FriendDomainServiceTest {
 
     @Test
     fun `친구 요청 수락을 처리할 수 있다`() {
-        val current = User(id=1L, username="a", nickname="A", userCode="A1", incomingFriendRequestIds=setOf(2L))
-        val requester = User(id=2L, username="b", nickname="B", userCode="B1")
+        val current = User(id=1L, username="a", nickname="A", userCode=UserCode.from("A1"), incomingFriendRequestIds=setOf(2L))
+        val requester = User(id=2L, username="b", nickname="B", userCode=UserCode.from("B1"))
         val result = service.processFriendAccept(current, requester, 2L)
         assertThat(result.updatedCurrentUser.friendIds).contains(2L)
         assertThat(result.updatedRequester.friendIds).contains(1L)
@@ -38,8 +39,8 @@ class FriendDomainServiceTest {
 
     @Test
     fun `친구 관계 삭제를 처리할 수 있다`() {
-        val current = User(id=1L, username="a", nickname="A", userCode="A1", friendIds=setOf(2L))
-        val friend = User(id=2L, username="b", nickname="B", userCode="B1", friendIds=setOf(1L))
+        val current = User(id=1L, username="a", nickname="A", userCode=UserCode.from("A1"), friendIds=setOf(2L))
+        val friend = User(id=2L, username="b", nickname="B", userCode=UserCode.from("B1"), friendIds=setOf(1L))
         val result = service.processFriendRemoval(current, friend, 2L)
         assertThat(result.updatedCurrentUser.friendIds).doesNotContain(2L)
         assertThat(result.updatedFriend.friendIds).doesNotContain(1L)

--- a/src/test/kotlin/com/stark/shoot/domain/service/user/UserBlockDomainServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/service/user/UserBlockDomainServiceTest.kt
@@ -1,6 +1,7 @@
 package com.stark.shoot.domain.service.user
 
 import com.stark.shoot.domain.chat.user.User
+import com.stark.shoot.domain.chat.user.UserCode
 import com.stark.shoot.domain.service.user.block.UserBlockDomainService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
@@ -13,13 +14,13 @@ class UserBlockDomainServiceTest {
 
     @Test
     fun `자신을 차단하면 예외`() {
-        val user = User(id=1L, username="a", nickname="A", userCode="A1")
+        val user = User(id=1L, username="a", nickname="A", userCode=UserCode.from("A1"))
         assertThrows<IllegalArgumentException> { service.block(user,1L) }
     }
 
     @Test
     fun `차단과 해제가 가능하다`() {
-        val user = User(id=1L, username="a", nickname="A", userCode="A1")
+        val user = User(id=1L, username="a", nickname="A", userCode=UserCode.from("A1"))
         val blocked = service.block(user,2L)
         assertThat(blocked.blockedUserIds).contains(2L)
         val unblocked = service.unblock(blocked,2L)


### PR DESCRIPTION
## Summary
- create `UserCode` value object
- store `User.userCode` as `UserCode`
- support conversion in `UserMapper` and persistence adapter
- use new VO in manage-user-code logic and HTTP DTOs
- update user domain and service tests

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68550228d350832080b34b142ea19c6e