### PR TITLE
Refactor notification domain to use UserId VO

### DIFF
--- a/src/main/kotlin/com/stark/shoot/adapter/in/event/notification/ChatNotificationFactory.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/event/notification/ChatNotificationFactory.kt
@@ -3,6 +3,7 @@ package com.stark.shoot.adapter.`in`.event.notification
 import com.stark.shoot.domain.chat.message.ChatMessage
 import com.stark.shoot.domain.notification.Notification
 import com.stark.shoot.domain.notification.NotificationType
+import com.stark.shoot.domain.common.vo.UserId
 import org.springframework.stereotype.Component
 
 /**
@@ -23,7 +24,7 @@ class ChatNotificationFactory {
         val truncatedText = truncateMessageText(message.content.text)
 
         return Notification.fromChatEvent(
-            userId = userId,
+            userId = UserId.from(userId),
             title = "새로운 멘션",
             message = "메시지에서 언급되었습니다: $truncatedText",
             type = NotificationType.MENTION,
@@ -43,7 +44,7 @@ class ChatNotificationFactory {
         val truncatedText = truncateMessageText(message.content.text)
 
         return Notification.fromChatEvent(
-            userId = userId,
+            userId = UserId.from(userId),
             title = "새로운 메시지",
             message = truncatedText,
             type = NotificationType.NEW_MESSAGE,
@@ -98,7 +99,7 @@ class ChatNotificationFactory {
         reactionType: String
     ): Notification {
         return Notification.fromChatEvent(
-            userId = userId,
+            userId = UserId.from(userId),
             title = "새로운 반응",
             message = "내 메시지에 새로운 반응이 추가되었습니다",
             type = NotificationType.REACTION,

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/notification/NotificationResponse.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/notification/NotificationResponse.kt
@@ -22,7 +22,7 @@ data class NotificationResponse(
         fun from(notification: Notification): NotificationResponse {
             return NotificationResponse(
                 id = notification.id?.value,
-                userId = notification.userId,
+                userId = notification.userId.value,
                 title = notification.title.value,
                 message = notification.message.value,
                 type = notification.type.name,

--- a/src/main/kotlin/com/stark/shoot/adapter/out/kafka/notification/SendNotificationKafkaAdapter.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/kafka/notification/SendNotificationKafkaAdapter.kt
@@ -31,7 +31,7 @@ class SendNotificationKafkaAdapter(
     override fun sendNotification(notification: Notification) {
         try {
             // 사용자 ID를 파티션 키로 사용하여 같은 사용자의 알림이 순서대로 처리되도록 함
-            val key = notification.userId.toString()
+            val key = notification.userId.value.toString()
             val notificationJson = objectMapper.writeValueAsString(notification)
             
             // Kafka 토픽에 알림 발행
@@ -42,7 +42,7 @@ class SendNotificationKafkaAdapter(
                     logger.error(ex) { "Kafka를 통한 알림 전송 중 오류가 발생했습니다: ${ex.message}" }
                     throw KafkaPublishException("Kafka를 통한 알림 전송 중 오류가 발생했습니다: ${ex.message}", ex)
                 } else {
-                    logger.info { "알림이 Kafka 토픽에 발행되었습니다: userId=${notification.userId}, type=${notification.type}, offset=${result.recordMetadata.offset()}" }
+                    logger.info { "알림이 Kafka 토픽에 발행되었습니다: userId=${notification.userId.value}, type=${notification.type}, offset=${result.recordMetadata.offset()}" }
                 }
             }
         } catch (e: Exception) {

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/document/notification/NotificationDocument.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/document/notification/NotificationDocument.kt
@@ -6,6 +6,7 @@ import com.stark.shoot.domain.notification.NotificationType
 import com.stark.shoot.domain.notification.SourceType
 import com.stark.shoot.domain.notification.NotificationTitle
 import com.stark.shoot.domain.notification.NotificationMessage
+import com.stark.shoot.domain.common.vo.UserId
 import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.index.Indexed
 import org.springframework.data.mongodb.core.mapping.Document
@@ -43,7 +44,7 @@ data class NotificationDocument(
     fun toDomain(): Notification {
         return Notification(
             id = id?.let { NotificationId.from(it) },
-            userId = userId,
+            userId = UserId.from(userId),
             title = NotificationTitle.from(title),
             message = NotificationMessage.from(message),
             type = NotificationType.valueOf(type),
@@ -60,7 +61,7 @@ data class NotificationDocument(
         fun fromDomain(notification: Notification): NotificationDocument {
             return NotificationDocument(
                 id = notification.id?.value,
-                userId = notification.userId,
+                userId = notification.userId.value,
                 title = notification.title.value,
                 message = notification.message.value,
                 type = notification.type.name,

--- a/src/main/kotlin/com/stark/shoot/adapter/out/redis/notification/SendNotificationRedisAdapter.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/redis/notification/SendNotificationRedisAdapter.kt
@@ -30,13 +30,13 @@ class SendNotificationRedisAdapter(
      */
     override fun sendNotification(notification: Notification) {
         try {
-            val channel = "$NOTIFICATION_CHANNEL_PREFIX${notification.userId}"
+            val channel = "$NOTIFICATION_CHANNEL_PREFIX${notification.userId.value}"
             val notificationJson = objectMapper.writeValueAsString(notification)
             
             // Redis pub/sub 채널에 알림 발행
             val result = redisTemplate.convertAndSend(channel, notificationJson)
             
-            logger.info { "알림이 Redis 채널에 발행되었습니다: userId=${notification.userId}, type=${notification.type}, result=$result" }
+            logger.info { "알림이 Redis 채널에 발행되었습니다: userId=${notification.userId.value}, type=${notification.type}, result=$result" }
         } catch (e: Exception) {
             val errorMessage = "Redis를 통한 알림 전송 중 오류가 발생했습니다: ${e.message}"
             logger.error(e) { errorMessage }
@@ -63,7 +63,7 @@ class SendNotificationRedisAdapter(
             
             // 각 사용자별로 알림 전송
             notificationsByUser.forEach { (userId, userNotifications) ->
-                val channel = "$NOTIFICATION_CHANNEL_PREFIX$userId"
+                val channel = "$NOTIFICATION_CHANNEL_PREFIX${userId.value}"
                 
                 // 각 알림을 개별적으로 발행
                 userNotifications.forEach { notification ->

--- a/src/main/kotlin/com/stark/shoot/application/service/notification/NotificationManagementService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/notification/NotificationManagementService.kt
@@ -8,6 +8,7 @@ import com.stark.shoot.domain.notification.Notification
 import com.stark.shoot.domain.notification.NotificationId
 import com.stark.shoot.domain.notification.NotificationType
 import com.stark.shoot.domain.notification.SourceType
+import com.stark.shoot.domain.common.vo.UserId
 import com.stark.shoot.domain.notification.service.NotificationDomainService
 import com.stark.shoot.infrastructure.exception.web.MongoOperationException
 import com.stark.shoot.infrastructure.exception.web.ResourceNotFoundException
@@ -50,7 +51,7 @@ class NotificationManagementService(
             ?: throw ResourceNotFoundException("알림을 찾을 수 없습니다: $notificationId")
 
         // 도메인 모델의 메서드를 사용하여 소유권 검증
-        notification.validateOwnership(userId)
+        notification.validateOwnership(UserId.from(userId))
 
         // 이미 읽은 알림인 경우 바로 반환
         if (notification.isRead) {
@@ -172,7 +173,7 @@ class NotificationManagementService(
             ?: throw ResourceNotFoundException("알림을 찾을 수 없습니다: $notificationId")
 
         // 도메인 모델의 메서드를 사용하여 소유권 검증
-        notification.validateOwnership(userId)
+        notification.validateOwnership(UserId.from(userId))
 
         // 알림 삭제 (소프트 삭제 방식)
         val deletedNotification = notification.markAsDeleted()

--- a/src/main/kotlin/com/stark/shoot/domain/notification/Notification.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/notification/Notification.kt
@@ -5,6 +5,7 @@ import com.stark.shoot.domain.notification.event.NotificationEvent
 import com.stark.shoot.domain.notification.NotificationTitle
 import com.stark.shoot.domain.notification.NotificationId
 import com.stark.shoot.domain.notification.NotificationMessage
+import com.stark.shoot.domain.common.vo.UserId
 import java.time.Instant
 
 /**
@@ -15,7 +16,7 @@ import java.time.Instant
  */
 class Notification(
     val id: NotificationId? = null,
-    val userId: Long,
+    val userId: UserId,
     val title: NotificationTitle,
     val message: NotificationMessage,
     val type: NotificationType,
@@ -62,7 +63,7 @@ class Notification(
      * @param userId 확인할 사용자 ID
      * @return 사용자에게 속하면 true, 아니면 false
      */
-    fun belongsToUser(userId: Long): Boolean {
+    fun belongsToUser(userId: UserId): Boolean {
         return this.userId == userId
     }
 
@@ -72,7 +73,7 @@ class Notification(
      * @param userId 확인할 사용자 ID
      * @throws NotificationException 알림이 해당 사용자의 것이 아닌 경우
      */
-    fun validateOwnership(userId: Long) {
+    fun validateOwnership(userId: UserId) {
         if (!belongsToUser(userId)) {
             throw NotificationException("알림이 해당 사용자의 것이 아닙니다: ${this.id}", "NOTIFICATION_OWNERSHIP_INVALID")
         }
@@ -118,7 +119,7 @@ class Notification(
          * @return 생성된 알림 객체
          */
         fun fromChatEvent(
-            userId: Long,
+            userId: UserId,
             title: String,
             message: String,
             type: NotificationType,
@@ -143,7 +144,7 @@ class Notification(
          * @param recipientId 수신자 ID
          * @return 생성된 알림 객체
          */
-        fun fromEvent(event: NotificationEvent, recipientId: Long): Notification {
+        fun fromEvent(event: NotificationEvent, recipientId: UserId): Notification {
             return Notification(
                 userId = recipientId,
                 title = NotificationTitle.from(event.getTitle()),
@@ -168,7 +169,7 @@ class Notification(
          * @return 생성된 알림 객체
          */
         fun create(
-            userId: Long,
+            userId: UserId,
             title: String,
             message: String,
             type: NotificationType,

--- a/src/main/kotlin/com/stark/shoot/domain/notification/NotificationSettings.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/notification/NotificationSettings.kt
@@ -1,12 +1,13 @@
 package com.stark.shoot.domain.notification
 
 import java.time.Instant
+import com.stark.shoot.domain.common.vo.UserId
 
 /**
  * 사용자별 알림 설정을 관리하는 애그리게이트
  */
 data class NotificationSettings(
-    val userId: Long,
+    val userId: UserId,
     val preferences: Map<NotificationType, Boolean> = emptyMap(),
     val createdAt: Instant = Instant.now(),
     val updatedAt: Instant? = null,

--- a/src/main/kotlin/com/stark/shoot/domain/notification/event/MentionEvent.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/notification/event/MentionEvent.kt
@@ -2,15 +2,16 @@ package com.stark.shoot.domain.notification.event
 
 import com.stark.shoot.domain.notification.NotificationType
 import com.stark.shoot.domain.notification.SourceType
+import com.stark.shoot.domain.common.vo.UserId
 import java.time.Instant
 
 class MentionEvent(
     id: String? = null,
     val roomId: Long,
     val messageId: String,
-    val senderId: Long,
+    val senderId: UserId,
     val senderName: String,
-    val mentionedUserIds: Set<Long>,
+    val mentionedUserIds: Set<UserId>,
     val messageContent: String,
     timestamp: Instant = Instant.now(),
     metadata: Map<String, Any> = emptyMap()
@@ -23,7 +24,7 @@ class MentionEvent(
     metadata = metadata
 ) {
 
-    override fun getRecipients(): Set<Long> = mentionedUserIds
+    override fun getRecipients(): Set<UserId> = mentionedUserIds
 
     override fun getTitle(): String = "$senderName mentioned you"
 

--- a/src/main/kotlin/com/stark/shoot/domain/notification/event/NewMessageEvent.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/notification/event/NewMessageEvent.kt
@@ -2,15 +2,16 @@ package com.stark.shoot.domain.notification.event
 
 import com.stark.shoot.domain.notification.NotificationType
 import com.stark.shoot.domain.notification.SourceType
+import com.stark.shoot.domain.common.vo.UserId
 import java.time.Instant
 
 class NewMessageEvent(
     id: String? = null,
     val roomId: Long,
-    val senderId: Long,
+    val senderId: UserId,
     val senderName: String,
     val messageContent: String,
-    val recipientIds: Set<Long>,
+    val recipientIds: Set<UserId>,
     timestamp: Instant = Instant.now(),
     metadata: Map<String, Any> = emptyMap()
 ) : NotificationEvent(
@@ -22,7 +23,7 @@ class NewMessageEvent(
     metadata = metadata
 ) {
 
-    override fun getRecipients(): Set<Long> = recipientIds
+    override fun getRecipients(): Set<UserId> = recipientIds
 
     override fun getTitle(): String = "New message from $senderName"
 

--- a/src/main/kotlin/com/stark/shoot/domain/notification/event/NotificationEvent.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/notification/event/NotificationEvent.kt
@@ -2,6 +2,7 @@ package com.stark.shoot.domain.notification.event
 
 import com.stark.shoot.domain.notification.NotificationType
 import com.stark.shoot.domain.notification.SourceType
+import com.stark.shoot.domain.common.vo.UserId
 import java.time.Instant
 
 abstract class NotificationEvent(
@@ -13,7 +14,7 @@ abstract class NotificationEvent(
     val metadata: Map<String, Any> = emptyMap()
 ) {
 
-    abstract fun getRecipients(): Set<Long>
+    abstract fun getRecipients(): Set<UserId>
 
     abstract fun getTitle(): String
 

--- a/src/main/kotlin/com/stark/shoot/domain/notification/service/NotificationDomainService.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/notification/service/NotificationDomainService.kt
@@ -2,6 +2,7 @@ package com.stark.shoot.domain.notification.service
 
 import com.stark.shoot.domain.notification.Notification
 import com.stark.shoot.domain.notification.event.NotificationEvent
+import com.stark.shoot.domain.common.vo.UserId
 
 /**
  * 알림 도메인 서비스

--- a/src/test/kotlin/com/stark/shoot/domain/notification/NotificationSettingsTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/notification/NotificationSettingsTest.kt
@@ -3,24 +3,25 @@ package com.stark.shoot.domain.notification
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import com.stark.shoot.domain.common.vo.UserId
 
 class NotificationSettingsTest {
     @Test
     fun defaultAllEnabled() {
-        val settings = NotificationSettings(userId = 1L)
+        val settings = NotificationSettings(userId = UserId.from(1L))
         assertTrue(settings.isEnabled(NotificationType.NEW_MESSAGE))
     }
 
     @Test
     fun updatePreference() {
-        val settings = NotificationSettings(userId = 1L)
+        val settings = NotificationSettings(userId = UserId.from(1L))
             .updatePreference(NotificationType.NEW_MESSAGE, false)
         assertFalse(settings.isEnabled(NotificationType.NEW_MESSAGE))
     }
 
     @Test
     fun updateAll() {
-        val settings = NotificationSettings(userId = 1L)
+        val settings = NotificationSettings(userId = UserId.from(1L))
             .updateAll(mapOf(NotificationType.MENTION to false))
         assertFalse(settings.isEnabled(NotificationType.MENTION))
         assertTrue(settings.isEnabled(NotificationType.NEW_MESSAGE))

--- a/src/test/kotlin/com/stark/shoot/domain/notification/NotificationTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/notification/NotificationTest.kt
@@ -4,12 +4,13 @@ import com.stark.shoot.domain.exception.NotificationException
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
+import com.stark.shoot.domain.common.vo.UserId
 
 class NotificationTest {
     @Test
     fun markReadAndDelete() {
         val n = Notification.create(
-            userId = 1L,
+            userId = UserId.from(1L),
             title = "t",
             message = "m",
             type = NotificationType.NEW_MESSAGE,
@@ -25,13 +26,13 @@ class NotificationTest {
     @Test
     fun validateOwnershipThrows() {
         val n = Notification.create(
-            userId = 1L,
+            userId = UserId.from(1L),
             title = "t",
             message = "m",
             type = NotificationType.NEW_MESSAGE,
             sourceId = "s",
             sourceType = SourceType.CHAT
         )
-        assertFailsWith<NotificationException> { n.validateOwnership(2L) }
+        assertFailsWith<NotificationException> { n.validateOwnership(UserId.from(2L)) }
     }
 }

--- a/src/test/kotlin/com/stark/shoot/domain/notification/service/NotificationDomainServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/notification/service/NotificationDomainServiceTest.kt
@@ -4,6 +4,7 @@ import com.stark.shoot.domain.notification.Notification
 import com.stark.shoot.domain.notification.NotificationType
 import com.stark.shoot.domain.notification.SourceType
 import com.stark.shoot.domain.notification.event.NotificationEvent
+import com.stark.shoot.domain.common.vo.UserId
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -12,7 +13,7 @@ class NotificationDomainServiceTest {
 
     @Test
     fun markAsReadAndDeleted() {
-        val n = Notification.create(1L, "t", "m", NotificationType.NEW_MESSAGE, "s", SourceType.CHAT)
+        val n = Notification.create(UserId.from(1L), "t", "m", NotificationType.NEW_MESSAGE, "s", SourceType.CHAT)
         val read = service.markNotificationsAsRead(listOf(n))
         val deleted = service.markNotificationsAsDeleted(read)
         assertEquals(true, deleted[0].isDeleted)
@@ -20,7 +21,7 @@ class NotificationDomainServiceTest {
 
     @Test
     fun filterUnread() {
-        val n1 = Notification.create(1L, "t", "m", NotificationType.NEW_MESSAGE, "s", SourceType.CHAT)
+        val n1 = Notification.create(UserId.from(1L), "t", "m", NotificationType.NEW_MESSAGE, "s", SourceType.CHAT)
         val n2 = n1.markAsRead()
         val unread = service.filterUnread(listOf(n1, n2))
         assertEquals(1, unread.size)
@@ -33,13 +34,13 @@ class NotificationDomainServiceTest {
             sourceId = "1",
             sourceType = SourceType.CHAT
         ) {
-            override fun getRecipients(): Set<Long> = setOf(1L, 2L)
+            override fun getRecipients(): Set<UserId> = setOf(UserId.from(1L), UserId.from(2L))
             override fun getTitle(): String = "title"
             override fun getMessage(): String = "msg"
         }
 
         val result = service.createNotificationsFromEvent(event)
         assertEquals(2, result.size)
-        assertEquals(setOf(1L, 2L), result.map { it.userId }.toSet())
+        assertEquals(setOf(UserId.from(1L), UserId.from(2L)), result.map { it.userId }.toSet())
     }
 }


### PR DESCRIPTION
## Summary
- use `UserId` value object in notification entities
- update related events and services
- adapt adapters and DTOs for the new type
- update unit tests

## Testing
- `./gradlew test --no-daemon` *(failed: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685525f9822883209ddb079af1e9b3fd