### PR TITLE
Introduce RetentionDays value object

### DIFF
--- a/src/main/kotlin/com/stark/shoot/domain/chat/room/ChatRoomSettings.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/room/ChatRoomSettings.kt
@@ -2,7 +2,7 @@ package com.stark.shoot.domain.chat.room
 
 data class ChatRoomSettings(
     val isNotificationEnabled: Boolean = true,
-    val retentionDays: Int? = null,
+    val retentionDays: RetentionDays? = null,
     val isEncrypted: Boolean = false,
     val customSettings: Map<String, Any> = emptyMap()
 ) {
@@ -27,7 +27,7 @@ data class ChatRoomSettings(
          */
         fun create(
             isNotificationEnabled: Boolean = true,
-            retentionDays: Int? = null,
+            retentionDays: RetentionDays? = null,
             isEncrypted: Boolean = false,
             customSettings: Map<String, Any> = emptyMap()
         ): ChatRoomSettings {
@@ -55,7 +55,7 @@ data class ChatRoomSettings(
      * @param days 보존할 일수 (null이면 무기한 보존)
      * @return 업데이트된 ChatRoomSettings 객체
      */
-    fun updateRetentionPolicy(days: Int?): ChatRoomSettings {
+    fun updateRetentionPolicy(days: RetentionDays?): ChatRoomSettings {
         return this.copy(retentionDays = days)
     }
 

--- a/src/main/kotlin/com/stark/shoot/domain/chat/room/RetentionDays.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/room/RetentionDays.kt
@@ -1,0 +1,13 @@
+package com.stark.shoot.domain.chat.room
+
+@JvmInline
+value class RetentionDays private constructor(val value: Int) {
+    companion object {
+        fun from(value: Int): RetentionDays {
+            require(value > 0) { "보존 기간은 1일 이상이어야 합니다." }
+            return RetentionDays(value)
+        }
+    }
+
+    override fun toString(): String = value.toString()
+}

--- a/src/test/kotlin/com/stark/shoot/domain/chat/room/ChatRoomSettingsTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/chat/room/ChatRoomSettingsTest.kt
@@ -5,6 +5,9 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
+/** 새 값 객체 사용을 위한 import */
+import com.stark.shoot.domain.chat.room.RetentionDays
+
 @DisplayName("채팅방 설정 테스트")
 class ChatRoomSettingsTest {
 
@@ -30,7 +33,7 @@ class ChatRoomSettingsTest {
         fun `사용자 지정 값으로 채팅방 설정을 생성할 수 있다`() {
             // given
             val isNotificationEnabled = false
-            val retentionDays = 30
+            val retentionDays = RetentionDays.from(30)
             val isEncrypted = true
             val customSettings = mapOf("theme" to "dark", "fontSize" to 14)
             
@@ -98,7 +101,7 @@ class ChatRoomSettingsTest {
         fun `메시지 보존 기간을 설정할 수 있다`() {
             // given
             val settings = ChatRoomSettings(retentionDays = null)
-            val newRetentionDays = 14
+            val newRetentionDays = RetentionDays.from(14)
             
             // when
             val updatedSettings = settings.updateRetentionPolicy(newRetentionDays)
@@ -115,7 +118,7 @@ class ChatRoomSettingsTest {
         @DisplayName("메시지 보존 기간을 무기한으로 설정할 수 있다")
         fun `메시지 보존 기간을 무기한으로 설정할 수 있다`() {
             // given
-            val settings = ChatRoomSettings(retentionDays = 30)
+            val settings = ChatRoomSettings(retentionDays = RetentionDays.from(30))
             
             // when
             val updatedSettings = settings.updateRetentionPolicy(null)


### PR DESCRIPTION
## Summary
- add `RetentionDays` value class
- refactor `ChatRoomSettings` to use `RetentionDays`
- update `ChatRoomSettingsTest` for new value object

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*
- `./gradlew test --offline` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685520d074348320997186ab9948ee3b