### PR TITLE
Refactor ChatMessage IDs to use value objects

### DIFF
--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/message/ChatMessageMapperExtensions.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/message/ChatMessageMapperExtensions.kt
@@ -5,6 +5,8 @@ import com.stark.shoot.domain.chat.message.ChatMessageMetadata
 import com.stark.shoot.domain.chat.message.MessageContent
 import com.stark.shoot.domain.chat.message.type.MessageStatus
 import com.stark.shoot.domain.common.vo.MessageId
+import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.common.vo.UserId
 
 fun ChatMessageMetadataRequest.toDomain(): ChatMessageMetadata {
     return ChatMessageMetadata(
@@ -48,12 +50,12 @@ fun ChatMessageRequest.toDomain(): ChatMessage {
 
     return ChatMessage(
         id = this.id?.let { MessageId.from(it) },
-        roomId = this.roomId,
-        senderId = this.senderId,
+        roomId = ChatRoomId.from(this.roomId),
+        senderId = UserId.from(this.senderId),
         content = content,
         threadId = this.threadId?.let { MessageId.from(it) },
         status = this.status ?: MessageStatus.SAVED,
-        readBy = this.readBy?.mapKeys { it.key.toLong() }?.toMutableMap() ?: mutableMapOf(),
+        readBy = this.readBy?.mapKeys { UserId.from(it.key.toLong()) }?.toMutableMap() ?: mutableMapOf(),
         metadata = metadata
     )
 }

--- a/src/main/kotlin/com/stark/shoot/application/service/message/SendMessageService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/message/SendMessageService.kt
@@ -141,7 +141,7 @@ class SendMessageService(
             publishMessageToKafka(message)
 
             // 2. 상태 업데이트 전송
-            notifyMessageStatus(message.roomId, tempId, MessageStatus.SENT_TO_KAFKA)
+            notifyMessageStatus(message.roomId.value, tempId, MessageStatus.SENT_TO_KAFKA)
 
             logger.debug { "메시지 Kafka 발행 성공, 상태 업데이트: tempId=$tempId" }
         } catch (e: Exception) {
@@ -376,12 +376,12 @@ class SendMessageService(
         logMessageError(message, throwable)
 
         // 2. 오류 알림
-        notifyMessageError(message.roomId, throwable)
+        notifyMessageError(message.roomId.value, throwable)
 
         // 3. 메시지 상태 업데이트
         if (tempId.isNotEmpty()) {
             notifyMessageStatus(
-                roomId = message.roomId,
+                roomId = message.roomId.value,
                 tempId = tempId,
                 status = MessageStatus.FAILED,
                 errorMessage = throwable.message

--- a/src/main/kotlin/com/stark/shoot/application/service/message/reaction/ToggleMessageReactionService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/message/reaction/ToggleMessageReactionService.kt
@@ -80,13 +80,13 @@ class ToggleMessageReactionService(
         // 리액션 교체인 경우 (기존 리액션 제거 후 새 리액션 추가)
         if (result.isReplacement && result.previousReactionType != null) {
             // 기존 리액션 제거 알림
-            notifyReactionUpdate(messageId, message.roomId, userId, result.previousReactionType, false)
+            notifyReactionUpdate(messageId, message.roomId.value, userId.value, result.previousReactionType, false)
 
             // 새 리액션 추가 알림
-            notifyReactionUpdate(messageId, message.roomId, userId, result.reactionType, true)
+            notifyReactionUpdate(messageId, message.roomId.value, userId.value, result.reactionType, true)
         } else {
             // 일반 추가/제거 알림
-            notifyReactionUpdate(messageId, message.roomId, userId, result.reactionType, result.isAdded)
+            notifyReactionUpdate(messageId, message.roomId.value, userId.value, result.reactionType, result.isAdded)
         }
 
         // 도메인 서비스를 통해 이벤트 생성 및 발행

--- a/src/main/kotlin/com/stark/shoot/domain/chat/message/ReactionToggleResult.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/message/ReactionToggleResult.kt
@@ -1,6 +1,7 @@
 package com.stark.shoot.domain.chat.message
 
 import com.stark.shoot.domain.chat.reaction.MessageReactions
+import com.stark.shoot.domain.common.vo.UserId
 
 /**
  * 리액션 토글 결과를 나타내는 데이터 클래스
@@ -8,7 +9,7 @@ import com.stark.shoot.domain.chat.reaction.MessageReactions
 data class ReactionToggleResult(
     val reactions: MessageReactions,
     val message: ChatMessage,
-    val userId: Long,
+    val userId: UserId,
     val reactionType: String,
     val isAdded: Boolean,
     val previousReactionType: String? = null,

--- a/src/main/kotlin/com/stark/shoot/domain/service/message/MessageDomainService.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/service/message/MessageDomainService.kt
@@ -5,6 +5,8 @@ import com.stark.shoot.domain.chat.event.EventType
 import com.stark.shoot.domain.chat.message.ChatMessage
 import com.stark.shoot.domain.chat.message.UrlPreview
 import com.stark.shoot.domain.common.vo.MessageId
+import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.common.vo.UserId
 import java.util.*
 
 /**
@@ -22,8 +24,8 @@ class MessageDomainService {
      * @return 처리된 도메인 메시지 객체
      */
     fun createAndProcessMessage(
-        roomId: Long,
-        senderId: Long,
+        roomId: ChatRoomId,
+        senderId: UserId,
         contentText: String,
         contentType: com.stark.shoot.domain.chat.message.type.MessageType,
         threadId: MessageId? = null,

--- a/src/main/kotlin/com/stark/shoot/domain/service/message/MessageForwardDomainService.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/service/message/MessageForwardDomainService.kt
@@ -4,6 +4,8 @@ import com.stark.shoot.domain.chat.message.type.MessageStatus
 import com.stark.shoot.domain.chat.message.ChatMessage
 import com.stark.shoot.domain.chat.message.MessageContent
 import com.stark.shoot.domain.chat.reaction.MessageReactions
+import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.common.vo.UserId
 import java.time.Instant
 
 /**
@@ -38,8 +40,8 @@ class MessageForwardDomainService {
      * @return 생성된 메시지 객체
      */
     fun createForwardedMessage(
-        targetRoomId: Long,
-        forwardingUserId: Long,
+        targetRoomId: ChatRoomId,
+        forwardingUserId: UserId,
         forwardedContent: MessageContent
     ): ChatMessage {
         // 전달할 메시지 생성

--- a/src/main/kotlin/com/stark/shoot/domain/service/message/MessagePinDomainService.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/service/message/MessagePinDomainService.kt
@@ -2,6 +2,7 @@ package com.stark.shoot.domain.service.message
 
 import com.stark.shoot.domain.chat.event.MessagePinEvent
 import com.stark.shoot.domain.chat.message.ChatMessage
+import com.stark.shoot.domain.common.vo.UserId
 
 /**
  * 메시지 고정 관련 도메인 서비스
@@ -19,7 +20,7 @@ class MessagePinDomainService {
      */
     fun createPinEvent(
         message: ChatMessage,
-        userId: Long,
+        userId: UserId,
         isPinned: Boolean
     ): MessagePinEvent? {
         val messageId = message.id ?: return null
@@ -28,7 +29,7 @@ class MessagePinDomainService {
             messageId = messageId,
             roomId = message.roomId,
             isPinned = isPinned,
-            userId = userId
+            userId = userId.value
         )
     }
 


### PR DESCRIPTION
## Summary
- refactor `ChatMessage` to rely on `ChatRoomId` and `UserId`
- update message creation and reaction result models
- convert mappers and services to the new value objects
- adjust application services using `ChatMessage.roomId`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68553a08eebc83209585a3f9693452fa