### PR TITLE
Introduce FriendGroupName value object

### DIFF
--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/user/group/FriendGroupPersistenceAdapter.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/user/group/FriendGroupPersistenceAdapter.kt
@@ -27,7 +27,7 @@ class FriendGroupPersistenceAdapter(
 
         val entity: FriendGroupEntity = if (group.id != null) {
             val existing = groupRepository.findById(group.id).orElseThrow { ResourceNotFoundException("그룹을 찾을 수 없습니다: ${group.id}") }
-            existing.name = group.name
+            existing.name = group.name.value
             existing.description = group.description
             existing
         } else {

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/mapper/FriendGroupMapper.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/mapper/FriendGroupMapper.kt
@@ -3,6 +3,7 @@ package com.stark.shoot.adapter.out.persistence.postgres.mapper
 import com.stark.shoot.adapter.out.persistence.postgres.entity.FriendGroupEntity
 import com.stark.shoot.adapter.out.persistence.postgres.entity.UserEntity
 import com.stark.shoot.domain.chat.user.FriendGroup
+import com.stark.shoot.domain.chat.user.FriendGroupName
 import org.springframework.stereotype.Component
 
 @Component
@@ -11,7 +12,7 @@ class FriendGroupMapper {
         return FriendGroup(
             id = entity.id,
             ownerId = entity.owner.id,
-            name = entity.name,
+            name = FriendGroupName.from(entity.name),
             description = entity.description,
             memberIds = memberIds,
             createdAt = entity.createdAt,
@@ -22,7 +23,7 @@ class FriendGroupMapper {
     fun toEntity(domain: FriendGroup, owner: UserEntity): FriendGroupEntity {
         return FriendGroupEntity(
             owner = owner,
-            name = domain.name,
+            name = domain.name.value,
             description = domain.description
         )
     }

--- a/src/main/kotlin/com/stark/shoot/domain/chat/user/FriendGroup.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/user/FriendGroup.kt
@@ -1,6 +1,7 @@
 package com.stark.shoot.domain.chat.user
 
 import java.time.Instant
+import com.stark.shoot.domain.chat.user.FriendGroupName
 
 /**
  * 친구를 그룹화하여 관리하기 위한 애그리게이트
@@ -8,7 +9,7 @@ import java.time.Instant
 data class FriendGroup(
     val id: Long? = null,
     val ownerId: Long,
-    val name: String,
+    val name: FriendGroupName,
     val description: String? = null,
     val memberIds: Set<Long> = emptySet(),
     val createdAt: Instant = Instant.now(),
@@ -16,8 +17,8 @@ data class FriendGroup(
 ) {
     /** 그룹 이름 변경 */
     fun rename(newName: String): FriendGroup {
-        require(newName.isNotBlank()) { "그룹 이름은 비어있을 수 없습니다." }
-        return copy(name = newName, updatedAt = Instant.now())
+        val nameVo = FriendGroupName.from(newName)
+        return copy(name = nameVo, updatedAt = Instant.now())
     }
 
     /** 그룹 설명 업데이트 */

--- a/src/main/kotlin/com/stark/shoot/domain/chat/user/FriendGroupName.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/user/FriendGroupName.kt
@@ -1,0 +1,14 @@
+package com.stark.shoot.domain.chat.user
+
+@JvmInline
+value class FriendGroupName private constructor(val value: String) {
+    companion object {
+        fun from(value: String): FriendGroupName {
+            require(value.isNotBlank()) { "그룹 이름은 비어있을 수 없습니다." }
+            require(value.length <= 50) { "그룹 이름은 50자 이하여야 합니다." }
+            return FriendGroupName(value)
+        }
+    }
+
+    override fun toString(): String = value
+}

--- a/src/main/kotlin/com/stark/shoot/domain/service/user/group/FriendGroupDomainService.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/service/user/group/FriendGroupDomainService.kt
@@ -1,11 +1,12 @@
 package com.stark.shoot.domain.service.user.group
 
 import com.stark.shoot.domain.chat.user.FriendGroup
+import com.stark.shoot.domain.chat.user.FriendGroupName
 
 class FriendGroupDomainService {
     fun create(ownerId: Long, name: String, description: String?): FriendGroup {
-        require(name.isNotBlank()) { "그룹 이름은 비어있을 수 없습니다." }
-        return FriendGroup(ownerId = ownerId, name = name, description = description)
+        val nameVo = FriendGroupName.from(name)
+        return FriendGroup(ownerId = ownerId, name = nameVo, description = description)
     }
 
     fun rename(group: FriendGroup, newName: String): FriendGroup = group.rename(newName)

--- a/src/test/kotlin/com/stark/shoot/domain/chat/user/FriendGroupTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/chat/user/FriendGroupTest.kt
@@ -1,6 +1,7 @@
 package com.stark.shoot.domain.chat.user
 
 import org.assertj.core.api.Assertions.assertThat
+import com.stark.shoot.domain.chat.user.FriendGroupName
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -14,15 +15,15 @@ class FriendGroupTest {
 
         @Test
         fun `그룹 이름을 변경할 수 있다`() {
-            val group = FriendGroup(ownerId = 1L, name = "친구들")
+            val group = FriendGroup(ownerId = 1L, name = FriendGroupName.from("친구들"))
             val updated = group.rename("베프")
-            assertThat(updated.name).isEqualTo("베프")
+            assertThat(updated.name.value).isEqualTo("베프")
             assertThat(updated.updatedAt).isNotNull()
         }
 
         @Test
         fun `그룹 설명을 수정할 수 있다`() {
-            val group = FriendGroup(ownerId = 1L, name = "친구들")
+            val group = FriendGroup(ownerId = 1L, name = FriendGroupName.from("친구들"))
             val updated = group.updateDescription("오래된 친구")
             assertThat(updated.description).isEqualTo("오래된 친구")
             assertThat(updated.updatedAt).isNotNull()
@@ -35,28 +36,28 @@ class FriendGroupTest {
 
         @Test
         fun `멤버를 추가할 수 있다`() {
-            val group = FriendGroup(ownerId = 1L, name = "친구들")
+            val group = FriendGroup(ownerId = 1L, name = FriendGroupName.from("친구들"))
             val updated = group.addMember(2L)
             assertThat(updated.memberIds).contains(2L)
         }
 
         @Test
         fun `이미 있는 멤버를 추가하면 변경이 없다`() {
-            val group = FriendGroup(ownerId = 1L, name = "친구들", memberIds = setOf(2L))
+            val group = FriendGroup(ownerId = 1L, name = FriendGroupName.from("친구들"), memberIds = setOf(2L))
             val updated = group.addMember(2L)
             assertThat(updated).isEqualTo(group)
         }
 
         @Test
         fun `멤버를 제거할 수 있다`() {
-            val group = FriendGroup(ownerId = 1L, name = "친구들", memberIds = setOf(2L, 3L))
+            val group = FriendGroup(ownerId = 1L, name = FriendGroupName.from("친구들"), memberIds = setOf(2L, 3L))
             val updated = group.removeMember(2L)
             assertThat(updated.memberIds).doesNotContain(2L)
         }
 
         @Test
         fun `존재하지 않는 멤버를 제거하면 변경이 없다`() {
-            val group = FriendGroup(ownerId = 1L, name = "친구들", memberIds = setOf(2L))
+            val group = FriendGroup(ownerId = 1L, name = FriendGroupName.from("친구들"), memberIds = setOf(2L))
             val updated = group.removeMember(3L)
             assertThat(updated).isEqualTo(group)
         }

--- a/src/test/kotlin/com/stark/shoot/domain/service/user/FriendGroupDomainServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/service/user/FriendGroupDomainServiceTest.kt
@@ -1,6 +1,7 @@
 package com.stark.shoot.domain.service.user
 
 import com.stark.shoot.domain.chat.user.FriendGroup
+import com.stark.shoot.domain.chat.user.FriendGroupName
 import com.stark.shoot.domain.service.user.group.FriendGroupDomainService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
@@ -20,6 +21,6 @@ class FriendGroupDomainServiceTest {
     fun `그룹 이름을 변경할 수 있다`() {
         val group = service.create(1L, "g1", null)
         val updated = service.rename(group, "new")
-        assertThat(updated.name).isEqualTo("new")
+        assertThat(updated.name.value).isEqualTo("new")
     }
 }


### PR DESCRIPTION
## Summary
- add `FriendGroupName` inline value class
- use `FriendGroupName` in `FriendGroup`
- adjust domain service and persistence mapper/adapter
- update tests for the new value object

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68551cf3e3f0832092e9dfdf1e557363