### PR TITLE
Introduce Username value object

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ com.stark.shoot
 ```kotlin
 data class User(
     val id: ObjectId? = null,                      // 고유 ID
-    val username: String,                          // 사용자명 (로그인용)
+    val username: Username,                        // 사용자명 (로그인용)
     val nickname: String,                          // 닉네임 (표시용)
     val status: UserStatus = UserStatus.OFFLINE,   // 상태 (ONLINE, OFFLINE, BUSY, AWAY 등)
     val profileImageUrl: String? = null,           // 프로필 이미지 URL

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/user/UserDTO.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/user/UserDTO.kt
@@ -52,7 +52,7 @@ data class UserResponse(
 // User -> UserResponse 변환 확장 함수
 fun User.toResponse() = UserResponse(
     id = id.toString(),
-    username = username,
+    username = username.value,
     nickname = nickname,
     status = status,
     profileImageUrl = profileImageUrl,

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/mapper/UserMapper.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/mapper/UserMapper.kt
@@ -3,6 +3,7 @@ package com.stark.shoot.adapter.out.persistence.postgres.mapper
 import com.stark.shoot.adapter.out.persistence.postgres.entity.UserEntity
 import com.stark.shoot.domain.chat.user.User
 import com.stark.shoot.domain.chat.user.UserCode
+import com.stark.shoot.domain.chat.user.Username
 import org.springframework.stereotype.Component
 
 @Component
@@ -10,7 +11,7 @@ class UserMapper {
 
     fun toEntity(user: User): UserEntity {
         return UserEntity(
-            username = user.username,
+            username = user.username.value,
             nickname = user.nickname,
             status = user.status,
             userCode = user.userCode.value,
@@ -26,7 +27,7 @@ class UserMapper {
     fun toDomain(userEntity: UserEntity): User {
         return User(
             id = userEntity.id,
-            username = userEntity.username,
+            username = Username.from(userEntity.username),
             nickname = userEntity.nickname,
             status = userEntity.status,
             profileImageUrl = userEntity.profileImageUrl,

--- a/src/main/kotlin/com/stark/shoot/application/service/user/auth/UserLoginService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/user/auth/UserLoginService.kt
@@ -38,8 +38,8 @@ class UserLoginService(
         // JWT 토큰 생성
         val userId = user.id ?: throw IllegalStateException("User ID must not be null")
 
-        val accessToken = jwtProvider.generateToken(userId.toString(), user.username)
-        val refreshToken = jwtProvider.generateRefreshToken(userId.toString(), user.username, 43200) // 30일
+        val accessToken = jwtProvider.generateToken(userId.toString(), user.username.value)
+        val refreshToken = jwtProvider.generateRefreshToken(userId.toString(), user.username.value, 43200) // 30일
 
         // 리프레시 토큰 저장 (기본 정보만)
         refreshTokenPort.createRefreshToken(

--- a/src/main/kotlin/com/stark/shoot/application/service/user/friend/FriendSearchService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/user/friend/FriendSearchService.kt
@@ -40,12 +40,12 @@ class FriendSearchService(
         // 필터링된 사용자 목록
         return allUsers.filter { user ->
             user.id != null && !excludedIds.contains(user.id) &&
-                    (user.username.contains(query, ignoreCase = true) ||
+                    (user.username.value.contains(query, ignoreCase = true) ||
                             user.nickname.contains(query, ignoreCase = true))
         }.map { user ->
             FriendResponse(
                 id = user.id ?: 0L,
-                username = user.username,
+                username = user.username.value,
                 nickname = user.nickname,
                 profileImageUrl = user.profileImageUrl
             )

--- a/src/main/kotlin/com/stark/shoot/application/service/user/friend/recommend/RecommendFriendService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/user/friend/recommend/RecommendFriendService.kt
@@ -227,7 +227,7 @@ class RecommendFriendService(
             .map { user ->
                 FriendResponse(
                     id = user.id ?: 0L,
-                    username = user.username,
+                    username = user.username.value,
                     nickname = user.nickname,
                     profileImageUrl = user.profileImageUrl
                 )

--- a/src/main/kotlin/com/stark/shoot/domain/chat/user/User.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/user/User.kt
@@ -5,10 +5,11 @@ import java.time.Instant
 
 // 값 객체
 import com.stark.shoot.domain.chat.user.UserCode
+import com.stark.shoot.domain.chat.user.Username
 
 data class User(
     val id: Long? = null,
-    var username: String,
+    var username: Username,
     var nickname: String,
     var status: UserStatus = UserStatus.OFFLINE,
     var passwordHash: String? = null,
@@ -51,13 +52,13 @@ data class User(
             bio: String? = null,
             profileImageUrl: String? = null
         ): User {
-            // 유효성 검증
-            validateUsername(username)
+            // 유효성 검증 및 값 객체 생성
+            val usernameVo = Username.from(username)
             validateNickname(nickname)
             validatePassword(rawPassword)
 
             return User(
-                username = username,
+                username = usernameVo,
                 nickname = nickname,
                 passwordHash = passwordEncoder(rawPassword),
                 userCode = UserCode.generate(),
@@ -75,20 +76,6 @@ data class User(
             return UserCode.generate()
         }
 
-        /**
-         * 사용자명 유효성 검증
-         *
-         * @param username 검증할 사용자명
-         * @throws InvalidUserDataException 유효하지 않은 사용자명
-         */
-        private fun validateUsername(username: String) {
-            if (username.isBlank()) {
-                throw InvalidUserDataException("사용자명은 비어있을 수 없습니다.")
-            }
-            if (username.length < 3 || username.length > 20) {
-                throw InvalidUserDataException("사용자명은 3-20자 사이여야 합니다.")
-            }
-        }
 
         /**
          * 닉네임 유효성 검증

--- a/src/main/kotlin/com/stark/shoot/domain/chat/user/Username.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/user/Username.kt
@@ -1,0 +1,21 @@
+@file:JvmName("Username")
+package com.stark.shoot.domain.chat.user
+
+import com.stark.shoot.domain.exception.InvalidUserDataException
+
+@JvmInline
+value class Username private constructor(val value: String) {
+    companion object {
+        fun from(username: String): Username {
+            if (username.isBlank()) {
+                throw InvalidUserDataException("사용자명은 비어있을 수 없습니다.")
+            }
+            if (username.length < 3 || username.length > 20) {
+                throw InvalidUserDataException("사용자명은 3-20자 사이여야 합니다.")
+            }
+            return Username(username)
+        }
+    }
+
+    override fun toString(): String = value
+}

--- a/src/main/kotlin/com/stark/shoot/infrastructure/config/security/service/UserDetailsServiceImpl.kt
+++ b/src/main/kotlin/com/stark/shoot/infrastructure/config/security/service/UserDetailsServiceImpl.kt
@@ -18,7 +18,7 @@ class UserDetailsServiceImpl(
             ?: throw IllegalArgumentException("User not found")
 
         // UserDetails로 변환
-        return CustomUserDetails(user.id.toString(), user.username)
+        return CustomUserDetails(user.id.toString(), user.username.value)
     }
 
 }

--- a/src/test/kotlin/com/stark/shoot/domain/chat/user/UserTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/chat/user/UserTest.kt
@@ -2,6 +2,7 @@ package com.stark.shoot.domain.chat.user
 
 import com.stark.shoot.domain.chat.user.UserStatus
 import com.stark.shoot.domain.chat.user.UserCode
+import com.stark.shoot.domain.chat.user.Username
 import com.stark.shoot.domain.exception.InvalidUserDataException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
@@ -36,7 +37,7 @@ class UserTest {
             )
             
             // then
-            assertThat(user.username).isEqualTo(username)
+            assertThat(user.username.value).isEqualTo(username)
             assertThat(user.nickname).isEqualTo(nickname)
             assertThat(user.passwordHash).isEqualTo("encoded_$rawPassword")
             assertThat(user.status).isEqualTo(UserStatus.OFFLINE)
@@ -71,7 +72,7 @@ class UserTest {
             )
             
             // then
-            assertThat(user.username).isEqualTo(username)
+            assertThat(user.username.value).isEqualTo(username)
             assertThat(user.nickname).isEqualTo(nickname)
             assertThat(user.passwordHash).isEqualTo("encoded_$rawPassword")
             assertThat(user.bio).isEqualTo(bio)
@@ -265,7 +266,7 @@ class UserTest {
             // given
             val user = User(
                 id = 1L,
-                username = "testuser",
+                username = Username.from("testuser"),
                 nickname = "테스트유저",
                 userCode = UserCode.from("ABCD1234")
             )
@@ -285,7 +286,7 @@ class UserTest {
             // given
             val user = User(
                 id = 1L,
-                username = "testuser",
+                username = Username.from("testuser"),
                 nickname = "테스트유저",
                 userCode = UserCode.from("ABCD1234"),
                 outgoingFriendRequestIds = setOf(2L, 3L),
@@ -310,7 +311,7 @@ class UserTest {
             // given
             val user = User(
                 id = 1L,
-                username = "testuser",
+                username = Username.from("testuser"),
                 nickname = "테스트유저",
                 userCode = UserCode.from("ABCD1234"),
                 incomingFriendRequestIds = setOf(2L, 3L)
@@ -333,7 +334,7 @@ class UserTest {
             // given
             val user = User(
                 id = 1L,
-                username = "testuser",
+                username = Username.from("testuser"),
                 nickname = "테스트유저",
                 userCode = UserCode.from("ABCD1234"),
                 incomingFriendRequestIds = setOf(2L, 3L)
@@ -353,7 +354,7 @@ class UserTest {
             // given
             val user = User(
                 id = 1L,
-                username = "testuser",
+                username = Username.from("testuser"),
                 nickname = "테스트유저",
                 userCode = UserCode.from("ABCD1234"),
                 incomingFriendRequestIds = setOf(2L, 3L)
@@ -376,7 +377,7 @@ class UserTest {
             // given
             val user = User(
                 id = 1L,
-                username = "testuser",
+                username = Username.from("testuser"),
                 nickname = "테스트유저",
                 userCode = UserCode.from("ABCD1234"),
                 outgoingFriendRequestIds = setOf(2L, 3L)
@@ -403,7 +404,7 @@ class UserTest {
             // given
             val user = User(
                 id = 1L,
-                username = "testuser",
+                username = Username.from("testuser"),
                 nickname = "테스트유저",
                 userCode = UserCode.from("ABCD1234"),
                 status = UserStatus.ONLINE


### PR DESCRIPTION
## Summary
- add `Username` value object for validating usernames
- use `Username` in `User` domain model
- adjust services, mapper, DTO and tests
- update README for new `Username` type

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685506ad26348320a4b89872ec0dda78