### PR TITLE
Implement Nickname value object

### DIFF
--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/user/UserDTO.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/user/UserDTO.kt
@@ -53,7 +53,7 @@ data class UserResponse(
 fun User.toResponse() = UserResponse(
     id = id.toString(),
     username = username.value,
-    nickname = nickname,
+    nickname = nickname.value,
     status = status,
     profileImageUrl = profileImageUrl,
     backgroundImageUrl = backgroundImageUrl,

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/mapper/UserMapper.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/mapper/UserMapper.kt
@@ -4,6 +4,7 @@ import com.stark.shoot.adapter.out.persistence.postgres.entity.UserEntity
 import com.stark.shoot.domain.chat.user.User
 import com.stark.shoot.domain.chat.user.UserCode
 import com.stark.shoot.domain.chat.user.Username
+import com.stark.shoot.domain.chat.user.Nickname
 import org.springframework.stereotype.Component
 
 @Component
@@ -12,7 +13,7 @@ class UserMapper {
     fun toEntity(user: User): UserEntity {
         return UserEntity(
             username = user.username.value,
-            nickname = user.nickname,
+            nickname = user.nickname.value,
             status = user.status,
             userCode = user.userCode.value,
             profileImageUrl = user.profileImageUrl,
@@ -28,7 +29,7 @@ class UserMapper {
         return User(
             id = userEntity.id,
             username = Username.from(userEntity.username),
-            nickname = userEntity.nickname,
+            nickname = Nickname.from(userEntity.nickname),
             status = userEntity.status,
             profileImageUrl = userEntity.profileImageUrl,
             backgroundImageUrl = userEntity.backgroundImageUrl,

--- a/src/main/kotlin/com/stark/shoot/application/service/chatroom/CreateChatRoomService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/chatroom/CreateChatRoomService.kt
@@ -77,7 +77,7 @@ class CreateChatRoomService(
         val newChatRoom = ChatRoom.createDirectChat(
             userId = userId,
             friendId = friendId,
-            friendName = friend.nickname
+            friendName = friend.nickname.value
         )
 
         // 채팅방 저장

--- a/src/main/kotlin/com/stark/shoot/application/service/user/friend/FindFriendService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/user/friend/FindFriendService.kt
@@ -30,8 +30,8 @@ class FindFriendService(
                 ?: throw ResourceNotFoundException("Friend not found: $friendId")
             FriendResponse(
                 id = friend.id ?: 0L,
-                username = friend.username ?: "",
-                nickname = friend.nickname ?: "",
+                username = friend.username.value,
+                nickname = friend.nickname.value,
                 profileImageUrl = friend.profileImageUrl
             )
         }
@@ -56,8 +56,8 @@ class FindFriendService(
                 ?: throw ResourceNotFoundException("Requester not found: $requesterId")
             FriendResponse(
                 id = requester.id ?: 0L,
-                username = requester.username ?: "",
-                nickname = requester.nickname ?: "",
+                username = requester.username.value,
+                nickname = requester.nickname.value,
                 profileImageUrl = requester.profileImageUrl
             )
         }
@@ -82,8 +82,8 @@ class FindFriendService(
                 ?: throw ResourceNotFoundException("Target not found: $targetId")
             FriendResponse(
                 id = target.id ?: 0L,
-                username = target.username ?: "",
-                nickname = target.nickname ?: "",
+                username = target.username.value,
+                nickname = target.nickname.value,
                 profileImageUrl = target.profileImageUrl
             )
         }

--- a/src/main/kotlin/com/stark/shoot/application/service/user/friend/FriendSearchService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/user/friend/FriendSearchService.kt
@@ -41,12 +41,12 @@ class FriendSearchService(
         return allUsers.filter { user ->
             user.id != null && !excludedIds.contains(user.id) &&
                     (user.username.value.contains(query, ignoreCase = true) ||
-                            user.nickname.contains(query, ignoreCase = true))
+                            user.nickname.value.contains(query, ignoreCase = true))
         }.map { user ->
             FriendResponse(
                 id = user.id ?: 0L,
                 username = user.username.value,
-                nickname = user.nickname,
+                nickname = user.nickname.value,
                 profileImageUrl = user.profileImageUrl
             )
         }

--- a/src/main/kotlin/com/stark/shoot/application/service/user/friend/recommend/RecommendFriendService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/user/friend/recommend/RecommendFriendService.kt
@@ -228,7 +228,7 @@ class RecommendFriendService(
                 FriendResponse(
                     id = user.id ?: 0L,
                     username = user.username.value,
-                    nickname = user.nickname,
+                    nickname = user.nickname.value,
                     profileImageUrl = user.profileImageUrl
                 )
             }

--- a/src/main/kotlin/com/stark/shoot/domain/chat/user/Nickname.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/user/Nickname.kt
@@ -1,0 +1,20 @@
+package com.stark.shoot.domain.chat.user
+
+import com.stark.shoot.domain.exception.InvalidUserDataException
+
+@JvmInline
+value class Nickname private constructor(val value: String) {
+    companion object {
+        fun from(nickname: String): Nickname {
+            if (nickname.isBlank()) {
+                throw InvalidUserDataException("닉네임은 비어있을 수 없습니다.")
+            }
+            if (nickname.length < 2 || nickname.length > 30) {
+                throw InvalidUserDataException("닉네임은 2-30자 사이여야 합니다.")
+            }
+            return Nickname(nickname)
+        }
+    }
+
+    override fun toString(): String = value
+}

--- a/src/main/kotlin/com/stark/shoot/domain/chat/user/User.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/user/User.kt
@@ -6,11 +6,12 @@ import java.time.Instant
 // 값 객체
 import com.stark.shoot.domain.chat.user.UserCode
 import com.stark.shoot.domain.chat.user.Username
+import com.stark.shoot.domain.chat.user.Nickname
 
 data class User(
     val id: Long? = null,
     var username: Username,
-    var nickname: String,
+    var nickname: Nickname,
     var status: UserStatus = UserStatus.OFFLINE,
     var passwordHash: String? = null,
     var userCode: UserCode,
@@ -54,12 +55,12 @@ data class User(
         ): User {
             // 유효성 검증 및 값 객체 생성
             val usernameVo = Username.from(username)
-            validateNickname(nickname)
+            val nicknameVo = Nickname.from(nickname)
             validatePassword(rawPassword)
 
             return User(
                 username = usernameVo,
-                nickname = nickname,
+                nickname = nicknameVo,
                 passwordHash = passwordEncoder(rawPassword),
                 userCode = UserCode.generate(),
                 bio = bio,
@@ -76,21 +77,6 @@ data class User(
             return UserCode.generate()
         }
 
-
-        /**
-         * 닉네임 유효성 검증
-         *
-         * @param nickname 검증할 닉네임
-         * @throws InvalidUserDataException 유효하지 않은 닉네임
-         */
-        private fun validateNickname(nickname: String) {
-            if (nickname.isBlank()) {
-                throw InvalidUserDataException("닉네임은 비어있을 수 없습니다.")
-            }
-            if (nickname.length < 2 || nickname.length > 30) {
-                throw InvalidUserDataException("닉네임은 2-30자 사이여야 합니다.")
-            }
-        }
 
         /**
          * 비밀번호 유효성 검증
@@ -283,13 +269,11 @@ data class User(
         backgroundImageUrl: String? = null
     ): User {
         // 닉네임 유효성 검증
-        if (nickname != null) {
-            validateNickname(nickname)
-        }
+        val nicknameVo = nickname?.let { Nickname.from(it) }
 
         // 업데이트된 사용자 정보 반환
         return this.copy(
-            nickname = nickname ?: this.nickname,
+            nickname = nicknameVo ?: this.nickname,
             bio = bio ?: this.bio,
             profileImageUrl = profileImageUrl ?: this.profileImageUrl,
             backgroundImageUrl = backgroundImageUrl ?: this.backgroundImageUrl,

--- a/src/test/kotlin/com/stark/shoot/domain/chat/user/UserTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/chat/user/UserTest.kt
@@ -3,6 +3,7 @@ package com.stark.shoot.domain.chat.user
 import com.stark.shoot.domain.chat.user.UserStatus
 import com.stark.shoot.domain.chat.user.UserCode
 import com.stark.shoot.domain.chat.user.Username
+import com.stark.shoot.domain.chat.user.Nickname
 import com.stark.shoot.domain.exception.InvalidUserDataException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
@@ -38,7 +39,7 @@ class UserTest {
             
             // then
             assertThat(user.username.value).isEqualTo(username)
-            assertThat(user.nickname).isEqualTo(nickname)
+            assertThat(user.nickname.value).isEqualTo(nickname)
             assertThat(user.passwordHash).isEqualTo("encoded_$rawPassword")
             assertThat(user.status).isEqualTo(UserStatus.OFFLINE)
             assertThat(user.userCode.value).isNotEmpty()
@@ -73,7 +74,7 @@ class UserTest {
             
             // then
             assertThat(user.username.value).isEqualTo(username)
-            assertThat(user.nickname).isEqualTo(nickname)
+            assertThat(user.nickname.value).isEqualTo(nickname)
             assertThat(user.passwordHash).isEqualTo("encoded_$rawPassword")
             assertThat(user.bio).isEqualTo(bio)
             assertThat(user.profileImageUrl).isEqualTo(profileImageUrl)
@@ -267,7 +268,7 @@ class UserTest {
             val user = User(
                 id = 1L,
                 username = Username.from("testuser"),
-                nickname = "테스트유저",
+                nickname = Nickname.from("테스트유저"),
                 userCode = UserCode.from("ABCD1234")
             )
             val friendId = 2L
@@ -287,7 +288,7 @@ class UserTest {
             val user = User(
                 id = 1L,
                 username = Username.from("testuser"),
-                nickname = "테스트유저",
+                nickname = Nickname.from("테스트유저"),
                 userCode = UserCode.from("ABCD1234"),
                 outgoingFriendRequestIds = setOf(2L, 3L),
                 incomingFriendRequestIds = setOf(2L, 4L)
@@ -312,7 +313,7 @@ class UserTest {
             val user = User(
                 id = 1L,
                 username = Username.from("testuser"),
-                nickname = "테스트유저",
+                nickname = Nickname.from("테스트유저"),
                 userCode = UserCode.from("ABCD1234"),
                 incomingFriendRequestIds = setOf(2L, 3L)
             )
@@ -335,7 +336,7 @@ class UserTest {
             val user = User(
                 id = 1L,
                 username = Username.from("testuser"),
-                nickname = "테스트유저",
+                nickname = Nickname.from("테스트유저"),
                 userCode = UserCode.from("ABCD1234"),
                 incomingFriendRequestIds = setOf(2L, 3L)
             )
@@ -355,7 +356,7 @@ class UserTest {
             val user = User(
                 id = 1L,
                 username = Username.from("testuser"),
-                nickname = "테스트유저",
+                nickname = Nickname.from("테스트유저"),
                 userCode = UserCode.from("ABCD1234"),
                 incomingFriendRequestIds = setOf(2L, 3L)
             )
@@ -378,7 +379,7 @@ class UserTest {
             val user = User(
                 id = 1L,
                 username = Username.from("testuser"),
-                nickname = "테스트유저",
+                nickname = Nickname.from("테스트유저"),
                 userCode = UserCode.from("ABCD1234"),
                 outgoingFriendRequestIds = setOf(2L, 3L)
             )
@@ -405,7 +406,7 @@ class UserTest {
             val user = User(
                 id = 1L,
                 username = Username.from("testuser"),
-                nickname = "테스트유저",
+                nickname = Nickname.from("테스트유저"),
                 userCode = UserCode.from("ABCD1234"),
                 status = UserStatus.ONLINE
             )

--- a/src/test/kotlin/com/stark/shoot/domain/service/user/FriendDomainServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/service/user/FriendDomainServiceTest.kt
@@ -5,6 +5,8 @@ import com.stark.shoot.domain.chat.event.FriendRemovedEvent
 import com.stark.shoot.domain.chat.user.User
 import com.stark.shoot.domain.chat.user.UserCode
 import com.stark.shoot.domain.chat.user.UserStatus
+import com.stark.shoot.domain.chat.user.Username
+import com.stark.shoot.domain.chat.user.Nickname
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -27,8 +29,8 @@ class FriendDomainServiceTest {
 
     @Test
     fun `친구 요청 수락을 처리할 수 있다`() {
-        val current = User(id=1L, username="a", nickname="A", userCode=UserCode.from("A1"), incomingFriendRequestIds=setOf(2L))
-        val requester = User(id=2L, username="b", nickname="B", userCode=UserCode.from("B1"))
+        val current = User(id=1L, username=Username.from("a"), nickname=Nickname.from("A"), userCode=UserCode.from("A1"), incomingFriendRequestIds=setOf(2L))
+        val requester = User(id=2L, username=Username.from("b"), nickname=Nickname.from("B"), userCode=UserCode.from("B1"))
         val result = service.processFriendAccept(current, requester, 2L)
         assertThat(result.updatedCurrentUser.friendIds).contains(2L)
         assertThat(result.updatedRequester.friendIds).contains(1L)
@@ -39,8 +41,8 @@ class FriendDomainServiceTest {
 
     @Test
     fun `친구 관계 삭제를 처리할 수 있다`() {
-        val current = User(id=1L, username="a", nickname="A", userCode=UserCode.from("A1"), friendIds=setOf(2L))
-        val friend = User(id=2L, username="b", nickname="B", userCode=UserCode.from("B1"), friendIds=setOf(1L))
+        val current = User(id=1L, username=Username.from("a"), nickname=Nickname.from("A"), userCode=UserCode.from("A1"), friendIds=setOf(2L))
+        val friend = User(id=2L, username=Username.from("b"), nickname=Nickname.from("B"), userCode=UserCode.from("B1"), friendIds=setOf(1L))
         val result = service.processFriendRemoval(current, friend, 2L)
         assertThat(result.updatedCurrentUser.friendIds).doesNotContain(2L)
         assertThat(result.updatedFriend.friendIds).doesNotContain(1L)

--- a/src/test/kotlin/com/stark/shoot/domain/service/user/UserBlockDomainServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/service/user/UserBlockDomainServiceTest.kt
@@ -2,6 +2,8 @@ package com.stark.shoot.domain.service.user
 
 import com.stark.shoot.domain.chat.user.User
 import com.stark.shoot.domain.chat.user.UserCode
+import com.stark.shoot.domain.chat.user.Username
+import com.stark.shoot.domain.chat.user.Nickname
 import com.stark.shoot.domain.service.user.block.UserBlockDomainService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
@@ -14,13 +16,13 @@ class UserBlockDomainServiceTest {
 
     @Test
     fun `자신을 차단하면 예외`() {
-        val user = User(id=1L, username="a", nickname="A", userCode=UserCode.from("A1"))
+        val user = User(id=1L, username=Username.from("a"), nickname=Nickname.from("A"), userCode=UserCode.from("A1"))
         assertThrows<IllegalArgumentException> { service.block(user,1L) }
     }
 
     @Test
     fun `차단과 해제가 가능하다`() {
-        val user = User(id=1L, username="a", nickname="A", userCode=UserCode.from("A1"))
+        val user = User(id=1L, username=Username.from("a"), nickname=Nickname.from("A"), userCode=UserCode.from("A1"))
         val blocked = service.block(user,2L)
         assertThat(blocked.blockedUserIds).contains(2L)
         val unblocked = service.unblock(blocked,2L)


### PR DESCRIPTION
## Summary
- add `Nickname` VO for user nickname validation
- update `User` entity to use `Nickname`
- adjust mappers, services and DTO conversions
- fix tests to construct users with `Nickname`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68550bb55edc832089b6b85d11d19188