### PR TITLE
Introduce value objects across multiple domains

### DIFF
--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/chatroom/ChatRoomResponse.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/chatroom/ChatRoomResponse.kt
@@ -32,10 +32,10 @@ data class ChatRoomResponse(
             val roomTitle = if (chatRoom.type == ChatRoomType.INDIVIDUAL) {
                 // 1:1 채팅인 경우: 다른 참여자의 이름을 사용하고 싶다면 추가 조회가 필요하지만,
                 // 여기서는 채팅방의 title이 있으면 사용하고, 없으면 기본 "채팅방"으로 처리합니다.
-                chatRoom.title ?: "채팅방"
+                chatRoom.title?.value ?: "채팅방"
             } else {
                 // 그룹 채팅의 경우 제목 그대로 사용
-                chatRoom.title ?: "채팅방"
+                chatRoom.title?.value ?: "채팅방"
             }
             return ChatRoomResponse(
                 roomId = chatRoom.id ?: 0L,

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/notification/NotificationResponse.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/notification/NotificationResponse.kt
@@ -23,8 +23,8 @@ data class NotificationResponse(
             return NotificationResponse(
                 id = notification.id,
                 userId = notification.userId,
-                title = notification.title,
-                message = notification.message,
+                title = notification.title.value,
+                message = notification.message.value,
                 type = notification.type.name,
                 sourceId = notification.sourceId,
                 sourceType = notification.sourceType.name,

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/document/notification/NotificationDocument.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/document/notification/NotificationDocument.kt
@@ -3,6 +3,8 @@ package com.stark.shoot.adapter.out.persistence.mongodb.document.notification
 import com.stark.shoot.domain.notification.Notification
 import com.stark.shoot.domain.notification.NotificationType
 import com.stark.shoot.domain.notification.SourceType
+import com.stark.shoot.domain.notification.NotificationTitle
+import com.stark.shoot.domain.notification.NotificationMessage
 import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.index.Indexed
 import org.springframework.data.mongodb.core.mapping.Document
@@ -41,8 +43,8 @@ data class NotificationDocument(
         return Notification(
             id = id,
             userId = userId,
-            title = title,
-            message = message,
+            title = NotificationTitle.from(title),
+            message = NotificationMessage.from(message),
             type = NotificationType.valueOf(type),
             sourceId = sourceId,
             sourceType = SourceType.valueOf(sourceType),
@@ -58,8 +60,8 @@ data class NotificationDocument(
             return NotificationDocument(
                 id = notification.id,
                 userId = notification.userId,
-                title = notification.title,
-                message = notification.message,
+                title = notification.title.value,
+                message = notification.message.value,
                 type = notification.type.name,
                 sourceId = notification.sourceId,
                 sourceType = notification.sourceType.name,

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/chatroom/SaveChatRoomPersistenceAdapter.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/chatroom/SaveChatRoomPersistenceAdapter.kt
@@ -34,7 +34,7 @@ class SaveChatRoomPersistenceAdapter(
 
             // 업데이트된 도메인 객체를 사용하여 엔티티 업데이트
             existingEntity.update(
-                title = chatRoom.title,
+                title = chatRoom.title?.value,
                 type = chatRoom.type,
                 announcement = chatRoom.announcement,
                 lastMessageId = chatRoom.lastMessageId?.toLongOrNull(),

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/mapper/ChatRoomMapper.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/mapper/ChatRoomMapper.kt
@@ -4,6 +4,7 @@ import com.stark.shoot.adapter.out.persistence.postgres.entity.ChatRoomEntity
 import com.stark.shoot.adapter.out.persistence.postgres.entity.ChatRoomUserEntity
 import com.stark.shoot.domain.chat.room.ChatRoom
 import com.stark.shoot.domain.chat.room.ChatRoomType
+import com.stark.shoot.domain.chat.room.ChatRoomTitle
 import org.springframework.stereotype.Component
 
 @Component
@@ -28,7 +29,7 @@ class ChatRoomMapper {
 
         return ChatRoom(
             id = entity.id,
-            title = entity.title,
+            title = entity.title?.let { ChatRoomTitle.from(it) },
             type = domainType,
             announcement = entity.announcement,
             participants = participantIds,
@@ -45,7 +46,7 @@ class ChatRoomMapper {
         val lastMessageIdLong: Long? = domain.lastMessageId?.toLongOrNull()
 
         return ChatRoomEntity(
-            title = domain.title,
+            title = domain.title?.value,
             type = domain.type,
             announcement = domain.announcement,
             lastMessageId = lastMessageIdLong,

--- a/src/main/kotlin/com/stark/shoot/application/service/chatroom/ManageChatRoomService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/chatroom/ManageChatRoomService.kt
@@ -7,6 +7,7 @@ import com.stark.shoot.application.port.out.chatroom.SaveChatRoomPort
 import com.stark.shoot.application.port.out.user.FindUserPort
 import com.stark.shoot.domain.chat.room.ChatRoom
 import com.stark.shoot.domain.service.chatroom.ChatRoomParticipantDomainService
+import com.stark.shoot.domain.chat.room.ChatRoomTitle
 import com.stark.shoot.infrastructure.annotation.UseCase
 import com.stark.shoot.infrastructure.exception.web.ResourceNotFoundException
 import org.springframework.transaction.annotation.Transactional
@@ -132,7 +133,7 @@ class ManageChatRoomService(
     ): Boolean {
         return withChatRoom(roomId) { chatRoom ->
             // 제목 업데이트 (도메인 객체의 update 메서드 사용)
-            val updatedRoom = chatRoom.update(title = title)
+            val updatedRoom = chatRoom.update(title = ChatRoomTitle.from(title))
 
             // 결과 반환 (업데이트된 채팅방과 성공 여부)
             Pair(updatedRoom, true)

--- a/src/main/kotlin/com/stark/shoot/domain/chat/room/ChatRoom.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/room/ChatRoom.kt
@@ -1,13 +1,14 @@
 package com.stark.shoot.domain.chat.room
 
 import com.stark.shoot.domain.exception.FavoriteLimitExceededException
+import com.stark.shoot.domain.chat.room.ChatRoomTitle
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
 data class ChatRoom(
     val id: Long? = null,
-    val title: String? = null,
+    val title: ChatRoomTitle? = null,
     val type: ChatRoomType,
     val participants: MutableSet<Long>,
     val lastMessageId: String? = null,
@@ -97,7 +98,7 @@ data class ChatRoom(
             friendId: Long,
             friendName: String
         ): ChatRoom {
-            val title = "${friendName}님과의 대화"
+            val title = ChatRoomTitle.from("${friendName}님과의 대화")
 
             return ChatRoom(
                 title = title,
@@ -117,7 +118,7 @@ data class ChatRoom(
      */
     fun update(
         id: Long? = this.id,
-        title: String? = this.title,
+        title: ChatRoomTitle? = this.title,
         type: ChatRoomType = this.type,
         announcement: String? = this.announcement,
         lastMessageId: String? = this.lastMessageId,
@@ -324,13 +325,13 @@ data class ChatRoom(
             val otherParticipantId = participants.find { it != userId }
             if (otherParticipantId != null) {
                 // 실제 구현에서는 사용자 정보 조회 서비스를 통해 닉네임 가져오기
-                title ?: "1:1 채팅방"
+                title?.value ?: "1:1 채팅방"
             } else {
-                title ?: "1:1 채팅방"
+                title?.value ?: "1:1 채팅방"
             }
         } else {
             // 그룹 채팅의 경우 정해진 제목 사용
-            title ?: "그룹 채팅방"
+            title?.value ?: "그룹 채팅방"
         }
     }
 

--- a/src/main/kotlin/com/stark/shoot/domain/chat/room/ChatRoomTitle.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/room/ChatRoomTitle.kt
@@ -1,0 +1,13 @@
+package com.stark.shoot.domain.chat.room
+
+@JvmInline
+value class ChatRoomTitle private constructor(val value: String) {
+    companion object {
+        fun from(value: String): ChatRoomTitle {
+            require(value.isNotBlank()) { "채팅방 제목은 비어있을 수 없습니다." }
+            return ChatRoomTitle(value)
+        }
+    }
+
+    override fun toString(): String = value
+}

--- a/src/main/kotlin/com/stark/shoot/domain/chat/room/service/ChatRoomDomainService.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/room/service/ChatRoomDomainService.kt
@@ -30,7 +30,7 @@ class ChatRoomDomainService {
         return chatRooms.filter { room ->
             // 검색어 필터링 (제목에 검색어 포함 여부)
             val matchesQuery = query.isNullOrBlank() ||
-                    (room.title?.contains(query, ignoreCase = true) ?: false)
+                    (room.title?.value?.contains(query, ignoreCase = true) ?: false)
 
             // 채팅방 타입 필터링
             val matchesType = type.isNullOrBlank() ||

--- a/src/main/kotlin/com/stark/shoot/domain/chat/user/RefreshToken.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/user/RefreshToken.kt
@@ -1,11 +1,12 @@
 package com.stark.shoot.domain.chat.user
 
 import java.time.Instant
+import com.stark.shoot.domain.chat.user.RefreshTokenValue
 
 data class RefreshToken(
     val id: Long? = null,
     val userId: Long,                 // 사용자 ID 참조
-    val token: String,                // 리프레시 토큰 값
+    val token: RefreshTokenValue,                // 리프레시 토큰 값
     val expirationDate: Instant,      // 만료 시간
     val deviceInfo: String? = null,   // 디바이스 정보 (선택적)
     val ipAddress: String? = null,    // IP 주소 (선택적)

--- a/src/main/kotlin/com/stark/shoot/domain/chat/user/RefreshTokenValue.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/user/RefreshTokenValue.kt
@@ -1,0 +1,13 @@
+package com.stark.shoot.domain.chat.user
+
+@JvmInline
+value class RefreshTokenValue private constructor(val value: String) {
+    companion object {
+        fun from(value: String): RefreshTokenValue {
+            require(value.isNotBlank()) { "리프레시 토큰 값은 비어있을 수 없습니다." }
+            return RefreshTokenValue(value)
+        }
+    }
+
+    override fun toString(): String = value
+}

--- a/src/main/kotlin/com/stark/shoot/domain/notification/Notification.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/notification/Notification.kt
@@ -2,6 +2,8 @@ package com.stark.shoot.domain.notification
 
 import com.stark.shoot.domain.exception.NotificationException
 import com.stark.shoot.domain.notification.event.NotificationEvent
+import com.stark.shoot.domain.notification.NotificationTitle
+import com.stark.shoot.domain.notification.NotificationMessage
 import java.time.Instant
 
 /**
@@ -13,8 +15,8 @@ import java.time.Instant
 class Notification(
     val id: String? = null,
     val userId: Long,
-    val title: String,
-    val message: String,
+    val title: NotificationTitle,
+    val message: NotificationMessage,
     val type: NotificationType,
     val sourceId: String,
     val sourceType: SourceType,
@@ -124,8 +126,8 @@ class Notification(
         ): Notification {
             return Notification(
                 userId = userId,
-                title = title,
-                message = message,
+                title = NotificationTitle.from(title),
+                message = NotificationMessage.from(message),
                 type = type,
                 sourceId = sourceId,
                 sourceType = SourceType.CHAT,
@@ -143,8 +145,8 @@ class Notification(
         fun fromEvent(event: NotificationEvent, recipientId: Long): Notification {
             return Notification(
                 userId = recipientId,
-                title = event.getTitle(),
-                message = event.getMessage(),
+                title = NotificationTitle.from(event.getTitle()),
+                message = NotificationMessage.from(event.getMessage()),
                 type = event.type,
                 sourceId = event.sourceId,
                 sourceType = event.sourceType,
@@ -175,8 +177,8 @@ class Notification(
         ): Notification {
             return Notification(
                 userId = userId,
-                title = title,
-                message = message,
+                title = NotificationTitle.from(title),
+                message = NotificationMessage.from(message),
                 type = type,
                 sourceId = sourceId,
                 sourceType = sourceType,

--- a/src/main/kotlin/com/stark/shoot/domain/notification/NotificationMessage.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/notification/NotificationMessage.kt
@@ -1,0 +1,13 @@
+package com.stark.shoot.domain.notification
+
+@JvmInline
+value class NotificationMessage private constructor(val value: String) {
+    companion object {
+        fun from(value: String): NotificationMessage {
+            require(value.isNotBlank()) { "알림 메시지는 비어있을 수 없습니다." }
+            return NotificationMessage(value)
+        }
+    }
+
+    override fun toString(): String = value
+}

--- a/src/main/kotlin/com/stark/shoot/domain/notification/NotificationTitle.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/notification/NotificationTitle.kt
@@ -1,0 +1,13 @@
+package com.stark.shoot.domain.notification
+
+@JvmInline
+value class NotificationTitle private constructor(val value: String) {
+    companion object {
+        fun from(value: String): NotificationTitle {
+            require(value.isNotBlank()) { "알림 제목은 비어있을 수 없습니다." }
+            return NotificationTitle(value)
+        }
+    }
+
+    override fun toString(): String = value
+}

--- a/src/test/kotlin/com/stark/shoot/domain/chat/room/ChatRoomTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/chat/room/ChatRoomTest.kt
@@ -1,6 +1,7 @@
 package com.stark.shoot.domain.chat.room
 
 import com.stark.shoot.domain.exception.FavoriteLimitExceededException
+import com.stark.shoot.domain.chat.room.ChatRoomTitle
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -23,13 +24,13 @@ class ChatRoomTest {
 
             // when
             val chatRoom = ChatRoom(
-                title = "테스트 채팅방",
+                title = ChatRoomTitle.from("테스트 채팅방"),
                 type = ChatRoomType.GROUP,
                 participants = participants
             )
 
             // then
-            assertThat(chatRoom.title).isEqualTo("테스트 채팅방")
+            assertThat(chatRoom.title?.value).isEqualTo("테스트 채팅방")
             assertThat(chatRoom.type).isEqualTo(ChatRoomType.GROUP)
             assertThat(chatRoom.participants).containsExactlyInAnyOrderElementsOf(participants)
             assertThat(chatRoom.lastMessageId).isNull()
@@ -49,7 +50,7 @@ class ChatRoomTest {
             val chatRoom = ChatRoom.createDirectChat(userId, friendId, friendName)
 
             // then
-            assertThat(chatRoom.title).isEqualTo("${friendName}님과의 대화")
+            assertThat(chatRoom.title?.value).isEqualTo("${friendName}님과의 대화")
             assertThat(chatRoom.type).isEqualTo(ChatRoomType.INDIVIDUAL)
             assertThat(chatRoom.participants).containsExactlyInAnyOrder(userId, friendId)
             assertThat(chatRoom.lastMessageId).isNull()
@@ -68,7 +69,7 @@ class ChatRoomTest {
             // given
             val chatRoom = ChatRoom(
                 id = 1L,
-                title = "원래 제목",
+                title = ChatRoomTitle.from("원래 제목"),
                 type = ChatRoomType.GROUP,
                 participants = mutableSetOf(1L, 2L)
             )
@@ -79,7 +80,7 @@ class ChatRoomTest {
 
             // when
             val updatedChatRoom = chatRoom.update(
-                title = newTitle,
+                title = ChatRoomTitle.from(newTitle),
                 announcement = newAnnouncement,
                 lastMessageId = newLastMessageId,
                 lastActiveAt = newLastActiveAt
@@ -87,7 +88,7 @@ class ChatRoomTest {
 
             // then
             assertThat(updatedChatRoom.id).isEqualTo(chatRoom.id)
-            assertThat(updatedChatRoom.title).isEqualTo(newTitle)
+            assertThat(updatedChatRoom.title?.value).isEqualTo(newTitle)
             assertThat(updatedChatRoom.type).isEqualTo(chatRoom.type)
             assertThat(updatedChatRoom.announcement).isEqualTo(newAnnouncement)
             assertThat(updatedChatRoom.lastMessageId).isEqualTo(newLastMessageId)
@@ -100,7 +101,7 @@ class ChatRoomTest {
         fun `공지사항만 업데이트할 수 있다`() {
             // given
             val chatRoom = ChatRoom(
-                title = "테스트 채팅방",
+                title = ChatRoomTitle.from("테스트 채팅방"),
                 type = ChatRoomType.GROUP,
                 participants = mutableSetOf(1L, 2L)
             )
@@ -119,7 +120,7 @@ class ChatRoomTest {
         fun `공지사항을 삭제할 수 있다`() {
             // given
             val chatRoom = ChatRoom(
-                title = "테스트 채팅방",
+                title = ChatRoomTitle.from("테스트 채팅방"),
                 type = ChatRoomType.GROUP,
                 participants = mutableSetOf(1L, 2L),
                 announcement = "기존 공지사항"
@@ -143,7 +144,7 @@ class ChatRoomTest {
         fun `참여자를 추가할 수 있다`() {
             // given
             val chatRoom = ChatRoom(
-                title = "테스트 채팅방",
+                title = ChatRoomTitle.from("테스트 채팅방"),
                 type = ChatRoomType.GROUP,
                 participants = mutableSetOf(1L, 2L)
             )
@@ -162,7 +163,7 @@ class ChatRoomTest {
         fun `이미 참여 중인 사용자를 추가하면 변경이 없다`() {
             // given
             val chatRoom = ChatRoom(
-                title = "테스트 채팅방",
+                title = ChatRoomTitle.from("테스트 채팅방"),
                 type = ChatRoomType.GROUP,
                 participants = mutableSetOf(1L, 2L)
             )
@@ -181,7 +182,7 @@ class ChatRoomTest {
         fun `참여자를 제거할 수 있다`() {
             // given
             val chatRoom = ChatRoom(
-                title = "테스트 채팅방",
+                title = ChatRoomTitle.from("테스트 채팅방"),
                 type = ChatRoomType.GROUP,
                 participants = mutableSetOf(1L, 2L, 3L)
             )
@@ -200,7 +201,7 @@ class ChatRoomTest {
         fun `참여하지 않은 사용자를 제거하면 변경이 없다`() {
             // given
             val chatRoom = ChatRoom(
-                title = "테스트 채팅방",
+                title = ChatRoomTitle.from("테스트 채팅방"),
                 type = ChatRoomType.GROUP,
                 participants = mutableSetOf(1L, 2L)
             )
@@ -219,7 +220,7 @@ class ChatRoomTest {
         fun `여러 참여자를 한번에 추가할 수 있다`() {
             // given
             val chatRoom = ChatRoom(
-                title = "테스트 채팅방",
+                title = ChatRoomTitle.from("테스트 채팅방"),
                 type = ChatRoomType.GROUP,
                 participants = mutableSetOf(1L, 2L)
             )
@@ -238,7 +239,7 @@ class ChatRoomTest {
         fun `여러 참여자를 한번에 제거할 수 있다`() {
             // given
             val chatRoom = ChatRoom(
-                title = "테스트 채팅방",
+                title = ChatRoomTitle.from("테스트 채팅방"),
                 type = ChatRoomType.GROUP,
                 participants = mutableSetOf(1L, 2L, 3L, 4L, 5L)
             )
@@ -257,7 +258,7 @@ class ChatRoomTest {
         fun `참여자 목록을 한번에 업데이트할 수 있다`() {
             // given
             val chatRoom = ChatRoom(
-                title = "테스트 채팅방",
+                title = ChatRoomTitle.from("테스트 채팅방"),
                 type = ChatRoomType.GROUP,
                 participants = mutableSetOf(1L, 2L, 3L)
             )
@@ -282,7 +283,7 @@ class ChatRoomTest {
         fun `참여자 변경 사항을 계산할 수 있다`() {
             // given
             val chatRoom = ChatRoom(
-                title = "테스트 채팅방",
+                title = ChatRoomTitle.from("테스트 채팅방"),
                 type = ChatRoomType.GROUP,
                 participants = mutableSetOf(1L, 2L, 3L),
                 pinnedParticipants = mutableSetOf(1L)
@@ -306,7 +307,7 @@ class ChatRoomTest {
         fun `변경 사항이 없으면 빈 결과를 반환한다`() {
             // given
             val chatRoom = ChatRoom(
-                title = "테스트 채팅방",
+                title = ChatRoomTitle.from("테스트 채팅방"),
                 type = ChatRoomType.GROUP,
                 participants = mutableSetOf(1L, 2L),
                 pinnedParticipants = mutableSetOf(1L)
@@ -334,7 +335,7 @@ class ChatRoomTest {
         fun `채팅방을 즐겨찾기에 추가할 수 있다`() {
             // given
             val chatRoom = ChatRoom(
-                title = "테스트 채팅방",
+                title = ChatRoomTitle.from("테스트 채팅방"),
                 type = ChatRoomType.GROUP,
                 participants = mutableSetOf(1L, 2L)
             )
@@ -355,7 +356,7 @@ class ChatRoomTest {
             // given
             val userId = 1L
             val chatRoom = ChatRoom(
-                title = "테스트 채팅방",
+                title = ChatRoomTitle.from("테스트 채팅방"),
                 type = ChatRoomType.GROUP,
                 participants = mutableSetOf(userId, 2L),
                 pinnedParticipants = mutableSetOf(userId)
@@ -376,7 +377,7 @@ class ChatRoomTest {
             // given
             val userId = 1L
             val chatRoom = ChatRoom(
-                title = "테스트 채팅방",
+                title = ChatRoomTitle.from("테스트 채팅방"),
                 type = ChatRoomType.GROUP,
                 participants = mutableSetOf(userId, 2L),
                 pinnedParticipants = mutableSetOf(userId)
@@ -396,7 +397,7 @@ class ChatRoomTest {
         fun `즐겨찾기 최대 개수를 초과하면 예외가 발생한다`() {
             // given
             val chatRoom = ChatRoom(
-                title = "테스트 채팅방",
+                title = ChatRoomTitle.from("테스트 채팅방"),
                 type = ChatRoomType.GROUP,
                 participants = mutableSetOf(1L, 2L)
             )

--- a/src/test/kotlin/com/stark/shoot/domain/chat/user/RefreshTokenTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/chat/user/RefreshTokenTest.kt
@@ -1,6 +1,7 @@
 package com.stark.shoot.domain.chat.user
 
 import org.assertj.core.api.Assertions.assertThat
+import com.stark.shoot.domain.chat.user.RefreshTokenValue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -19,7 +20,7 @@ class RefreshTokenTest {
         fun `필수 속성으로 리프레시 토큰을 생성할 수 있다`() {
             // given
             val userId = 1L
-            val token = "refresh_token_value"
+            val token = RefreshTokenValue.from("refresh_token_value")
             val expirationDate = Instant.now().plus(7, ChronoUnit.DAYS)
             
             // when
@@ -47,7 +48,7 @@ class RefreshTokenTest {
             // given
             val id = 1L
             val userId = 2L
-            val token = "refresh_token_value"
+            val token = RefreshTokenValue.from("refresh_token_value")
             val expirationDate = Instant.now().plus(7, ChronoUnit.DAYS)
             val deviceInfo = "Android 12, Samsung Galaxy S21"
             val ipAddress = "192.168.1.1"
@@ -91,7 +92,7 @@ class RefreshTokenTest {
             // given
             val refreshToken = RefreshToken(
                 userId = 1L,
-                token = "valid_token",
+                token = RefreshTokenValue.from("valid_token"),
                 expirationDate = Instant.now().plus(7, ChronoUnit.DAYS),
                 isRevoked = false
             )
@@ -109,7 +110,7 @@ class RefreshTokenTest {
             // given
             val refreshToken = RefreshToken(
                 userId = 1L,
-                token = "expired_token",
+                token = RefreshTokenValue.from("expired_token"),
                 expirationDate = Instant.now().minus(1, ChronoUnit.DAYS),
                 isRevoked = false
             )
@@ -127,7 +128,7 @@ class RefreshTokenTest {
             // given
             val refreshToken = RefreshToken(
                 userId = 1L,
-                token = "revoked_token",
+                token = RefreshTokenValue.from("revoked_token"),
                 expirationDate = Instant.now().plus(7, ChronoUnit.DAYS),
                 isRevoked = true
             )
@@ -145,7 +146,7 @@ class RefreshTokenTest {
             // given
             val refreshToken = RefreshToken(
                 userId = 1L,
-                token = "expired_and_revoked_token",
+                token = RefreshTokenValue.from("expired_and_revoked_token"),
                 expirationDate = Instant.now().minus(1, ChronoUnit.DAYS),
                 isRevoked = true
             )
@@ -168,7 +169,7 @@ class RefreshTokenTest {
             // given
             val refreshToken = RefreshToken(
                 userId = 1L,
-                token = "token",
+                token = RefreshTokenValue.from("token"),
                 expirationDate = Instant.now().plus(7, ChronoUnit.DAYS)
             )
             val beforeUpdate = Instant.now().minusMillis(100)
@@ -200,7 +201,7 @@ class RefreshTokenTest {
             val oldLastUsedAt = Instant.now().minus(1, ChronoUnit.HOURS)
             val refreshToken = RefreshToken(
                 userId = 1L,
-                token = "token",
+                token = RefreshTokenValue.from("token"),
                 expirationDate = Instant.now().plus(7, ChronoUnit.DAYS),
                 lastUsedAt = oldLastUsedAt
             )
@@ -228,7 +229,7 @@ class RefreshTokenTest {
             // given
             val refreshToken = RefreshToken(
                 userId = 1L,
-                token = "token_to_revoke",
+                token = RefreshTokenValue.from("token_to_revoke"),
                 expirationDate = Instant.now().plus(7, ChronoUnit.DAYS),
                 isRevoked = false
             )
@@ -256,7 +257,7 @@ class RefreshTokenTest {
             // given
             val refreshToken = RefreshToken(
                 userId = 1L,
-                token = "already_revoked_token",
+                token = RefreshTokenValue.from("already_revoked_token"),
                 expirationDate = Instant.now().plus(7, ChronoUnit.DAYS),
                 isRevoked = true
             )


### PR DESCRIPTION
## Summary
- add `ChatRoomTitle`, `NotificationTitle`, `NotificationMessage`, and `RefreshTokenValue` value objects
- refactor `ChatRoom`, `Notification`, and `RefreshToken` to use the new value objects
- update related mappers, services and DTOs
- adjust unit tests for new types

## Testing
- `./gradlew test` *(fails: Unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68550ed4c1648320a1222260e872e0f7