### PR TITLE
Introduce MessageId value object

### DIFF
--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/message/ChatMessageMapperExtensions.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/message/ChatMessageMapperExtensions.kt
@@ -4,6 +4,7 @@ import com.stark.shoot.domain.chat.message.ChatMessage
 import com.stark.shoot.domain.chat.message.ChatMessageMetadata
 import com.stark.shoot.domain.chat.message.MessageContent
 import com.stark.shoot.domain.chat.message.type.MessageStatus
+import com.stark.shoot.domain.common.vo.MessageId
 
 fun ChatMessageMetadataRequest.toDomain(): ChatMessageMetadata {
     return ChatMessageMetadata(
@@ -46,11 +47,11 @@ fun ChatMessageRequest.toDomain(): ChatMessage {
     val metadata = this.metadata.toDomain()
 
     return ChatMessage(
-        id = this.id,
+        id = this.id?.let { MessageId.from(it) },
         roomId = this.roomId,
         senderId = this.senderId,
         content = content,
-        threadId = this.threadId,
+        threadId = this.threadId?.let { MessageId.from(it) },
         status = this.status ?: MessageStatus.SAVED,
         readBy = this.readBy?.mapKeys { it.key.toLong() }?.toMutableMap() ?: mutableMapOf(),
         metadata = metadata

--- a/src/main/kotlin/com/stark/shoot/application/service/message/SendMessageService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/message/SendMessageService.kt
@@ -14,6 +14,7 @@ import com.stark.shoot.application.port.out.message.preview.ExtractUrlPort
 import com.stark.shoot.domain.chat.event.ChatEvent
 import com.stark.shoot.domain.chat.event.EventType
 import com.stark.shoot.domain.chat.message.ChatMessage
+import com.stark.shoot.domain.common.vo.MessageId
 import com.stark.shoot.infrastructure.annotation.UseCase
 import com.stark.shoot.infrastructure.config.async.ApplicationCoroutineScope
 import com.stark.shoot.infrastructure.exception.web.ErrorResponse
@@ -68,7 +69,7 @@ class SendMessageService(
             senderId = messageRequest.senderId,
             contentText = messageRequest.content.text,
             contentType = messageRequest.content.type,
-            threadId = messageRequest.threadId,
+            threadId = messageRequest.threadId?.let { MessageId.from(it) },
             extractUrls = { text -> extractUrlPort.extractUrls(text) },
             getCachedPreview = { url -> cacheUrlPreviewPort.getCachedUrlPreview(url) }
         )

--- a/src/main/kotlin/com/stark/shoot/domain/chat/message/ChatMessage.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/message/ChatMessage.kt
@@ -4,16 +4,17 @@ import com.stark.shoot.domain.chat.message.type.MessageStatus
 import com.stark.shoot.domain.chat.message.type.MessageType
 import com.stark.shoot.domain.chat.reaction.MessageReactions
 import com.stark.shoot.domain.chat.reaction.ReactionType
+import com.stark.shoot.domain.common.vo.MessageId
 import java.time.Instant
 
 data class ChatMessage(
-    val id: String? = null,
+    val id: MessageId? = null,
     val roomId: Long,
     val senderId: Long,
     val content: MessageContent,
     val status: MessageStatus,
-    val replyToMessageId: String? = null,
-    val threadId: String? = null,
+    val replyToMessageId: MessageId? = null,
+    val threadId: MessageId? = null,
     val expiresAt: Instant? = null,
     val messageReactions: MessageReactions = MessageReactions(),
     val mentions: Set<Long> = emptySet(),
@@ -301,7 +302,7 @@ data class ChatMessage(
             text: String,
             type: MessageType = MessageType.TEXT,
             tempId: String? = null,
-            threadId: String? = null,
+            threadId: MessageId? = null,
             expiresAt: Instant? = null
         ): ChatMessage {
             val content = MessageContent(

--- a/src/main/kotlin/com/stark/shoot/domain/chat/message/ScheduledMessage.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/message/ScheduledMessage.kt
@@ -1,10 +1,11 @@
 package com.stark.shoot.domain.chat.message
 
 import com.stark.shoot.domain.chat.message.ScheduledMessageStatus
+import com.stark.shoot.domain.common.vo.MessageId
 import java.time.Instant
 
 data class ScheduledMessage(
-    val id: String? = null,
+    val id: MessageId? = null,
     val roomId: Long,
     val senderId: Long,
     val content: MessageContent,

--- a/src/main/kotlin/com/stark/shoot/domain/service/message/MessageDomainService.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/service/message/MessageDomainService.kt
@@ -4,6 +4,7 @@ import com.stark.shoot.domain.chat.event.ChatEvent
 import com.stark.shoot.domain.chat.event.EventType
 import com.stark.shoot.domain.chat.message.ChatMessage
 import com.stark.shoot.domain.chat.message.UrlPreview
+import com.stark.shoot.domain.common.vo.MessageId
 import java.util.*
 
 /**
@@ -25,7 +26,7 @@ class MessageDomainService {
         senderId: Long,
         contentText: String,
         contentType: com.stark.shoot.domain.chat.message.type.MessageType,
-        threadId: String? = null,
+        threadId: MessageId? = null,
         extractUrls: (String) -> List<String>,
         getCachedPreview: (String) -> UrlPreview?
     ): ChatMessage {

--- a/src/test/kotlin/com/stark/shoot/application/service/message/PaginationMessageSyncServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/application/service/message/PaginationMessageSyncServiceTest.kt
@@ -12,6 +12,7 @@ import com.stark.shoot.application.port.out.message.LoadMessagePort
 import com.stark.shoot.domain.chat.message.ChatMessage
 import com.stark.shoot.domain.chat.message.MessageContent
 import com.stark.shoot.domain.chat.message.SyncDirection
+import com.stark.shoot.domain.common.vo.MessageId
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
@@ -209,7 +210,7 @@ class PaginationMessageSyncServiceTest {
     
     private fun createChatMessage(id: String, roomId: Long): ChatMessage {
         return ChatMessage(
-            id = id,
+            id = MessageId.from(id),
             roomId = roomId,
             senderId = 3L,
             content = MessageContent("테스트 메시지 $id", MessageType.TEXT),

--- a/src/test/kotlin/com/stark/shoot/application/service/message/schedule/ScheduledMessageServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/application/service/message/schedule/ScheduledMessageServiceTest.kt
@@ -14,6 +14,7 @@ import com.stark.shoot.domain.chat.message.ScheduledMessage
 import com.stark.shoot.domain.chat.room.ChatRoom
 import com.stark.shoot.domain.chat.room.ChatRoomType
 import com.stark.shoot.domain.chat.message.ScheduledMessageStatus
+import com.stark.shoot.domain.common.vo.MessageId
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -221,7 +222,7 @@ class ScheduledMessageServiceTest {
             override fun findById(id: org.bson.types.ObjectId): ScheduledMessage? {
                 // In test environment, we'll return a message regardless of the ObjectId
                 return ScheduledMessage(
-                    id = messageId,
+                    id = MessageId.from(messageId),
                     roomId = 1L,
                     senderId = 2L,
                     content = MessageContent(
@@ -259,7 +260,7 @@ class ScheduledMessageServiceTest {
         }
 
         // given
-        val messageId = "507f1f77bcf86cd799439011" // Use a valid ObjectId string
+            val messageId = "507f1f77bcf86cd799439011" // Use a valid ObjectId string
         val userId = 2L
 
         val testScheduledMessagePort = TestScheduledMessagePort()
@@ -279,14 +280,14 @@ class ScheduledMessageServiceTest {
         // then
         // Verify the result is not null and has the expected properties
         assertThat(result).isNotNull
-        assertThat(result.id).isEqualTo(messageId)
+        assertThat(result.id?.value).isEqualTo(messageId)
         assertThat(result.senderId).isEqualTo(userId)
         assertThat(result.status).isEqualTo(ScheduledMessageStatus.CANCELED)
 
         // Verify the saved message has the expected properties
         val savedMessage = testScheduledMessagePort.savedMessage
         assertThat(savedMessage).isNotNull
-        assertThat(savedMessage?.id).isEqualTo(messageId)
+        assertThat(savedMessage?.id?.value).isEqualTo(messageId)
         assertThat(savedMessage?.senderId).isEqualTo(userId)
         assertThat(savedMessage?.status).isEqualTo(ScheduledMessageStatus.CANCELED)
     }
@@ -311,7 +312,7 @@ class ScheduledMessageServiceTest {
             override fun findById(id: org.bson.types.ObjectId): ScheduledMessage? {
                 // In test environment, we'll return a message regardless of the ObjectId
                 return ScheduledMessage(
-                    id = messageId,
+                    id = MessageId.from(messageId),
                     roomId = 1L,
                     senderId = 2L,
                     content = MessageContent(
@@ -371,7 +372,7 @@ class ScheduledMessageServiceTest {
         // then
         // Verify the result is not null and has the expected properties
         assertThat(result).isNotNull
-        assertThat(result.id).isEqualTo(messageId)
+        assertThat(result.id?.value).isEqualTo(messageId)
         assertThat(result.senderId).isEqualTo(userId)
         assertThat(result.content.text).isEqualTo(newContent)
         assertThat(result.scheduledAt).isEqualTo(newScheduledAt)
@@ -380,7 +381,7 @@ class ScheduledMessageServiceTest {
         // Verify the saved message has the expected properties
         val savedMessage = testScheduledMessagePort.savedMessage
         assertThat(savedMessage).isNotNull
-        assertThat(savedMessage?.id).isEqualTo(messageId)
+        assertThat(savedMessage?.id?.value).isEqualTo(messageId)
         assertThat(savedMessage?.senderId).isEqualTo(userId)
         assertThat(savedMessage?.content?.text).isEqualTo(newContent)
         assertThat(savedMessage?.scheduledAt).isEqualTo(newScheduledAt)
@@ -402,7 +403,7 @@ class ScheduledMessageServiceTest {
                 // 테스트용 예약 메시지 목록 생성
                 val messages = listOf(
                     ScheduledMessage(
-                        id = "message-1",
+                        id = MessageId.from("message-1"),
                         roomId = 1L,
                         senderId = userId,
                         content = MessageContent(
@@ -413,7 +414,7 @@ class ScheduledMessageServiceTest {
                         status = ScheduledMessageStatus.PENDING
                     ),
                     ScheduledMessage(
-                        id = "message-2",
+                        id = MessageId.from("message-2"),
                         roomId = 2L,
                         senderId = userId,
                         content = MessageContent(
@@ -424,7 +425,7 @@ class ScheduledMessageServiceTest {
                         status = ScheduledMessageStatus.PENDING
                     ),
                     ScheduledMessage(
-                        id = "message-3",
+                        id = MessageId.from("message-3"),
                         roomId = 1L,
                         senderId = userId,
                         content = MessageContent(
@@ -487,7 +488,7 @@ class ScheduledMessageServiceTest {
 
         // then - 대기 중인 메시지만 반환되어야 함 (PENDING 상태)
         assertThat(allResults).hasSize(2)
-        assertThat(allResults.map { it.id }).containsExactlyInAnyOrder("message-1", "message-2")
+        assertThat(allResults.map { it.id?.value }).containsExactlyInAnyOrder("message-1", "message-2")
         assertThat(allResults.all { it.senderId == userId }).isTrue()
         assertThat(allResults.all { it.status == ScheduledMessageStatus.PENDING }).isTrue()
 
@@ -496,7 +497,7 @@ class ScheduledMessageServiceTest {
 
         // then - 해당 채팅방의 대기 중인 메시지만 반환되어야 함
         assertThat(roomResults).hasSize(1)
-        assertThat(roomResults[0].id).isEqualTo("message-1")
+        assertThat(roomResults[0].id?.value).isEqualTo("message-1")
         assertThat(roomResults[0].roomId).isEqualTo(1L)
         assertThat(roomResults[0].senderId).isEqualTo(userId)
         assertThat(roomResults[0].status).isEqualTo(ScheduledMessageStatus.PENDING)
@@ -520,7 +521,7 @@ class ScheduledMessageServiceTest {
             override fun findById(id: org.bson.types.ObjectId): ScheduledMessage? {
                 // In test environment, we'll return a message regardless of the ObjectId
                 return ScheduledMessage(
-                    id = messageId,
+                    id = MessageId.from(messageId),
                     roomId = 1L,
                     senderId = 2L,
                     content = MessageContent(
@@ -578,14 +579,14 @@ class ScheduledMessageServiceTest {
         // then
         // Verify the result is not null and has the expected properties
         assertThat(result).isNotNull
-        assertThat(result.id).isEqualTo(messageId)
+        assertThat(result.id?.value).isEqualTo(messageId)
         assertThat(result.senderId).isEqualTo(userId)
         assertThat(result.status).isEqualTo(ScheduledMessageStatus.SENT)
 
         // Verify the saved message has the expected properties
         val savedMessage = testScheduledMessagePort.savedMessage
         assertThat(savedMessage).isNotNull
-        assertThat(savedMessage?.id).isEqualTo(messageId)
+        assertThat(savedMessage?.id?.value).isEqualTo(messageId)
         assertThat(savedMessage?.senderId).isEqualTo(userId)
         assertThat(savedMessage?.status).isEqualTo(ScheduledMessageStatus.SENT)
     }

--- a/src/test/kotlin/com/stark/shoot/application/service/message/thread/GetThreadDetailServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/application/service/message/thread/GetThreadDetailServiceTest.kt
@@ -6,6 +6,7 @@ import com.stark.shoot.domain.chat.message.ChatMessage
 import com.stark.shoot.domain.chat.message.MessageContent
 import com.stark.shoot.domain.chat.message.type.MessageStatus
 import com.stark.shoot.domain.chat.message.type.MessageType
+import com.stark.shoot.domain.common.vo.MessageId
 import com.stark.shoot.infrastructure.exception.web.ResourceNotFoundException
 import com.stark.shoot.infrastructure.util.toObjectId
 import org.assertj.core.api.Assertions.assertThat
@@ -36,7 +37,7 @@ class GetThreadDetailServiceTest {
         fun `루트 메시지와 스레드 메시지를 함께 조회할 수 있다`() {
             val threadId = "5f9f1b9b9c9d1b9b9c9d1b9b"
             val rootMessage = ChatMessage(
-                id = threadId,
+                id = MessageId.from(threadId),
                 roomId = 1L,
                 senderId = 2L,
                 content = MessageContent("root", MessageType.TEXT),
@@ -44,12 +45,12 @@ class GetThreadDetailServiceTest {
                 createdAt = Instant.now()
             )
             val reply = ChatMessage(
-                id = "5f9f1b9b9c9d1b9b9c9d1b9c",
+                id = MessageId.from("5f9f1b9b9c9d1b9b9c9d1b9c"),
                 roomId = 1L,
                 senderId = 3L,
                 content = MessageContent("reply", MessageType.TEXT),
                 status = MessageStatus.SAVED,
-                threadId = threadId,
+                threadId = MessageId.from(threadId),
                 createdAt = Instant.now()
             )
 

--- a/src/test/kotlin/com/stark/shoot/application/service/message/thread/GetThreadMessagesServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/application/service/message/thread/GetThreadMessagesServiceTest.kt
@@ -6,6 +6,7 @@ import com.stark.shoot.domain.chat.message.ChatMessage
 import com.stark.shoot.domain.chat.message.MessageContent
 import com.stark.shoot.domain.chat.message.type.MessageStatus
 import com.stark.shoot.domain.chat.message.type.MessageType
+import com.stark.shoot.domain.common.vo.MessageId
 import com.stark.shoot.infrastructure.util.toObjectId
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
@@ -35,12 +36,12 @@ class GetThreadMessagesServiceTest {
             // given
             val threadId = "5f9f1b9b9c9d1b9b9c9d1b9b"
             val message = ChatMessage(
-                id = "5f9f1b9b9c9d1b9b9c9d1b9c",
+                id = MessageId.from("5f9f1b9b9c9d1b9b9c9d1b9c"),
                 roomId = 1L,
                 senderId = 2L,
                 content = MessageContent("hello", MessageType.TEXT),
                 status = MessageStatus.SAVED,
-                threadId = threadId,
+                threadId = MessageId.from(threadId),
                 createdAt = Instant.now()
             )
 

--- a/src/test/kotlin/com/stark/shoot/application/service/message/thread/SendThreadMessageServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/application/service/message/thread/SendThreadMessageServiceTest.kt
@@ -8,6 +8,7 @@ import com.stark.shoot.domain.chat.message.ChatMessage
 import com.stark.shoot.domain.chat.message.MessageContent
 import com.stark.shoot.domain.chat.message.type.MessageStatus
 import com.stark.shoot.domain.chat.message.type.MessageType
+import com.stark.shoot.domain.common.vo.MessageId
 import com.stark.shoot.infrastructure.exception.web.ResourceNotFoundException
 import com.stark.shoot.infrastructure.util.toObjectId
 import org.junit.jupiter.api.DisplayName
@@ -59,7 +60,7 @@ class SendThreadMessageServiceTest {
         )
 
         val rootMessage = ChatMessage(
-            id = threadId,
+            id = MessageId.from(threadId),
             roomId = 1L,
             senderId = 3L,
             content = MessageContent("root", MessageType.TEXT),

--- a/src/test/kotlin/com/stark/shoot/domain/chat/message/ScheduledMessageTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/chat/message/ScheduledMessageTest.kt
@@ -2,6 +2,7 @@ package com.stark.shoot.domain.chat.message
 
 import com.stark.shoot.domain.chat.message.type.MessageType
 import com.stark.shoot.domain.chat.message.ScheduledMessageStatus
+import com.stark.shoot.domain.common.vo.MessageId
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -51,7 +52,7 @@ class ScheduledMessageTest {
         @DisplayName("모든 속성으로 예약 메시지를 생성할 수 있다")
         fun `모든 속성으로 예약 메시지를 생성할 수 있다`() {
             // given
-            val id = "message123"
+            val id = MessageId.from("message123")
             val roomId = 1L
             val senderId = 2L
             val content = MessageContent(


### PR DESCRIPTION
## Summary
- refactor ChatMessage to use `MessageId` for identifiers
- update mappers and services to handle `MessageId`
- adapt tests for new value object usage

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68552f43ef808320b19f3ecd283cecf2