### PR TITLE
Add value object for chat room announcement

### DIFF
--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/chatroom/ChatRoomNoticeController.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/chatroom/ChatRoomNoticeController.kt
@@ -4,6 +4,7 @@ import com.stark.shoot.adapter.`in`.web.dto.ResponseDto
 import com.stark.shoot.adapter.`in`.web.dto.chatroom.AnnouncementRequest
 import com.stark.shoot.adapter.`in`.web.dto.chatroom.TitleRequest
 import com.stark.shoot.application.port.`in`.chatroom.ManageChatRoomUseCase
+import com.stark.shoot.domain.chat.room.ChatRoomAnnouncement
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.*
@@ -21,7 +22,8 @@ class ChatRoomNoticeController(
         @PathVariable roomId: Long,
         @RequestBody request: AnnouncementRequest
     ): ResponseDto<Unit> {
-        manageChatRoomUseCase.updateAnnouncement(roomId, request.announcement)
+        val announcement = request.announcement?.let { ChatRoomAnnouncement.from(it) }
+        manageChatRoomUseCase.updateAnnouncement(roomId, announcement)
         return ResponseDto.success(Unit, "공지사항이 업데이트되었습니다.")
     }
 

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/chatroom/SaveChatRoomPersistenceAdapter.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/chatroom/SaveChatRoomPersistenceAdapter.kt
@@ -36,7 +36,7 @@ class SaveChatRoomPersistenceAdapter(
             existingEntity.update(
                 title = chatRoom.title?.value,
                 type = chatRoom.type,
-                announcement = chatRoom.announcement,
+                announcement = chatRoom.announcement?.value,
                 lastMessageId = chatRoom.lastMessageId?.toLongOrNull(),
                 lastActiveAt = chatRoom.lastActiveAt
             )

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/mapper/ChatRoomMapper.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/mapper/ChatRoomMapper.kt
@@ -5,6 +5,7 @@ import com.stark.shoot.adapter.out.persistence.postgres.entity.ChatRoomUserEntit
 import com.stark.shoot.domain.chat.room.ChatRoom
 import com.stark.shoot.domain.chat.room.ChatRoomType
 import com.stark.shoot.domain.chat.room.ChatRoomTitle
+import com.stark.shoot.domain.chat.room.ChatRoomAnnouncement
 import org.springframework.stereotype.Component
 
 @Component
@@ -31,7 +32,7 @@ class ChatRoomMapper {
             id = entity.id,
             title = entity.title?.let { ChatRoomTitle.from(it) },
             type = domainType,
-            announcement = entity.announcement,
+            announcement = entity.announcement?.let { ChatRoomAnnouncement.from(it) },
             participants = participantIds,
             pinnedParticipants = pinnedParticipantIds,
             lastMessageId = entity.lastMessageId?.toString(),
@@ -48,7 +49,7 @@ class ChatRoomMapper {
         return ChatRoomEntity(
             title = domain.title?.value,
             type = domain.type,
-            announcement = domain.announcement,
+            announcement = domain.announcement?.value,
             lastMessageId = lastMessageIdLong,
             lastActiveAt = domain.lastActiveAt
         )

--- a/src/main/kotlin/com/stark/shoot/application/port/in/chatroom/ManageChatRoomUseCase.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/chatroom/ManageChatRoomUseCase.kt
@@ -1,9 +1,11 @@
 package com.stark.shoot.application.port.`in`.chatroom
 
+import com.stark.shoot.domain.chat.room.ChatRoomAnnouncement
+
 interface ManageChatRoomUseCase {
     fun addParticipant(roomId: Long, userId: Long): Boolean
     fun removeParticipant(roomId: Long, userId: Long): Boolean
-    fun updateAnnouncement(roomId: Long, announcement: String?)
+    fun updateAnnouncement(roomId: Long, announcement: ChatRoomAnnouncement?)
 
     /**
      * 채팅방 제목을 업데이트합니다.

--- a/src/main/kotlin/com/stark/shoot/application/service/chatroom/ManageChatRoomService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/chatroom/ManageChatRoomService.kt
@@ -8,6 +8,7 @@ import com.stark.shoot.application.port.out.user.FindUserPort
 import com.stark.shoot.domain.chat.room.ChatRoom
 import com.stark.shoot.domain.service.chatroom.ChatRoomParticipantDomainService
 import com.stark.shoot.domain.chat.room.ChatRoomTitle
+import com.stark.shoot.domain.chat.room.ChatRoomAnnouncement
 import com.stark.shoot.infrastructure.annotation.UseCase
 import com.stark.shoot.infrastructure.exception.web.ResourceNotFoundException
 import org.springframework.transaction.annotation.Transactional
@@ -109,7 +110,7 @@ class ManageChatRoomService(
      */
     override fun updateAnnouncement(
         roomId: Long,
-        announcement: String?
+        announcement: ChatRoomAnnouncement?
     ) {
         withChatRoom(roomId) { chatRoom ->
             // 공지사항 업데이트 (도메인 객체의 메서드 사용)

--- a/src/main/kotlin/com/stark/shoot/domain/chat/room/ChatRoom.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/room/ChatRoom.kt
@@ -2,6 +2,7 @@ package com.stark.shoot.domain.chat.room
 
 import com.stark.shoot.domain.exception.FavoriteLimitExceededException
 import com.stark.shoot.domain.chat.room.ChatRoomTitle
+import com.stark.shoot.domain.chat.room.ChatRoomAnnouncement
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -16,7 +17,7 @@ data class ChatRoom(
     val createdAt: Instant = Instant.now(),
 
     // 필요한 경우에만 남길 선택적 필드
-    val announcement: String? = null,
+    val announcement: ChatRoomAnnouncement? = null,
     val pinnedParticipants: MutableSet<Long> = mutableSetOf(),
     val updatedAt: Instant? = null,
 ) {
@@ -120,7 +121,7 @@ data class ChatRoom(
         id: Long? = this.id,
         title: ChatRoomTitle? = this.title,
         type: ChatRoomType = this.type,
-        announcement: String? = this.announcement,
+        announcement: ChatRoomAnnouncement? = this.announcement,
         lastMessageId: String? = this.lastMessageId,
         lastActiveAt: Instant = this.lastActiveAt
     ): ChatRoom {
@@ -272,7 +273,7 @@ data class ChatRoom(
      * @param announcement 새 공지사항 (null인 경우 공지사항 삭제)
      * @return 업데이트된 ChatRoom 객체
      */
-    fun updateAnnouncement(announcement: String?): ChatRoom {
+    fun updateAnnouncement(announcement: ChatRoomAnnouncement?): ChatRoom {
         return this.copy(
             announcement = announcement,
             updatedAt = Instant.now()

--- a/src/main/kotlin/com/stark/shoot/domain/chat/room/ChatRoomAnnouncement.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/room/ChatRoomAnnouncement.kt
@@ -1,0 +1,14 @@
+package com.stark.shoot.domain.chat.room
+
+@JvmInline
+value class ChatRoomAnnouncement private constructor(val value: String) {
+    companion object {
+        fun from(value: String): ChatRoomAnnouncement {
+            require(value.isNotBlank()) { "채팅방 공지사항은 비어있을 수 없습니다." }
+            require(value.length <= 200) { "채팅방 공지사항은 200자 이하여야 합니다." }
+            return ChatRoomAnnouncement(value)
+        }
+    }
+
+    override fun toString(): String = value
+}

--- a/src/test/kotlin/com/stark/shoot/domain/chat/room/ChatRoomTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/chat/room/ChatRoomTest.kt
@@ -2,6 +2,7 @@ package com.stark.shoot.domain.chat.room
 
 import com.stark.shoot.domain.exception.FavoriteLimitExceededException
 import com.stark.shoot.domain.chat.room.ChatRoomTitle
+import com.stark.shoot.domain.chat.room.ChatRoomAnnouncement
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -74,7 +75,7 @@ class ChatRoomTest {
                 participants = mutableSetOf(1L, 2L)
             )
             val newTitle = "새 제목"
-            val newAnnouncement = "새 공지사항"
+            val newAnnouncement = ChatRoomAnnouncement.from("새 공지사항")
             val newLastMessageId = "message123"
             val newLastActiveAt = Instant.now().plusSeconds(3600)
 
@@ -105,7 +106,7 @@ class ChatRoomTest {
                 type = ChatRoomType.GROUP,
                 participants = mutableSetOf(1L, 2L)
             )
-            val newAnnouncement = "새 공지사항"
+            val newAnnouncement = ChatRoomAnnouncement.from("새 공지사항")
 
             // when
             val updatedChatRoom = chatRoom.updateAnnouncement(newAnnouncement)
@@ -123,7 +124,7 @@ class ChatRoomTest {
                 title = ChatRoomTitle.from("테스트 채팅방"),
                 type = ChatRoomType.GROUP,
                 participants = mutableSetOf(1L, 2L),
-                announcement = "기존 공지사항"
+                announcement = ChatRoomAnnouncement.from("기존 공지사항")
             )
 
             // when


### PR DESCRIPTION
## Summary
- introduce `ChatRoomAnnouncement` value object for validating announcement text
- refactor `ChatRoom` and service layers to use the new VO
- adapt persistence mappers, adapters, controllers and tests

## Testing
- `./gradlew test -q` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685528501298832096932989d9684c55