### PR TITLE
Add MessageId & UserId value objects

### DIFF
--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/adapter/message/BookmarkMessageMongoAdapter.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/adapter/message/BookmarkMessageMongoAdapter.kt
@@ -5,6 +5,8 @@ import com.stark.shoot.adapter.out.persistence.mongodb.repository.ChatMessageMon
 import com.stark.shoot.adapter.out.persistence.mongodb.repository.MessageBookmarkMongoRepository
 import com.stark.shoot.application.port.out.message.BookmarkMessagePort
 import com.stark.shoot.domain.chat.bookmark.MessageBookmark
+import com.stark.shoot.domain.common.vo.MessageId
+import com.stark.shoot.domain.common.vo.UserId
 import com.stark.shoot.infrastructure.annotation.Adapter
 import org.bson.types.ObjectId
 
@@ -20,12 +22,12 @@ class BookmarkMessageMongoAdapter(
         return saved.toDomain()
     }
 
-    override fun deleteBookmark(messageId: String, userId: Long) {
-        bookmarkRepository.deleteByMessageIdAndUserId(messageId, userId)
+    override fun deleteBookmark(messageId: MessageId, userId: UserId) {
+        bookmarkRepository.deleteByMessageIdAndUserId(messageId.value, userId.value)
     }
 
-    override fun findBookmarksByUser(userId: Long, roomId: Long?): List<MessageBookmark> {
-        val documents = bookmarkRepository.findByUserId(userId)
+    override fun findBookmarksByUser(userId: UserId, roomId: Long?): List<MessageBookmark> {
+        val documents = bookmarkRepository.findByUserId(userId.value)
         if (roomId == null) {
             return documents.map { it.toDomain() }
         }
@@ -36,7 +38,7 @@ class BookmarkMessageMongoAdapter(
         }.map { it.toDomain() }
     }
 
-    override fun exists(messageId: String, userId: Long): Boolean {
-        return bookmarkRepository.existsByMessageIdAndUserId(messageId, userId)
+    override fun exists(messageId: MessageId, userId: UserId): Boolean {
+        return bookmarkRepository.existsByMessageIdAndUserId(messageId.value, userId.value)
     }
 }

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/document/message/bookmark/MessageBookmarkDocument.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/document/message/bookmark/MessageBookmarkDocument.kt
@@ -1,6 +1,8 @@
 package com.stark.shoot.adapter.out.persistence.mongodb.document.message.bookmark
 
 import com.stark.shoot.domain.chat.bookmark.MessageBookmark
+import com.stark.shoot.domain.common.vo.MessageId
+import com.stark.shoot.domain.common.vo.UserId
 import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.index.Indexed
 import org.springframework.data.mongodb.core.mapping.Document
@@ -19,8 +21,8 @@ data class MessageBookmarkDocument(
     fun toDomain(): MessageBookmark {
         return MessageBookmark(
             id = id,
-            messageId = messageId,
-            userId = userId,
+            messageId = MessageId.from(messageId),
+            userId = UserId.from(userId),
             createdAt = createdAt
         )
     }
@@ -29,8 +31,8 @@ data class MessageBookmarkDocument(
         fun fromDomain(bookmark: MessageBookmark): MessageBookmarkDocument {
             return MessageBookmarkDocument(
                 id = bookmark.id,
-                messageId = bookmark.messageId,
-                userId = bookmark.userId,
+                messageId = bookmark.messageId.value,
+                userId = bookmark.userId.value,
                 createdAt = bookmark.createdAt
             )
         }

--- a/src/main/kotlin/com/stark/shoot/application/port/in/message/bookmark/BookmarkMessageUseCase.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/message/bookmark/BookmarkMessageUseCase.kt
@@ -1,9 +1,11 @@
 package com.stark.shoot.application.port.`in`.message.bookmark
 
 import com.stark.shoot.domain.chat.bookmark.MessageBookmark
+import com.stark.shoot.domain.common.vo.MessageId
+import com.stark.shoot.domain.common.vo.UserId
 
 interface BookmarkMessageUseCase {
-    fun bookmarkMessage(messageId: String, userId: Long): MessageBookmark
-    fun removeBookmark(messageId: String, userId: Long)
-    fun getBookmarks(userId: Long, roomId: Long? = null): List<MessageBookmark>
+    fun bookmarkMessage(messageId: MessageId, userId: UserId): MessageBookmark
+    fun removeBookmark(messageId: MessageId, userId: UserId)
+    fun getBookmarks(userId: UserId, roomId: Long? = null): List<MessageBookmark>
 }

--- a/src/main/kotlin/com/stark/shoot/application/port/out/message/BookmarkMessagePort.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/out/message/BookmarkMessagePort.kt
@@ -1,10 +1,12 @@
 package com.stark.shoot.application.port.out.message
 
 import com.stark.shoot.domain.chat.bookmark.MessageBookmark
+import com.stark.shoot.domain.common.vo.MessageId
+import com.stark.shoot.domain.common.vo.UserId
 
 interface BookmarkMessagePort {
     fun saveBookmark(bookmark: MessageBookmark): MessageBookmark
-    fun deleteBookmark(messageId: String, userId: Long)
-    fun findBookmarksByUser(userId: Long, roomId: Long? = null): List<MessageBookmark>
-    fun exists(messageId: String, userId: Long): Boolean
+    fun deleteBookmark(messageId: MessageId, userId: UserId)
+    fun findBookmarksByUser(userId: UserId, roomId: Long? = null): List<MessageBookmark>
+    fun exists(messageId: MessageId, userId: UserId): Boolean
 }

--- a/src/main/kotlin/com/stark/shoot/application/service/message/bookmark/MessageBookmarkService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/message/bookmark/MessageBookmarkService.kt
@@ -4,6 +4,8 @@ import com.stark.shoot.application.port.`in`.message.bookmark.BookmarkMessageUse
 import com.stark.shoot.application.port.out.message.BookmarkMessagePort
 import com.stark.shoot.application.port.out.message.LoadMessagePort
 import com.stark.shoot.domain.chat.bookmark.MessageBookmark
+import com.stark.shoot.domain.common.vo.MessageId
+import com.stark.shoot.domain.common.vo.UserId
 import com.stark.shoot.infrastructure.annotation.UseCase
 import com.stark.shoot.infrastructure.exception.web.ResourceNotFoundException
 import com.stark.shoot.infrastructure.util.toObjectId
@@ -18,13 +20,13 @@ class MessageBookmarkService(
 
     private val logger = KotlinLogging.logger {}
 
-    override fun bookmarkMessage(messageId: String, userId: Long): MessageBookmark {
+    override fun bookmarkMessage(messageId: MessageId, userId: UserId): MessageBookmark {
         if (bookmarkPort.exists(messageId, userId)) {
             logger.debug { "이미 북마크된 메시지입니다: messageId=$messageId, userId=$userId" }
             throw IllegalArgumentException("이미 북마크된 메시지입니다.")
         }
 
-        loadMessagePort.findById(messageId.toObjectId())
+        loadMessagePort.findById(messageId.value.toObjectId())
             ?: throw ResourceNotFoundException("메시지를 찾을 수 없습니다: messageId=$messageId")
 
         val bookmark = MessageBookmark(
@@ -35,11 +37,11 @@ class MessageBookmarkService(
         return bookmarkPort.saveBookmark(bookmark)
     }
 
-    override fun removeBookmark(messageId: String, userId: Long) {
+    override fun removeBookmark(messageId: MessageId, userId: UserId) {
         bookmarkPort.deleteBookmark(messageId, userId)
     }
 
-    override fun getBookmarks(userId: Long, roomId: Long?): List<MessageBookmark> {
+    override fun getBookmarks(userId: UserId, roomId: Long?): List<MessageBookmark> {
         return bookmarkPort.findBookmarksByUser(userId, roomId)
     }
 }

--- a/src/main/kotlin/com/stark/shoot/domain/chat/bookmark/MessageBookmark.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/bookmark/MessageBookmark.kt
@@ -1,5 +1,7 @@
 package com.stark.shoot.domain.chat.bookmark
 
+import com.stark.shoot.domain.common.vo.MessageId
+import com.stark.shoot.domain.common.vo.UserId
 import java.time.Instant
 
 /**
@@ -7,7 +9,7 @@ import java.time.Instant
  */
 data class MessageBookmark(
     val id: String? = null,
-    val messageId: String,
-    val userId: Long,
+    val messageId: MessageId,
+    val userId: UserId,
     val createdAt: Instant = Instant.now(),
 )

--- a/src/main/kotlin/com/stark/shoot/domain/common/vo/MessageId.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/common/vo/MessageId.kt
@@ -1,0 +1,13 @@
+package com.stark.shoot.domain.common.vo
+
+@JvmInline
+value class MessageId private constructor(val value: String) {
+    companion object {
+        fun from(value: String): MessageId {
+            require(value.isNotBlank()) { "메시지 ID는 비어있을 수 없습니다." }
+            return MessageId(value)
+        }
+    }
+
+    override fun toString(): String = value
+}

--- a/src/main/kotlin/com/stark/shoot/domain/common/vo/UserId.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/common/vo/UserId.kt
@@ -1,0 +1,13 @@
+package com.stark.shoot.domain.common.vo
+
+@JvmInline
+value class UserId private constructor(val value: Long) {
+    companion object {
+        fun from(value: Long): UserId {
+            require(value > 0) { "사용자 ID는 양수여야 합니다." }
+            return UserId(value)
+        }
+    }
+
+    override fun toString(): String = value.toString()
+}

--- a/src/test/kotlin/com/stark/shoot/domain/chat/bookmark/MessageBookmarkTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/chat/bookmark/MessageBookmarkTest.kt
@@ -1,5 +1,7 @@
 package com.stark.shoot.domain.chat.bookmark
 
+import com.stark.shoot.domain.common.vo.MessageId
+import com.stark.shoot.domain.common.vo.UserId
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -14,11 +16,14 @@ class MessageBookmarkTest {
     inner class CreateBookmark {
         @Test
         fun `필수 정보로 북마크를 생성할 수 있다`() {
-            val bookmark = MessageBookmark(messageId = "m1", userId = 1L)
+            val bookmark = MessageBookmark(
+                messageId = MessageId.from("m1"),
+                userId = UserId.from(1L)
+            )
 
             assertThat(bookmark.id).isNull()
-            assertThat(bookmark.messageId).isEqualTo("m1")
-            assertThat(bookmark.userId).isEqualTo(1L)
+            assertThat(bookmark.messageId).isEqualTo(MessageId.from("m1"))
+            assertThat(bookmark.userId).isEqualTo(UserId.from(1L))
             assertThat(bookmark.createdAt).isNotNull()
         }
 
@@ -27,14 +32,14 @@ class MessageBookmarkTest {
             val now = Instant.now()
             val bookmark = MessageBookmark(
                 id = "b1",
-                messageId = "m1",
-                userId = 2L,
+                messageId = MessageId.from("m1"),
+                userId = UserId.from(2L),
                 createdAt = now
             )
 
             assertThat(bookmark.id).isEqualTo("b1")
-            assertThat(bookmark.messageId).isEqualTo("m1")
-            assertThat(bookmark.userId).isEqualTo(2L)
+            assertThat(bookmark.messageId).isEqualTo(MessageId.from("m1"))
+            assertThat(bookmark.userId).isEqualTo(UserId.from(2L))
             assertThat(bookmark.createdAt).isEqualTo(now)
         }
     }


### PR DESCRIPTION
## Summary
- introduce `MessageId` and `UserId` value objects for better type safety
- apply the new value objects to message bookmark domain model
- adapt bookmark ports, service and MongoDB adapter
- update tests for bookmark to use value objects

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685516bef54083208e4010fc7ba37975