### PR TITLE
Refactor domain VO packages

### DIFF
--- a/src/main/kotlin/com/stark/shoot/adapter/in/event/listener/sse/ChatUnreadCountEventListener.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/event/listener/sse/ChatUnreadCountEventListener.kt
@@ -2,7 +2,7 @@ package com.stark.shoot.adapter.`in`.event.listener.sse
 
 import com.stark.shoot.application.port.`in`.chatroom.SseEmitterUseCase
 import com.stark.shoot.domain.chat.event.ChatUnreadCountUpdatedEvent
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.UserId
 import io.swagger.v3.oas.annotations.Operation
 import org.springframework.context.event.EventListener

--- a/src/main/kotlin/com/stark/shoot/adapter/in/event/notification/ChatNotificationFactory.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/event/notification/ChatNotificationFactory.kt
@@ -1,11 +1,11 @@
 package com.stark.shoot.adapter.`in`.event.notification
 
 import com.stark.shoot.domain.chat.message.ChatMessage
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.MessageId
 import com.stark.shoot.domain.common.vo.UserId
 import com.stark.shoot.domain.notification.Notification
-import com.stark.shoot.domain.notification.NotificationType
+import com.stark.shoot.domain.notification.type.NotificationType
 import org.springframework.stereotype.Component
 
 /**

--- a/src/main/kotlin/com/stark/shoot/adapter/in/event/notification/ReactionEventNotificationListener.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/event/notification/ReactionEventNotificationListener.kt
@@ -4,7 +4,7 @@ import com.stark.shoot.application.port.out.message.LoadMessagePort
 import com.stark.shoot.application.port.out.notification.SaveNotificationPort
 import com.stark.shoot.application.port.out.notification.SendNotificationPort
 import com.stark.shoot.domain.chat.event.MessageReactionEvent
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.MessageId
 import com.stark.shoot.domain.common.vo.UserId
 import io.github.oshai.kotlinlogging.KotlinLogging

--- a/src/main/kotlin/com/stark/shoot/adapter/in/kafka/MessageKafkaConsumer.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/kafka/MessageKafkaConsumer.kt
@@ -8,7 +8,7 @@ import com.stark.shoot.application.port.`in`.message.ProcessMessageUseCase
 import com.stark.shoot.application.port.out.message.preview.CacheUrlPreviewPort
 import com.stark.shoot.application.port.out.message.preview.LoadUrlContentPort
 import com.stark.shoot.domain.chat.event.ChatEvent
-import com.stark.shoot.domain.chat.event.EventType
+import com.stark.shoot.domain.chat.event.type.EventType
 import com.stark.shoot.domain.chat.message.ChatMessage
 import com.stark.shoot.domain.chat.message.ChatMessageMetadata
 import com.stark.shoot.domain.chat.message.UrlPreview

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/chatroom/ChatRoomController.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/chatroom/ChatRoomController.kt
@@ -6,8 +6,8 @@ import com.stark.shoot.adapter.`in`.web.dto.chatroom.TitleRequest
 import com.stark.shoot.application.port.`in`.chatroom.CreateChatRoomUseCase
 import com.stark.shoot.application.port.`in`.chatroom.FindChatRoomUseCase
 import com.stark.shoot.application.port.`in`.chatroom.ManageChatRoomUseCase
-import com.stark.shoot.domain.chat.room.ChatRoomId
-import com.stark.shoot.domain.chat.room.ChatRoomTitle
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomTitle
 import com.stark.shoot.domain.common.vo.UserId
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/chatroom/ChatRoomFavoriteController.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/chatroom/ChatRoomFavoriteController.kt
@@ -3,7 +3,7 @@ package com.stark.shoot.adapter.`in`.web.chatroom
 import com.stark.shoot.adapter.`in`.web.dto.ResponseDto
 import com.stark.shoot.adapter.`in`.web.dto.chatroom.ChatRoomResponse
 import com.stark.shoot.application.port.`in`.chatroom.UpdateChatRoomFavoriteUseCase
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.UserId
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/chatroom/ChatRoomNoticeController.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/chatroom/ChatRoomNoticeController.kt
@@ -3,8 +3,8 @@ package com.stark.shoot.adapter.`in`.web.chatroom
 import com.stark.shoot.adapter.`in`.web.dto.ResponseDto
 import com.stark.shoot.adapter.`in`.web.dto.chatroom.AnnouncementRequest
 import com.stark.shoot.application.port.`in`.chatroom.ManageChatRoomUseCase
-import com.stark.shoot.domain.chat.room.ChatRoomAnnouncement
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomAnnouncement
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.*

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/chatroom/MultipleChatRoomController.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/chatroom/MultipleChatRoomController.kt
@@ -4,7 +4,7 @@ import com.stark.shoot.adapter.`in`.web.dto.ResponseDto
 import com.stark.shoot.adapter.`in`.web.dto.chatroom.InvitationRequest
 import com.stark.shoot.adapter.`in`.web.dto.chatroom.ManageParticipantRequest
 import com.stark.shoot.application.port.`in`.chatroom.ManageChatRoomUseCase
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.UserId
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/chatroom/ChatRoomResponse.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/chatroom/ChatRoomResponse.kt
@@ -1,7 +1,7 @@
 package com.stark.shoot.adapter.`in`.web.dto.chatroom
 
 import com.stark.shoot.domain.chat.room.ChatRoom
-import com.stark.shoot.domain.chat.room.ChatRoomType
+import com.stark.shoot.domain.chat.room.type.ChatRoomType
 import com.stark.shoot.infrastructure.annotation.ApplicationDto
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/message/ChatMessageMapperExtensions.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/message/ChatMessageMapperExtensions.kt
@@ -5,7 +5,7 @@ import com.stark.shoot.domain.chat.message.ChatMessageMetadata
 import com.stark.shoot.domain.chat.message.MessageContent
 import com.stark.shoot.domain.chat.message.type.MessageStatus
 import com.stark.shoot.domain.common.vo.MessageId
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.UserId
 
 fun ChatMessageMetadataRequest.toDomain(): ChatMessageMetadata {

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/message/reaction/ReactionInfoDto.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/message/reaction/ReactionInfoDto.kt
@@ -1,6 +1,6 @@
 package com.stark.shoot.adapter.`in`.web.dto.message.reaction
 
-import com.stark.shoot.domain.chat.reaction.ReactionType
+import com.stark.shoot.domain.chat.reaction.type.ReactionType
 
 data class ReactionInfoDto(
     val reactionType: String,     // 리액션 타입 코드

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/message/read/ReadStatus.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/dto/message/read/ReadStatus.kt
@@ -1,6 +1,6 @@
 package com.stark.shoot.adapter.`in`.web.dto.message.read
 
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.MessageId
 import com.stark.shoot.domain.common.vo.UserId
 import java.time.Instant

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/message/MessageForwardController.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/message/MessageForwardController.kt
@@ -4,7 +4,7 @@ import com.stark.shoot.adapter.`in`.web.dto.ResponseDto
 import com.stark.shoot.adapter.`in`.web.socket.dto.ChatMessageResponse
 import com.stark.shoot.application.port.`in`.message.ForwardMessageToUserUseCase
 import com.stark.shoot.application.port.`in`.message.ForwardMessageUseCase
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.MessageId
 import com.stark.shoot.domain.common.vo.UserId
 import io.swagger.v3.oas.annotations.Operation

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/message/MessageReadController.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/message/MessageReadController.kt
@@ -3,7 +3,7 @@ package com.stark.shoot.adapter.`in`.web.message
 import com.stark.shoot.adapter.`in`.web.dto.ResponseDto
 import com.stark.shoot.adapter.`in`.web.dto.message.MessageResponseDto
 import com.stark.shoot.application.port.`in`.message.GetMessagesUseCase
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.MessageId
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/message/pin/GetPinnedMessageController.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/message/pin/GetPinnedMessageController.kt
@@ -3,7 +3,7 @@ package com.stark.shoot.adapter.`in`.web.message.pin
 import com.stark.shoot.adapter.`in`.web.dto.ResponseDto
 import com.stark.shoot.adapter.`in`.web.dto.message.pin.PinnedMessagesResponse
 import com.stark.shoot.application.port.`in`.message.pin.GetPinnedMessageUseCase
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.GetMapping

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/message/schedule/ScheduledMessageController.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/message/schedule/ScheduledMessageController.kt
@@ -3,7 +3,7 @@ package com.stark.shoot.adapter.`in`.web.message.schedule
 import com.stark.shoot.adapter.`in`.web.dto.ResponseDto
 import com.stark.shoot.adapter.`in`.web.dto.message.schedule.ScheduledMessageResponseDto
 import com.stark.shoot.application.port.`in`.message.schedule.ScheduledMessageUseCase
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.UserId
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/notification/NotificationDeleteController.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/notification/NotificationDeleteController.kt
@@ -2,7 +2,7 @@ package com.stark.shoot.adapter.`in`.web.notification
 
 import com.stark.shoot.application.port.`in`.notification.NotificationManagementUseCase
 import com.stark.shoot.domain.common.vo.UserId
-import com.stark.shoot.domain.notification.NotificationId
+import com.stark.shoot.domain.notification.vo.NotificationId
 import io.swagger.v3.oas.annotations.Operation
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/notification/NotificationQueryController.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/notification/NotificationQueryController.kt
@@ -3,8 +3,8 @@ package com.stark.shoot.adapter.`in`.web.notification
 import com.stark.shoot.adapter.`in`.web.dto.notification.NotificationResponse
 import com.stark.shoot.application.port.`in`.notification.NotificationQueryUseCase
 import com.stark.shoot.domain.common.vo.UserId
-import com.stark.shoot.domain.notification.NotificationType
-import com.stark.shoot.domain.notification.SourceType
+import com.stark.shoot.domain.notification.type.NotificationType
+import com.stark.shoot.domain.notification.type.SourceType
 import io.swagger.v3.oas.annotations.Operation
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/notification/NotificationReadController.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/notification/NotificationReadController.kt
@@ -3,9 +3,9 @@ package com.stark.shoot.adapter.`in`.web.notification
 import com.stark.shoot.adapter.`in`.web.dto.notification.NotificationResponse
 import com.stark.shoot.application.port.`in`.notification.NotificationManagementUseCase
 import com.stark.shoot.domain.common.vo.UserId
-import com.stark.shoot.domain.notification.NotificationId
-import com.stark.shoot.domain.notification.NotificationType
-import com.stark.shoot.domain.notification.SourceType
+import com.stark.shoot.domain.notification.vo.NotificationId
+import com.stark.shoot.domain.notification.type.NotificationType
+import com.stark.shoot.domain.notification.type.SourceType
 import io.swagger.v3.oas.annotations.Operation
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/socket/mapper/MessageSyncMapper.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/socket/mapper/MessageSyncMapper.kt
@@ -4,7 +4,7 @@ import com.stark.shoot.adapter.`in`.web.dto.message.MessageContentRequest
 import com.stark.shoot.adapter.`in`.web.socket.dto.MessageSyncInfoDto
 import com.stark.shoot.adapter.`in`.web.socket.dto.ReactionDto
 import com.stark.shoot.domain.chat.message.ChatMessage
-import com.stark.shoot.domain.chat.reaction.ReactionType
+import com.stark.shoot.domain.chat.reaction.type.ReactionType
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Component
 import java.time.Instant

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/socket/mark/MessageReadCountStompHandler.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/socket/mark/MessageReadCountStompHandler.kt
@@ -2,7 +2,7 @@ package com.stark.shoot.adapter.`in`.web.socket.mark
 
 import com.stark.shoot.adapter.`in`.web.dto.message.read.ChatReadRequest
 import com.stark.shoot.application.port.`in`.message.mark.MessageReadUseCase
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.MessageId
 import com.stark.shoot.domain.common.vo.UserId
 import io.swagger.v3.oas.annotations.Operation

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/sse/MessageReadCountController.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/sse/MessageReadCountController.kt
@@ -2,7 +2,7 @@ package com.stark.shoot.adapter.`in`.web.sse
 
 import com.stark.shoot.adapter.`in`.web.dto.ResponseDto
 import com.stark.shoot.application.port.`in`.message.mark.MessageReadUseCase
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.MessageId
 import com.stark.shoot.domain.common.vo.UserId
 import io.swagger.v3.oas.annotations.Operation

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/adapter/message/BookmarkMessageMongoAdapter.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/adapter/message/BookmarkMessageMongoAdapter.kt
@@ -5,7 +5,7 @@ import com.stark.shoot.adapter.out.persistence.mongodb.repository.ChatMessageMon
 import com.stark.shoot.adapter.out.persistence.mongodb.repository.MessageBookmarkMongoRepository
 import com.stark.shoot.application.port.out.message.BookmarkMessagePort
 import com.stark.shoot.domain.chat.bookmark.MessageBookmark
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.MessageId
 import com.stark.shoot.domain.common.vo.UserId
 import com.stark.shoot.infrastructure.annotation.Adapter

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/adapter/message/LoadMessageMongoAdapter.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/adapter/message/LoadMessageMongoAdapter.kt
@@ -5,7 +5,7 @@ import com.stark.shoot.adapter.out.persistence.mongodb.repository.ChatMessageMon
 import com.stark.shoot.application.port.out.message.LoadMessagePort
 import com.stark.shoot.application.port.out.message.LoadThreadPort
 import com.stark.shoot.domain.chat.message.ChatMessage
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.MessageId
 import com.stark.shoot.domain.common.vo.UserId
 import com.stark.shoot.infrastructure.annotation.Adapter

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/adapter/notification/DeleteNotificationMongoAdapter.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/adapter/notification/DeleteNotificationMongoAdapter.kt
@@ -3,7 +3,7 @@ package com.stark.shoot.adapter.out.persistence.mongodb.adapter.notification
 import com.stark.shoot.adapter.out.persistence.mongodb.repository.NotificationMongoRepository
 import com.stark.shoot.application.port.out.notification.DeleteNotificationPort
 import com.stark.shoot.domain.common.vo.UserId
-import com.stark.shoot.domain.notification.NotificationId
+import com.stark.shoot.domain.notification.vo.NotificationId
 import com.stark.shoot.infrastructure.annotation.Adapter
 import com.stark.shoot.infrastructure.exception.web.MongoOperationException
 import com.stark.shoot.infrastructure.exception.web.ResourceNotFoundException

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/adapter/notification/LoadNotificationMongoAdapter.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/adapter/notification/LoadNotificationMongoAdapter.kt
@@ -4,9 +4,9 @@ import com.stark.shoot.adapter.out.persistence.mongodb.repository.NotificationMo
 import com.stark.shoot.application.port.out.notification.LoadNotificationPort
 import com.stark.shoot.domain.common.vo.UserId
 import com.stark.shoot.domain.notification.Notification
-import com.stark.shoot.domain.notification.NotificationId
-import com.stark.shoot.domain.notification.NotificationType
-import com.stark.shoot.domain.notification.SourceType
+import com.stark.shoot.domain.notification.vo.NotificationId
+import com.stark.shoot.domain.notification.type.NotificationType
+import com.stark.shoot.domain.notification.type.SourceType
 import com.stark.shoot.infrastructure.annotation.Adapter
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/document/notification/NotificationDocument.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/document/notification/NotificationDocument.kt
@@ -1,11 +1,11 @@
 package com.stark.shoot.adapter.out.persistence.mongodb.document.notification
 
 import com.stark.shoot.domain.notification.Notification
-import com.stark.shoot.domain.notification.NotificationId
-import com.stark.shoot.domain.notification.NotificationType
-import com.stark.shoot.domain.notification.SourceType
-import com.stark.shoot.domain.notification.NotificationTitle
-import com.stark.shoot.domain.notification.NotificationMessage
+import com.stark.shoot.domain.notification.vo.NotificationId
+import com.stark.shoot.domain.notification.type.NotificationType
+import com.stark.shoot.domain.notification.type.SourceType
+import com.stark.shoot.domain.notification.vo.NotificationTitle
+import com.stark.shoot.domain.notification.vo.NotificationMessage
 import com.stark.shoot.domain.common.vo.UserId
 import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.index.Indexed

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/mapper/ChatMessageMapper.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/mapper/ChatMessageMapper.kt
@@ -9,9 +9,9 @@ import com.stark.shoot.adapter.out.persistence.mongodb.document.message.embedded
 import com.stark.shoot.adapter.out.persistence.mongodb.document.message.embedded.MessageContentDocument
 import com.stark.shoot.adapter.out.persistence.mongodb.document.message.embedded.MessageMetadataDocument
 import com.stark.shoot.domain.chat.message.*
-import com.stark.shoot.domain.chat.reaction.MessageReactions
+import com.stark.shoot.domain.chat.reaction.vo.MessageReactions
 import com.stark.shoot.domain.common.vo.MessageId
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.UserId
 import org.bson.types.ObjectId
 import org.springframework.stereotype.Component

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/chatroom/DeleteChatRoomPersistenceAdapter.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/chatroom/DeleteChatRoomPersistenceAdapter.kt
@@ -2,7 +2,7 @@ package com.stark.shoot.adapter.out.persistence.postgres.adapter.chatroom
 
 import com.stark.shoot.adapter.out.persistence.postgres.repository.ChatRoomRepository
 import com.stark.shoot.application.port.out.chatroom.DeleteChatRoomPort
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.infrastructure.annotation.Adapter
 import io.github.oshai.kotlinlogging.KotlinLogging
 

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/chatroom/LoadChatRoomPersistenceAdapter.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/chatroom/LoadChatRoomPersistenceAdapter.kt
@@ -5,7 +5,7 @@ import com.stark.shoot.adapter.out.persistence.postgres.repository.ChatRoomRepos
 import com.stark.shoot.adapter.out.persistence.postgres.repository.ChatRoomUserRepository
 import com.stark.shoot.application.port.out.chatroom.LoadChatRoomPort
 import com.stark.shoot.domain.chat.room.ChatRoom
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.UserId
 import com.stark.shoot.infrastructure.annotation.Adapter
 

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/chatroom/ReadStatusPersistenceAdapter.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/chatroom/ReadStatusPersistenceAdapter.kt
@@ -2,7 +2,7 @@ package com.stark.shoot.adapter.out.persistence.postgres.adapter.chatroom
 
 import com.stark.shoot.adapter.out.persistence.postgres.repository.ChatRoomUserRepository
 import com.stark.shoot.application.port.out.chatroom.ReadStatusPort
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.MessageId
 import com.stark.shoot.domain.common.vo.UserId
 import com.stark.shoot.infrastructure.annotation.Adapter

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/chatroom/SaveChatRoomPersistenceAdapter.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/chatroom/SaveChatRoomPersistenceAdapter.kt
@@ -7,9 +7,9 @@ import com.stark.shoot.adapter.out.persistence.postgres.repository.ChatRoomUserR
 import com.stark.shoot.adapter.out.persistence.postgres.repository.UserRepository
 import com.stark.shoot.application.port.out.chatroom.SaveChatRoomPort
 import com.stark.shoot.domain.chat.room.ChatRoom
-import com.stark.shoot.domain.chat.room.ChatRoomAnnouncement
-import com.stark.shoot.domain.chat.room.ChatRoomId
-import com.stark.shoot.domain.chat.room.ChatRoomTitle
+import com.stark.shoot.domain.chat.room.vo.ChatRoomAnnouncement
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomTitle
 import com.stark.shoot.domain.common.vo.UserId
 import com.stark.shoot.infrastructure.annotation.Adapter
 

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/entity/ChatRoomEntity.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/entity/ChatRoomEntity.kt
@@ -1,6 +1,6 @@
 package com.stark.shoot.adapter.out.persistence.postgres.entity
 
-import com.stark.shoot.domain.chat.room.ChatRoomType
+import com.stark.shoot.domain.chat.room.type.ChatRoomType
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/mapper/ChatRoomMapper.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/mapper/ChatRoomMapper.kt
@@ -3,9 +3,9 @@ package com.stark.shoot.adapter.out.persistence.postgres.mapper
 import com.stark.shoot.adapter.out.persistence.postgres.entity.ChatRoomEntity
 import com.stark.shoot.adapter.out.persistence.postgres.entity.ChatRoomUserEntity
 import com.stark.shoot.domain.chat.room.ChatRoom
-import com.stark.shoot.domain.chat.room.ChatRoomAnnouncement
-import com.stark.shoot.domain.chat.room.ChatRoomId
-import com.stark.shoot.domain.chat.room.ChatRoomTitle
+import com.stark.shoot.domain.chat.room.vo.ChatRoomAnnouncement
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomTitle
 import com.stark.shoot.domain.common.vo.MessageId
 import com.stark.shoot.domain.common.vo.UserId
 import org.springframework.stereotype.Component

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/redis/RedisReadStatusAdapter.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/redis/RedisReadStatusAdapter.kt
@@ -3,7 +3,7 @@ package com.stark.shoot.adapter.out.persistence.redis
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.stark.shoot.adapter.`in`.web.dto.message.read.ReadStatus
 import com.stark.shoot.application.port.out.message.ReadStatusPort
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.MessageId
 import com.stark.shoot.domain.common.vo.UserId
 import com.stark.shoot.infrastructure.annotation.Adapter

--- a/src/main/kotlin/com/stark/shoot/application/port/in/chatroom/ManageChatRoomUseCase.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/chatroom/ManageChatRoomUseCase.kt
@@ -1,8 +1,8 @@
 package com.stark.shoot.application.port.`in`.chatroom
 
-import com.stark.shoot.domain.chat.room.ChatRoomAnnouncement
-import com.stark.shoot.domain.chat.room.ChatRoomId
-import com.stark.shoot.domain.chat.room.ChatRoomTitle
+import com.stark.shoot.domain.chat.room.vo.ChatRoomAnnouncement
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomTitle
 import com.stark.shoot.domain.common.vo.UserId
 
 interface ManageChatRoomUseCase {

--- a/src/main/kotlin/com/stark/shoot/application/port/in/chatroom/SseEmitterUseCase.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/chatroom/SseEmitterUseCase.kt
@@ -3,7 +3,7 @@ package com.stark.shoot.application.port.`in`.chatroom
 import com.stark.shoot.domain.chat.event.ChatRoomCreatedEvent
 import com.stark.shoot.domain.chat.event.FriendAddedEvent
 import com.stark.shoot.domain.chat.event.FriendRemovedEvent
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.UserId
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 

--- a/src/main/kotlin/com/stark/shoot/application/port/in/chatroom/UpdateChatRoomFavoriteUseCase.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/chatroom/UpdateChatRoomFavoriteUseCase.kt
@@ -1,7 +1,7 @@
 package com.stark.shoot.application.port.`in`.chatroom
 
 import com.stark.shoot.adapter.`in`.web.dto.chatroom.ChatRoomResponse
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.UserId
 
 interface UpdateChatRoomFavoriteUseCase {

--- a/src/main/kotlin/com/stark/shoot/application/port/in/message/ForwardMessageUseCase.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/message/ForwardMessageUseCase.kt
@@ -1,7 +1,7 @@
 package com.stark.shoot.application.port.`in`.message
 
 import com.stark.shoot.domain.chat.message.ChatMessage
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.MessageId
 import com.stark.shoot.domain.common.vo.UserId
 

--- a/src/main/kotlin/com/stark/shoot/application/port/in/message/GetMessagesUseCase.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/message/GetMessagesUseCase.kt
@@ -1,7 +1,7 @@
 package com.stark.shoot.application.port.`in`.message
 
 import com.stark.shoot.adapter.`in`.web.dto.message.MessageResponseDto
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.MessageId
 
 interface GetMessagesUseCase {

--- a/src/main/kotlin/com/stark/shoot/application/port/in/message/bookmark/BookmarkMessageUseCase.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/message/bookmark/BookmarkMessageUseCase.kt
@@ -1,7 +1,7 @@
 package com.stark.shoot.application.port.`in`.message.bookmark
 
 import com.stark.shoot.domain.chat.bookmark.MessageBookmark
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.MessageId
 import com.stark.shoot.domain.common.vo.UserId
 

--- a/src/main/kotlin/com/stark/shoot/application/port/in/message/mark/MessageReadUseCase.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/message/mark/MessageReadUseCase.kt
@@ -1,6 +1,6 @@
 package com.stark.shoot.application.port.`in`.message.mark
 
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.MessageId
 import com.stark.shoot.domain.common.vo.UserId
 

--- a/src/main/kotlin/com/stark/shoot/application/port/in/message/pin/GetPinnedMessageUseCase.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/message/pin/GetPinnedMessageUseCase.kt
@@ -1,7 +1,7 @@
 package com.stark.shoot.application.port.`in`.message.pin
 
 import com.stark.shoot.domain.chat.message.ChatMessage
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 
 interface GetPinnedMessageUseCase {
     fun getPinnedMessages(roomId: ChatRoomId): List<ChatMessage>

--- a/src/main/kotlin/com/stark/shoot/application/port/in/message/reaction/GetMessageReactionUseCase.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/message/reaction/GetMessageReactionUseCase.kt
@@ -1,6 +1,6 @@
 package com.stark.shoot.application.port.`in`.message.reaction
 
-import com.stark.shoot.domain.chat.reaction.ReactionType
+import com.stark.shoot.domain.chat.reaction.type.ReactionType
 import com.stark.shoot.domain.common.vo.MessageId
 
 interface GetMessageReactionUseCase {

--- a/src/main/kotlin/com/stark/shoot/application/port/in/message/schedule/ScheduledMessageUseCase.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/message/schedule/ScheduledMessageUseCase.kt
@@ -1,7 +1,7 @@
 package com.stark.shoot.application.port.`in`.message.schedule
 
 import com.stark.shoot.adapter.`in`.web.dto.message.schedule.ScheduledMessageResponseDto
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.UserId
 import java.time.Instant
 

--- a/src/main/kotlin/com/stark/shoot/application/port/in/message/thread/GetThreadsUseCase.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/message/thread/GetThreadsUseCase.kt
@@ -1,7 +1,7 @@
 package com.stark.shoot.application.port.`in`.message.thread
 
 import com.stark.shoot.adapter.`in`.web.dto.message.thread.ThreadSummaryDto
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.MessageId
 
 interface GetThreadsUseCase {

--- a/src/main/kotlin/com/stark/shoot/application/port/in/notification/NotificationManagementUseCase.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/notification/NotificationManagementUseCase.kt
@@ -2,9 +2,9 @@ package com.stark.shoot.application.port.`in`.notification
 
 import com.stark.shoot.domain.common.vo.UserId
 import com.stark.shoot.domain.notification.Notification
-import com.stark.shoot.domain.notification.NotificationId
-import com.stark.shoot.domain.notification.NotificationType
-import com.stark.shoot.domain.notification.SourceType
+import com.stark.shoot.domain.notification.vo.NotificationId
+import com.stark.shoot.domain.notification.type.NotificationType
+import com.stark.shoot.domain.notification.type.SourceType
 
 interface NotificationManagementUseCase {
 

--- a/src/main/kotlin/com/stark/shoot/application/port/in/notification/NotificationQueryUseCase.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/notification/NotificationQueryUseCase.kt
@@ -2,8 +2,8 @@ package com.stark.shoot.application.port.`in`.notification
 
 import com.stark.shoot.domain.common.vo.UserId
 import com.stark.shoot.domain.notification.Notification
-import com.stark.shoot.domain.notification.NotificationType
-import com.stark.shoot.domain.notification.SourceType
+import com.stark.shoot.domain.notification.type.NotificationType
+import com.stark.shoot.domain.notification.type.SourceType
 
 interface NotificationQueryUseCase {
 

--- a/src/main/kotlin/com/stark/shoot/application/port/out/chatroom/DeleteChatRoomPort.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/out/chatroom/DeleteChatRoomPort.kt
@@ -1,6 +1,6 @@
 package com.stark.shoot.application.port.out.chatroom
 
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.infrastructure.exception.web.MongoOperationException
 import com.stark.shoot.infrastructure.exception.web.ResourceNotFoundException
 

--- a/src/main/kotlin/com/stark/shoot/application/port/out/chatroom/LoadChatRoomPort.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/out/chatroom/LoadChatRoomPort.kt
@@ -1,7 +1,7 @@
 package com.stark.shoot.application.port.out.chatroom
 
 import com.stark.shoot.domain.chat.room.ChatRoom
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.UserId
 
 interface LoadChatRoomPort {

--- a/src/main/kotlin/com/stark/shoot/application/port/out/chatroom/ReadStatusPort.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/out/chatroom/ReadStatusPort.kt
@@ -1,6 +1,6 @@
 package com.stark.shoot.application.port.out.chatroom
 
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.MessageId
 import com.stark.shoot.domain.common.vo.UserId
 

--- a/src/main/kotlin/com/stark/shoot/application/port/out/message/BookmarkMessagePort.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/out/message/BookmarkMessagePort.kt
@@ -1,7 +1,7 @@
 package com.stark.shoot.application.port.out.message
 
 import com.stark.shoot.domain.chat.bookmark.MessageBookmark
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.MessageId
 import com.stark.shoot.domain.common.vo.UserId
 

--- a/src/main/kotlin/com/stark/shoot/application/port/out/message/LoadMessagePort.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/out/message/LoadMessagePort.kt
@@ -1,7 +1,7 @@
 package com.stark.shoot.application.port.out.message
 
 import com.stark.shoot.domain.chat.message.ChatMessage
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.MessageId
 import com.stark.shoot.domain.common.vo.UserId
 import kotlinx.coroutines.flow.Flow

--- a/src/main/kotlin/com/stark/shoot/application/port/out/message/LoadThreadPort.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/out/message/LoadThreadPort.kt
@@ -1,7 +1,7 @@
 package com.stark.shoot.application.port.out.message
 
 import com.stark.shoot.domain.chat.message.ChatMessage
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.MessageId
 
 interface LoadThreadPort {

--- a/src/main/kotlin/com/stark/shoot/application/port/out/message/ReadStatusPort.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/out/message/ReadStatusPort.kt
@@ -1,7 +1,7 @@
 package com.stark.shoot.application.port.out.message
 
 import com.stark.shoot.adapter.`in`.web.dto.message.read.ReadStatus
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.MessageId
 import com.stark.shoot.domain.common.vo.UserId
 

--- a/src/main/kotlin/com/stark/shoot/application/port/out/notification/DeleteNotificationPort.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/out/notification/DeleteNotificationPort.kt
@@ -1,7 +1,7 @@
 package com.stark.shoot.application.port.out.notification
 
 import com.stark.shoot.domain.common.vo.UserId
-import com.stark.shoot.domain.notification.NotificationId
+import com.stark.shoot.domain.notification.vo.NotificationId
 import com.stark.shoot.infrastructure.exception.web.MongoOperationException
 import com.stark.shoot.infrastructure.exception.web.ResourceNotFoundException
 

--- a/src/main/kotlin/com/stark/shoot/application/port/out/notification/LoadNotificationPort.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/out/notification/LoadNotificationPort.kt
@@ -2,9 +2,9 @@ package com.stark.shoot.application.port.out.notification
 
 import com.stark.shoot.domain.common.vo.UserId
 import com.stark.shoot.domain.notification.Notification
-import com.stark.shoot.domain.notification.NotificationType
-import com.stark.shoot.domain.notification.SourceType
-import com.stark.shoot.domain.notification.NotificationId
+import com.stark.shoot.domain.notification.type.NotificationType
+import com.stark.shoot.domain.notification.type.SourceType
+import com.stark.shoot.domain.notification.vo.NotificationId
 
 interface LoadNotificationPort {
 

--- a/src/main/kotlin/com/stark/shoot/application/service/chatroom/ManageChatRoomService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/chatroom/ManageChatRoomService.kt
@@ -6,9 +6,9 @@ import com.stark.shoot.application.port.out.chatroom.LoadChatRoomPort
 import com.stark.shoot.application.port.out.chatroom.SaveChatRoomPort
 import com.stark.shoot.application.port.out.user.FindUserPort
 import com.stark.shoot.domain.chat.room.ChatRoom
-import com.stark.shoot.domain.chat.room.ChatRoomAnnouncement
-import com.stark.shoot.domain.chat.room.ChatRoomId
-import com.stark.shoot.domain.chat.room.ChatRoomTitle
+import com.stark.shoot.domain.chat.room.vo.ChatRoomAnnouncement
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomTitle
 import com.stark.shoot.domain.common.vo.UserId
 import com.stark.shoot.domain.service.chatroom.ChatRoomParticipantDomainService
 import com.stark.shoot.infrastructure.annotation.UseCase

--- a/src/main/kotlin/com/stark/shoot/application/service/chatroom/UpdateChatRoomFavoriteService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/chatroom/UpdateChatRoomFavoriteService.kt
@@ -6,7 +6,7 @@ import com.stark.shoot.application.port.out.chatroom.LoadChatRoomPort
 import com.stark.shoot.application.port.out.chatroom.LoadPinnedRoomsPort
 import com.stark.shoot.application.port.out.chatroom.SaveChatRoomPort
 import com.stark.shoot.domain.chat.room.ChatRoom
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.UserId
 import com.stark.shoot.infrastructure.annotation.UseCase
 import com.stark.shoot.infrastructure.exception.web.ResourceNotFoundException

--- a/src/main/kotlin/com/stark/shoot/application/service/message/ForwardMessageService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/message/ForwardMessageService.kt
@@ -6,7 +6,7 @@ import com.stark.shoot.application.port.out.chatroom.SaveChatRoomPort
 import com.stark.shoot.application.port.out.message.LoadMessagePort
 import com.stark.shoot.application.port.out.message.SaveMessagePort
 import com.stark.shoot.domain.chat.message.ChatMessage
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.MessageId
 import com.stark.shoot.domain.common.vo.UserId
 import com.stark.shoot.domain.service.chatroom.ChatRoomMetadataDomainService

--- a/src/main/kotlin/com/stark/shoot/application/service/message/ForwardMessageToUserService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/message/ForwardMessageToUserService.kt
@@ -5,7 +5,7 @@ import com.stark.shoot.application.port.`in`.chatroom.CreateChatRoomUseCase
 import com.stark.shoot.application.port.`in`.message.ForwardMessageToUserUseCase
 import com.stark.shoot.application.port.`in`.message.ForwardMessageUseCase
 import com.stark.shoot.domain.chat.message.ChatMessage
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.MessageId
 import com.stark.shoot.domain.common.vo.UserId
 import com.stark.shoot.infrastructure.annotation.UseCase

--- a/src/main/kotlin/com/stark/shoot/application/service/message/GetMessagesService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/message/GetMessagesService.kt
@@ -4,7 +4,7 @@ import com.stark.shoot.adapter.`in`.web.dto.message.MessageResponseDto
 import com.stark.shoot.adapter.out.persistence.mongodb.mapper.ChatMessageMapper
 import com.stark.shoot.application.port.`in`.message.GetMessagesUseCase
 import com.stark.shoot.application.port.out.message.LoadMessagePort
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.MessageId
 import com.stark.shoot.infrastructure.annotation.UseCase
 

--- a/src/main/kotlin/com/stark/shoot/application/service/message/PaginationMessageSyncService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/message/PaginationMessageSyncService.kt
@@ -10,7 +10,7 @@ import com.stark.shoot.application.port.out.message.LoadMessagePort
 import com.stark.shoot.application.port.out.message.LoadThreadPort
 import com.stark.shoot.domain.chat.message.ChatMessage
 import com.stark.shoot.domain.chat.message.SyncDirection
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.MessageId
 import com.stark.shoot.infrastructure.annotation.UseCase
 import io.github.oshai.kotlinlogging.KotlinLogging

--- a/src/main/kotlin/com/stark/shoot/application/service/message/SendMessageService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/message/SendMessageService.kt
@@ -12,9 +12,9 @@ import com.stark.shoot.application.port.out.message.PublishMessagePort
 import com.stark.shoot.application.port.out.message.preview.CacheUrlPreviewPort
 import com.stark.shoot.application.port.out.message.preview.ExtractUrlPort
 import com.stark.shoot.domain.chat.event.ChatEvent
-import com.stark.shoot.domain.chat.event.EventType
+import com.stark.shoot.domain.chat.event.type.EventType
 import com.stark.shoot.domain.chat.message.ChatMessage
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.MessageId
 import com.stark.shoot.domain.common.vo.UserId
 import com.stark.shoot.infrastructure.annotation.UseCase

--- a/src/main/kotlin/com/stark/shoot/application/service/message/bookmark/MessageBookmarkService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/message/bookmark/MessageBookmarkService.kt
@@ -4,7 +4,7 @@ import com.stark.shoot.application.port.`in`.message.bookmark.BookmarkMessageUse
 import com.stark.shoot.application.port.out.message.BookmarkMessagePort
 import com.stark.shoot.application.port.out.message.LoadMessagePort
 import com.stark.shoot.domain.chat.bookmark.MessageBookmark
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.MessageId
 import com.stark.shoot.domain.common.vo.UserId
 import com.stark.shoot.infrastructure.annotation.UseCase

--- a/src/main/kotlin/com/stark/shoot/application/service/message/mark/MessageReadService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/message/mark/MessageReadService.kt
@@ -10,7 +10,7 @@ import com.stark.shoot.application.port.out.message.SaveMessagePort
 import com.stark.shoot.domain.chat.event.ChatBulkReadEvent
 import com.stark.shoot.domain.chat.event.ChatUnreadCountUpdatedEvent
 import com.stark.shoot.domain.chat.message.ChatMessage
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.MessageId
 import com.stark.shoot.domain.common.vo.UserId
 import com.stark.shoot.infrastructure.annotation.UseCase

--- a/src/main/kotlin/com/stark/shoot/application/service/message/pin/GetPinnedMessageService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/message/pin/GetPinnedMessageService.kt
@@ -3,7 +3,7 @@ package com.stark.shoot.application.service.message.pin
 import com.stark.shoot.application.port.`in`.message.pin.GetPinnedMessageUseCase
 import com.stark.shoot.application.port.out.message.LoadMessagePort
 import com.stark.shoot.domain.chat.message.ChatMessage
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.infrastructure.annotation.UseCase
 
 @UseCase

--- a/src/main/kotlin/com/stark/shoot/application/service/message/reaction/GetMessageReactionService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/message/reaction/GetMessageReactionService.kt
@@ -2,7 +2,7 @@ package com.stark.shoot.application.service.message.reaction
 
 import com.stark.shoot.application.port.`in`.message.reaction.GetMessageReactionUseCase
 import com.stark.shoot.application.port.out.message.LoadMessagePort
-import com.stark.shoot.domain.chat.reaction.ReactionType
+import com.stark.shoot.domain.chat.reaction.type.ReactionType
 import com.stark.shoot.domain.common.vo.MessageId
 import com.stark.shoot.infrastructure.annotation.UseCase
 import com.stark.shoot.infrastructure.exception.web.ResourceNotFoundException

--- a/src/main/kotlin/com/stark/shoot/application/service/message/reaction/ToggleMessageReactionService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/message/reaction/ToggleMessageReactionService.kt
@@ -6,8 +6,8 @@ import com.stark.shoot.application.port.out.event.EventPublisher
 import com.stark.shoot.application.port.out.message.LoadMessagePort
 import com.stark.shoot.application.port.out.message.SaveMessagePort
 import com.stark.shoot.domain.chat.message.ReactionToggleResult
-import com.stark.shoot.domain.chat.reaction.ReactionType
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.reaction.type.ReactionType
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.MessageId
 import com.stark.shoot.domain.common.vo.UserId
 import com.stark.shoot.domain.service.message.MessageReactionService

--- a/src/main/kotlin/com/stark/shoot/application/service/message/schedule/ScheduledMessageService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/message/schedule/ScheduledMessageService.kt
@@ -14,7 +14,7 @@ import com.stark.shoot.domain.chat.message.MessageContent
 import com.stark.shoot.domain.chat.message.ScheduledMessage
 import com.stark.shoot.domain.chat.message.ScheduledMessageStatus
 import com.stark.shoot.domain.chat.message.type.MessageType
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.UserId
 import com.stark.shoot.infrastructure.annotation.UseCase
 import com.stark.shoot.infrastructure.util.toObjectId

--- a/src/main/kotlin/com/stark/shoot/application/service/message/thread/GetThreadsService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/message/thread/GetThreadsService.kt
@@ -4,7 +4,7 @@ import com.stark.shoot.adapter.`in`.web.dto.message.thread.ThreadSummaryDto
 import com.stark.shoot.adapter.out.persistence.mongodb.mapper.ChatMessageMapper
 import com.stark.shoot.application.port.`in`.message.thread.GetThreadsUseCase
 import com.stark.shoot.application.port.out.message.LoadThreadPort
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.MessageId
 import com.stark.shoot.infrastructure.annotation.UseCase
 

--- a/src/main/kotlin/com/stark/shoot/application/service/notification/NotificationManagementService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/notification/NotificationManagementService.kt
@@ -6,9 +6,9 @@ import com.stark.shoot.application.port.out.notification.SaveNotificationPort
 import com.stark.shoot.domain.common.vo.UserId
 import com.stark.shoot.domain.exception.NotificationException
 import com.stark.shoot.domain.notification.Notification
-import com.stark.shoot.domain.notification.NotificationId
-import com.stark.shoot.domain.notification.NotificationType
-import com.stark.shoot.domain.notification.SourceType
+import com.stark.shoot.domain.notification.vo.NotificationId
+import com.stark.shoot.domain.notification.type.NotificationType
+import com.stark.shoot.domain.notification.type.SourceType
 import com.stark.shoot.domain.notification.service.NotificationDomainService
 import com.stark.shoot.infrastructure.exception.web.MongoOperationException
 import com.stark.shoot.infrastructure.exception.web.ResourceNotFoundException

--- a/src/main/kotlin/com/stark/shoot/application/service/notification/NotificationQueryService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/notification/NotificationQueryService.kt
@@ -4,8 +4,8 @@ import com.stark.shoot.application.port.`in`.notification.NotificationQueryUseCa
 import com.stark.shoot.application.port.out.notification.LoadNotificationPort
 import com.stark.shoot.domain.common.vo.UserId
 import com.stark.shoot.domain.notification.Notification
-import com.stark.shoot.domain.notification.NotificationType
-import com.stark.shoot.domain.notification.SourceType
+import com.stark.shoot.domain.notification.type.NotificationType
+import com.stark.shoot.domain.notification.type.SourceType
 import org.springframework.stereotype.Service
 
 @Service

--- a/src/main/kotlin/com/stark/shoot/application/service/sse/SseEmitterService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/sse/SseEmitterService.kt
@@ -4,7 +4,7 @@ import com.stark.shoot.application.port.`in`.chatroom.SseEmitterUseCase
 import com.stark.shoot.domain.chat.event.ChatRoomCreatedEvent
 import com.stark.shoot.domain.chat.event.FriendAddedEvent
 import com.stark.shoot.domain.chat.event.FriendRemovedEvent
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.UserId
 import com.stark.shoot.infrastructure.annotation.UseCase
 import io.github.oshai.kotlinlogging.KotlinLogging

--- a/src/main/kotlin/com/stark/shoot/domain/chat/event/MessageReactionEvent.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/event/MessageReactionEvent.kt
@@ -1,6 +1,6 @@
 package com.stark.shoot.domain.chat.event
 
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.DomainEvent
 import com.stark.shoot.domain.common.vo.MessageId
 import com.stark.shoot.domain.common.vo.UserId

--- a/src/main/kotlin/com/stark/shoot/domain/chat/event/type/EventType.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/event/type/EventType.kt
@@ -1,4 +1,4 @@
-package com.stark.shoot.domain.chat.event
+package com.stark.shoot.domain.chat.event.type
 
 enum class EventType(
     private val code: String,

--- a/src/main/kotlin/com/stark/shoot/domain/chat/message/ChatMessage.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/message/ChatMessage.kt
@@ -2,11 +2,11 @@ package com.stark.shoot.domain.chat.message
 
 import com.stark.shoot.domain.chat.message.type.MessageStatus
 import com.stark.shoot.domain.chat.message.type.MessageType
-import com.stark.shoot.domain.chat.reaction.MessageReactions
-import com.stark.shoot.domain.chat.reaction.ReactionType
+import com.stark.shoot.domain.chat.reaction.vo.MessageReactions
+import com.stark.shoot.domain.chat.reaction.type.ReactionType
 import com.stark.shoot.domain.common.vo.MessageId
 import com.stark.shoot.domain.common.vo.UserId
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import java.time.Instant
 
 data class ChatMessage(

--- a/src/main/kotlin/com/stark/shoot/domain/chat/message/ReactionToggleResult.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/message/ReactionToggleResult.kt
@@ -1,6 +1,6 @@
 package com.stark.shoot.domain.chat.message
 
-import com.stark.shoot.domain.chat.reaction.MessageReactions
+import com.stark.shoot.domain.chat.reaction.vo.MessageReactions
 import com.stark.shoot.domain.common.vo.UserId
 
 /**

--- a/src/main/kotlin/com/stark/shoot/domain/chat/reaction/type/ReactionType.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/reaction/type/ReactionType.kt
@@ -1,4 +1,4 @@
-package com.stark.shoot.domain.chat.reaction
+package com.stark.shoot.domain.chat.reaction.type
 
 enum class ReactionType(
     val code: String,

--- a/src/main/kotlin/com/stark/shoot/domain/chat/reaction/vo/MessageReactions.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/reaction/vo/MessageReactions.kt
@@ -1,4 +1,4 @@
-package com.stark.shoot.domain.chat.reaction
+package com.stark.shoot.domain.chat.reaction.vo
 
 /**
  * 메시지 반응을 관리하는 값 객체입니다.

--- a/src/main/kotlin/com/stark/shoot/domain/chat/room/ChatRoom.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/room/ChatRoom.kt
@@ -3,6 +3,11 @@ package com.stark.shoot.domain.chat.room
 import com.stark.shoot.domain.common.vo.MessageId
 import com.stark.shoot.domain.common.vo.UserId
 import com.stark.shoot.domain.exception.FavoriteLimitExceededException
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomTitle
+import com.stark.shoot.domain.chat.room.vo.ChatRoomAnnouncement
+import com.stark.shoot.domain.chat.room.vo.RetentionDays
+import com.stark.shoot.domain.chat.room.type.ChatRoomType
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter

--- a/src/main/kotlin/com/stark/shoot/domain/chat/room/ChatRoomSettings.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/room/ChatRoomSettings.kt
@@ -1,5 +1,7 @@
 package com.stark.shoot.domain.chat.room
 
+import com.stark.shoot.domain.chat.room.vo.RetentionDays
+
 data class ChatRoomSettings(
     val isNotificationEnabled: Boolean = true,
     val retentionDays: RetentionDays? = null,

--- a/src/main/kotlin/com/stark/shoot/domain/chat/room/type/ChatRoomType.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/room/type/ChatRoomType.kt
@@ -1,4 +1,4 @@
-package com.stark.shoot.domain.chat.room
+package com.stark.shoot.domain.chat.room.type
 
 /**
  * 채팅방 유형을 나타내는 열거형

--- a/src/main/kotlin/com/stark/shoot/domain/chat/room/vo/ChatRoomAnnouncement.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/room/vo/ChatRoomAnnouncement.kt
@@ -1,4 +1,4 @@
-package com.stark.shoot.domain.chat.room
+package com.stark.shoot.domain.chat.room.vo
 
 @JvmInline
 value class ChatRoomAnnouncement private constructor(val value: String) {

--- a/src/main/kotlin/com/stark/shoot/domain/chat/room/vo/ChatRoomId.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/room/vo/ChatRoomId.kt
@@ -1,4 +1,4 @@
-package com.stark.shoot.domain.chat.room
+package com.stark.shoot.domain.chat.room.vo
 
 @JvmInline
 value class ChatRoomId private constructor(val value: Long) {

--- a/src/main/kotlin/com/stark/shoot/domain/chat/room/vo/ChatRoomTitle.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/room/vo/ChatRoomTitle.kt
@@ -1,4 +1,4 @@
-package com.stark.shoot.domain.chat.room
+package com.stark.shoot.domain.chat.room.vo
 
 @JvmInline
 value class ChatRoomTitle private constructor(val value: String) {

--- a/src/main/kotlin/com/stark/shoot/domain/chat/room/vo/RetentionDays.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/room/vo/RetentionDays.kt
@@ -1,4 +1,4 @@
-package com.stark.shoot.domain.chat.room
+package com.stark.shoot.domain.chat.room.vo
 
 @JvmInline
 value class RetentionDays private constructor(val value: Int) {

--- a/src/main/kotlin/com/stark/shoot/domain/chat/user/FriendGroup.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/user/FriendGroup.kt
@@ -1,6 +1,7 @@
 package com.stark.shoot.domain.chat.user
 
 import com.stark.shoot.domain.common.vo.UserId
+import com.stark.shoot.domain.chat.user.vo.FriendGroupName
 import java.time.Instant
 
 /**

--- a/src/main/kotlin/com/stark/shoot/domain/chat/user/FriendRequest.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/user/FriendRequest.kt
@@ -1,6 +1,7 @@
 package com.stark.shoot.domain.chat.user
 
 import java.time.Instant
+import com.stark.shoot.domain.chat.user.type.FriendRequestStatus
 
 /**
  * 친구 요청 애그리게이트

--- a/src/main/kotlin/com/stark/shoot/domain/chat/user/RefreshToken.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/user/RefreshToken.kt
@@ -1,7 +1,7 @@
 package com.stark.shoot.domain.chat.user
 
 import java.time.Instant
-import com.stark.shoot.domain.chat.user.RefreshTokenValue
+import com.stark.shoot.domain.chat.user.vo.RefreshTokenValue
 
 data class RefreshToken(
     val id: Long? = null,

--- a/src/main/kotlin/com/stark/shoot/domain/chat/user/User.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/user/User.kt
@@ -1,6 +1,13 @@
 package com.stark.shoot.domain.chat.user
 
 import com.stark.shoot.domain.common.vo.UserId
+import com.stark.shoot.domain.chat.user.vo.Username
+import com.stark.shoot.domain.chat.user.vo.Nickname
+import com.stark.shoot.domain.chat.user.vo.UserCode
+import com.stark.shoot.domain.chat.user.vo.ProfileImageUrl
+import com.stark.shoot.domain.chat.user.vo.BackgroundImageUrl
+import com.stark.shoot.domain.chat.user.vo.UserBio
+import com.stark.shoot.domain.chat.user.type.UserStatus
 import com.stark.shoot.domain.exception.InvalidUserDataException
 import java.time.Instant
 

--- a/src/main/kotlin/com/stark/shoot/domain/chat/user/type/FriendRequestStatus.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/user/type/FriendRequestStatus.kt
@@ -1,4 +1,4 @@
-package com.stark.shoot.domain.chat.user
+package com.stark.shoot.domain.chat.user.type
 
 /**
  * 친구 요청 상태를 나타내는 열거형

--- a/src/main/kotlin/com/stark/shoot/domain/chat/user/type/UserStatus.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/user/type/UserStatus.kt
@@ -1,4 +1,4 @@
-package com.stark.shoot.domain.chat.user
+package com.stark.shoot.domain.chat.user.type
 
 enum class UserStatus {
     OFFLINE,

--- a/src/main/kotlin/com/stark/shoot/domain/chat/user/vo/BackgroundImageUrl.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/user/vo/BackgroundImageUrl.kt
@@ -1,4 +1,4 @@
-package com.stark.shoot.domain.chat.user
+package com.stark.shoot.domain.chat.user.vo
 
 @JvmInline
 value class BackgroundImageUrl private constructor(val value: String) {

--- a/src/main/kotlin/com/stark/shoot/domain/chat/user/vo/FriendGroupName.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/user/vo/FriendGroupName.kt
@@ -1,4 +1,4 @@
-package com.stark.shoot.domain.chat.user
+package com.stark.shoot.domain.chat.user.vo
 
 @JvmInline
 value class FriendGroupName private constructor(val value: String) {

--- a/src/main/kotlin/com/stark/shoot/domain/chat/user/vo/Nickname.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/user/vo/Nickname.kt
@@ -1,4 +1,4 @@
-package com.stark.shoot.domain.chat.user
+package com.stark.shoot.domain.chat.user.vo
 
 import com.stark.shoot.domain.exception.InvalidUserDataException
 

--- a/src/main/kotlin/com/stark/shoot/domain/chat/user/vo/ProfileImageUrl.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/user/vo/ProfileImageUrl.kt
@@ -1,4 +1,4 @@
-package com.stark.shoot.domain.chat.user
+package com.stark.shoot.domain.chat.user.vo
 
 @JvmInline
 value class ProfileImageUrl private constructor(val value: String) {

--- a/src/main/kotlin/com/stark/shoot/domain/chat/user/vo/RefreshTokenValue.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/user/vo/RefreshTokenValue.kt
@@ -1,4 +1,4 @@
-package com.stark.shoot.domain.chat.user
+package com.stark.shoot.domain.chat.user.vo
 
 @JvmInline
 value class RefreshTokenValue private constructor(val value: String) {

--- a/src/main/kotlin/com/stark/shoot/domain/chat/user/vo/UserBio.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/user/vo/UserBio.kt
@@ -1,4 +1,4 @@
-package com.stark.shoot.domain.chat.user
+package com.stark.shoot.domain.chat.user.vo
 
 @JvmInline
 value class UserBio private constructor(val value: String) {

--- a/src/main/kotlin/com/stark/shoot/domain/chat/user/vo/UserCode.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/user/vo/UserCode.kt
@@ -1,4 +1,4 @@
-package com.stark.shoot.domain.chat.user
+package com.stark.shoot.domain.chat.user.vo
 
 import java.util.UUID
 

--- a/src/main/kotlin/com/stark/shoot/domain/chat/user/vo/Username.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/user/vo/Username.kt
@@ -1,5 +1,5 @@
 @file:JvmName("Username")
-package com.stark.shoot.domain.chat.user
+package com.stark.shoot.domain.chat.user.vo
 
 import com.stark.shoot.domain.exception.InvalidUserDataException
 

--- a/src/main/kotlin/com/stark/shoot/domain/notification/Notification.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/notification/Notification.kt
@@ -2,9 +2,9 @@ package com.stark.shoot.domain.notification
 
 import com.stark.shoot.domain.exception.NotificationException
 import com.stark.shoot.domain.notification.event.NotificationEvent
-import com.stark.shoot.domain.notification.NotificationTitle
-import com.stark.shoot.domain.notification.NotificationId
-import com.stark.shoot.domain.notification.NotificationMessage
+import com.stark.shoot.domain.notification.vo.NotificationTitle
+import com.stark.shoot.domain.notification.vo.NotificationId
+import com.stark.shoot.domain.notification.vo.NotificationMessage
 import com.stark.shoot.domain.common.vo.UserId
 import java.time.Instant
 

--- a/src/main/kotlin/com/stark/shoot/domain/notification/event/MentionEvent.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/notification/event/MentionEvent.kt
@@ -1,7 +1,7 @@
 package com.stark.shoot.domain.notification.event
 
-import com.stark.shoot.domain.notification.NotificationType
-import com.stark.shoot.domain.notification.SourceType
+import com.stark.shoot.domain.notification.type.NotificationType
+import com.stark.shoot.domain.notification.type.SourceType
 import com.stark.shoot.domain.common.vo.UserId
 import java.time.Instant
 

--- a/src/main/kotlin/com/stark/shoot/domain/notification/event/NewMessageEvent.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/notification/event/NewMessageEvent.kt
@@ -1,7 +1,7 @@
 package com.stark.shoot.domain.notification.event
 
-import com.stark.shoot.domain.notification.NotificationType
-import com.stark.shoot.domain.notification.SourceType
+import com.stark.shoot.domain.notification.type.NotificationType
+import com.stark.shoot.domain.notification.type.SourceType
 import com.stark.shoot.domain.common.vo.UserId
 import java.time.Instant
 

--- a/src/main/kotlin/com/stark/shoot/domain/notification/event/NotificationEvent.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/notification/event/NotificationEvent.kt
@@ -1,7 +1,7 @@
 package com.stark.shoot.domain.notification.event
 
-import com.stark.shoot.domain.notification.NotificationType
-import com.stark.shoot.domain.notification.SourceType
+import com.stark.shoot.domain.notification.type.NotificationType
+import com.stark.shoot.domain.notification.type.SourceType
 import com.stark.shoot.domain.common.vo.UserId
 import java.time.Instant
 

--- a/src/main/kotlin/com/stark/shoot/domain/notification/type/NotificationType.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/notification/type/NotificationType.kt
@@ -1,4 +1,4 @@
-package com.stark.shoot.domain.notification
+package com.stark.shoot.domain.notification.type
 
 enum class NotificationType(
     val description: String = "",

--- a/src/main/kotlin/com/stark/shoot/domain/notification/type/SourceType.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/notification/type/SourceType.kt
@@ -1,4 +1,4 @@
-package com.stark.shoot.domain.notification
+package com.stark.shoot.domain.notification.type
 
 enum class SourceType(
     val description: String = "",

--- a/src/main/kotlin/com/stark/shoot/domain/notification/vo/NotificationId.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/notification/vo/NotificationId.kt
@@ -1,4 +1,4 @@
-package com.stark.shoot.domain.notification
+package com.stark.shoot.domain.notification.vo
 
 @JvmInline
 value class NotificationId private constructor(val value: String) {

--- a/src/main/kotlin/com/stark/shoot/domain/notification/vo/NotificationMessage.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/notification/vo/NotificationMessage.kt
@@ -1,4 +1,4 @@
-package com.stark.shoot.domain.notification
+package com.stark.shoot.domain.notification.vo
 
 @JvmInline
 value class NotificationMessage private constructor(val value: String) {

--- a/src/main/kotlin/com/stark/shoot/domain/notification/vo/NotificationTitle.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/notification/vo/NotificationTitle.kt
@@ -1,4 +1,4 @@
-package com.stark.shoot.domain.notification
+package com.stark.shoot.domain.notification.vo
 
 @JvmInline
 value class NotificationTitle private constructor(val value: String) {

--- a/src/main/kotlin/com/stark/shoot/domain/service/message/MessageDomainService.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/service/message/MessageDomainService.kt
@@ -1,11 +1,11 @@
 package com.stark.shoot.domain.service.message
 
 import com.stark.shoot.domain.chat.event.ChatEvent
-import com.stark.shoot.domain.chat.event.EventType
+import com.stark.shoot.domain.chat.event.type.EventType
 import com.stark.shoot.domain.chat.message.ChatMessage
 import com.stark.shoot.domain.chat.message.UrlPreview
 import com.stark.shoot.domain.common.vo.MessageId
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.UserId
 import java.util.*
 

--- a/src/main/kotlin/com/stark/shoot/domain/service/message/MessageForwardDomainService.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/service/message/MessageForwardDomainService.kt
@@ -3,8 +3,8 @@ package com.stark.shoot.domain.service.message
 import com.stark.shoot.domain.chat.message.type.MessageStatus
 import com.stark.shoot.domain.chat.message.ChatMessage
 import com.stark.shoot.domain.chat.message.MessageContent
-import com.stark.shoot.domain.chat.reaction.MessageReactions
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.reaction.vo.MessageReactions
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.UserId
 import java.time.Instant
 

--- a/src/main/kotlin/com/stark/shoot/infrastructure/config/socket/interceptor/StompChannelInterceptor.kt
+++ b/src/main/kotlin/com/stark/shoot/infrastructure/config/socket/interceptor/StompChannelInterceptor.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.stark.shoot.adapter.`in`.web.dto.message.ChatMessageRequest
 import com.stark.shoot.application.port.out.chatroom.LoadChatRoomPort
 import com.stark.shoot.application.port.out.user.FindUserPort
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.UserId
 import com.stark.shoot.infrastructure.config.socket.StompPrincipal
 import com.stark.shoot.infrastructure.exception.web.WebSocketException

--- a/src/test/kotlin/com/stark/shoot/adapter/persistence/chatroom/LoadChatRoomPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/stark/shoot/adapter/persistence/chatroom/LoadChatRoomPersistenceAdapterTest.kt
@@ -5,7 +5,7 @@ import com.stark.shoot.adapter.out.persistence.postgres.mapper.ChatRoomMapper
 import com.stark.shoot.adapter.out.persistence.postgres.repository.ChatRoomRepository
 import com.stark.shoot.adapter.out.persistence.postgres.repository.ChatRoomUserRepository
 import com.stark.shoot.adapter.out.persistence.postgres.repository.UserRepository
-import com.stark.shoot.domain.chat.room.ChatRoomType
+import com.stark.shoot.domain.chat.room.type.ChatRoomType
 import com.stark.shoot.util.TestEntityFactory
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName

--- a/src/test/kotlin/com/stark/shoot/adapter/persistence/chatroom/LoadPinnedRoomsPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/stark/shoot/adapter/persistence/chatroom/LoadPinnedRoomsPersistenceAdapterTest.kt
@@ -5,7 +5,7 @@ import com.stark.shoot.adapter.out.persistence.postgres.mapper.ChatRoomMapper
 import com.stark.shoot.adapter.out.persistence.postgres.repository.ChatRoomRepository
 import com.stark.shoot.adapter.out.persistence.postgres.repository.ChatRoomUserRepository
 import com.stark.shoot.adapter.out.persistence.postgres.repository.UserRepository
-import com.stark.shoot.domain.chat.room.ChatRoomType
+import com.stark.shoot.domain.chat.room.type.ChatRoomType
 import com.stark.shoot.util.TestEntityFactory
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName

--- a/src/test/kotlin/com/stark/shoot/adapter/persistence/chatroom/SaveChatRoomPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/stark/shoot/adapter/persistence/chatroom/SaveChatRoomPersistenceAdapterTest.kt
@@ -5,7 +5,7 @@ import com.stark.shoot.adapter.out.persistence.postgres.mapper.ChatRoomMapper
 import com.stark.shoot.adapter.out.persistence.postgres.repository.ChatRoomRepository
 import com.stark.shoot.adapter.out.persistence.postgres.repository.ChatRoomUserRepository
 import com.stark.shoot.adapter.out.persistence.postgres.repository.UserRepository
-import com.stark.shoot.domain.chat.room.ChatRoomType
+import com.stark.shoot.domain.chat.room.type.ChatRoomType
 import com.stark.shoot.util.TestEntityFactory
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName

--- a/src/test/kotlin/com/stark/shoot/application/service/message/reaction/GetMessageReactionServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/application/service/message/reaction/GetMessageReactionServiceTest.kt
@@ -3,8 +3,8 @@ package com.stark.shoot.application.service.message.reaction
 import com.stark.shoot.application.port.out.message.LoadMessagePort
 import com.stark.shoot.domain.chat.message.ChatMessage
 import com.stark.shoot.domain.chat.message.MessageContent
-import com.stark.shoot.domain.chat.reaction.MessageReactions
-import com.stark.shoot.domain.chat.reaction.ReactionType
+import com.stark.shoot.domain.chat.reaction.vo.MessageReactions
+import com.stark.shoot.domain.chat.reaction.type.ReactionType
 import com.stark.shoot.infrastructure.exception.web.ResourceNotFoundException
 import com.stark.shoot.infrastructure.util.toObjectId
 import org.assertj.core.api.Assertions.assertThat

--- a/src/test/kotlin/com/stark/shoot/application/service/message/reaction/ToggleMessageReactionServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/application/service/message/reaction/ToggleMessageReactionServiceTest.kt
@@ -10,8 +10,8 @@ import com.stark.shoot.domain.chat.event.MessageReactionEvent
 import com.stark.shoot.domain.chat.message.ChatMessage
 import com.stark.shoot.domain.chat.message.MessageContent
 import com.stark.shoot.domain.chat.message.ReactionToggleResult
-import com.stark.shoot.domain.chat.reaction.MessageReactions
-import com.stark.shoot.domain.chat.reaction.ReactionType
+import com.stark.shoot.domain.chat.reaction.vo.MessageReactions
+import com.stark.shoot.domain.chat.reaction.type.ReactionType
 import com.stark.shoot.domain.service.message.MessageReactionService
 import com.stark.shoot.infrastructure.exception.web.InvalidInputException
 import com.stark.shoot.infrastructure.exception.web.ResourceNotFoundException

--- a/src/test/kotlin/com/stark/shoot/application/service/message/schedule/ScheduledMessageServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/application/service/message/schedule/ScheduledMessageServiceTest.kt
@@ -12,7 +12,7 @@ import com.stark.shoot.application.port.out.message.ScheduledMessagePort
 import com.stark.shoot.domain.chat.message.MessageContent
 import com.stark.shoot.domain.chat.message.ScheduledMessage
 import com.stark.shoot.domain.chat.room.ChatRoom
-import com.stark.shoot.domain.chat.room.ChatRoomType
+import com.stark.shoot.domain.chat.room.type.ChatRoomType
 import com.stark.shoot.domain.chat.message.ScheduledMessageStatus
 import com.stark.shoot.domain.common.vo.MessageId
 import org.assertj.core.api.Assertions.assertThat

--- a/src/test/kotlin/com/stark/shoot/domain/chat/message/ChatMessageTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/chat/message/ChatMessageTest.kt
@@ -2,8 +2,8 @@ package com.stark.shoot.domain.chat.message
 
 import com.stark.shoot.domain.chat.message.type.MessageStatus
 import com.stark.shoot.domain.chat.message.type.MessageType
-import com.stark.shoot.domain.chat.reaction.MessageReactions
-import com.stark.shoot.domain.chat.reaction.ReactionType
+import com.stark.shoot.domain.chat.reaction.vo.MessageReactions
+import com.stark.shoot.domain.chat.reaction.type.ReactionType
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName

--- a/src/test/kotlin/com/stark/shoot/domain/chat/room/ChatRoomTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/chat/room/ChatRoomTest.kt
@@ -1,9 +1,9 @@
 package com.stark.shoot.domain.chat.room
 
 import com.stark.shoot.domain.exception.FavoriteLimitExceededException
-import com.stark.shoot.domain.chat.room.ChatRoomTitle
-import com.stark.shoot.domain.chat.room.ChatRoomAnnouncement
-import com.stark.shoot.domain.chat.room.ChatRoomId
+import com.stark.shoot.domain.chat.room.vo.ChatRoomTitle
+import com.stark.shoot.domain.chat.room.vo.ChatRoomAnnouncement
+import com.stark.shoot.domain.chat.room.vo.ChatRoomId
 import com.stark.shoot.domain.common.vo.MessageId
 import com.stark.shoot.domain.common.vo.UserId
 import org.assertj.core.api.Assertions.assertThat

--- a/src/test/kotlin/com/stark/shoot/domain/notification/service/NotificationDomainServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/notification/service/NotificationDomainServiceTest.kt
@@ -1,8 +1,8 @@
 package com.stark.shoot.domain.notification.service
 
 import com.stark.shoot.domain.notification.Notification
-import com.stark.shoot.domain.notification.NotificationType
-import com.stark.shoot.domain.notification.SourceType
+import com.stark.shoot.domain.notification.type.NotificationType
+import com.stark.shoot.domain.notification.type.SourceType
 import com.stark.shoot.domain.notification.event.NotificationEvent
 import com.stark.shoot.domain.common.vo.UserId
 import kotlin.test.Test

--- a/src/test/kotlin/com/stark/shoot/domain/service/chatroom/ChatRoomDomainServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/service/chatroom/ChatRoomDomainServiceTest.kt
@@ -1,7 +1,7 @@
 package com.stark.shoot.domain.service.chatroom
 
 import com.stark.shoot.domain.chat.room.ChatRoom
-import com.stark.shoot.domain.chat.room.ChatRoomType
+import com.stark.shoot.domain.chat.room.type.ChatRoomType
 import com.stark.shoot.domain.chat.room.service.ChatRoomDomainService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName

--- a/src/test/kotlin/com/stark/shoot/domain/service/chatroom/ChatRoomEventServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/service/chatroom/ChatRoomEventServiceTest.kt
@@ -2,7 +2,7 @@ package com.stark.shoot.domain.service.chatroom
 
 import com.stark.shoot.domain.chat.event.ChatRoomCreatedEvent
 import com.stark.shoot.domain.chat.room.ChatRoom
-import com.stark.shoot.domain.chat.room.ChatRoomType
+import com.stark.shoot.domain.chat.room.type.ChatRoomType
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/com/stark/shoot/domain/service/chatroom/ChatRoomMetadataDomainServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/service/chatroom/ChatRoomMetadataDomainServiceTest.kt
@@ -17,14 +17,14 @@ class ChatRoomMetadataDomainServiceTest {
 
     @Test
     fun `메시지 ID가 없으면 예외가 발생한다`() {
-        val room = ChatRoom(title = "room", type = com.stark.shoot.domain.chat.room.ChatRoomType.GROUP, participants = mutableSetOf(1L))
+        val room = ChatRoom(title = "room", type = com.stark.shoot.domain.chat.room.type.ChatRoomType.GROUP, participants = mutableSetOf(1L))
         val msg = ChatMessage(roomId = 1L, senderId = 2L, content = MessageContent("hi", MessageType.TEXT), status = MessageStatus.SAVED, createdAt = Instant.now())
         assertThrows<IllegalArgumentException> { service.updateChatRoomWithNewMessage(room, msg) }
     }
 
     @Test
     fun `새 메시지로 채팅방 메타데이터를 업데이트할 수 있다`() {
-        val room = ChatRoom(id = 1L, title = "room", type = com.stark.shoot.domain.chat.room.ChatRoomType.GROUP, participants = mutableSetOf(1L))
+        val room = ChatRoom(id = 1L, title = "room", type = com.stark.shoot.domain.chat.room.type.ChatRoomType.GROUP, participants = mutableSetOf(1L))
         val msg = ChatMessage(id = "m1", roomId = 1L, senderId = 2L, content = MessageContent("hi", MessageType.TEXT), status = MessageStatus.SAVED, createdAt = Instant.now())
         val updated = service.updateChatRoomWithNewMessage(room, msg)
         assertThat(updated.lastMessageId).isEqualTo("m1")

--- a/src/test/kotlin/com/stark/shoot/domain/service/chatroom/ChatRoomParticipantDomainServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/service/chatroom/ChatRoomParticipantDomainServiceTest.kt
@@ -1,7 +1,7 @@
 package com.stark.shoot.domain.service.chatroom
 
 import com.stark.shoot.domain.chat.room.ChatRoom
-import com.stark.shoot.domain.chat.room.ChatRoomType
+import com.stark.shoot.domain.chat.room.type.ChatRoomType
 import com.stark.shoot.domain.service.chatroom.ChatRoomParticipantDomainService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName

--- a/src/test/kotlin/com/stark/shoot/domain/service/message/MessageReactionServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/service/message/MessageReactionServiceTest.kt
@@ -6,7 +6,7 @@ import com.stark.shoot.domain.chat.message.MessageContent
 import com.stark.shoot.domain.chat.message.ReactionToggleResult
 import com.stark.shoot.domain.chat.message.type.MessageStatus
 import com.stark.shoot.domain.chat.message.type.MessageType
-import com.stark.shoot.domain.chat.reaction.MessageReactions
+import com.stark.shoot.domain.chat.reaction.vo.MessageReactions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested

--- a/src/test/kotlin/com/stark/shoot/util/TestEntityFactory.kt
+++ b/src/test/kotlin/com/stark/shoot/util/TestEntityFactory.kt
@@ -5,7 +5,7 @@ import com.stark.shoot.adapter.out.persistence.postgres.entity.ChatRoomUserEntit
 import com.stark.shoot.adapter.out.persistence.postgres.entity.UserEntity
 import com.stark.shoot.adapter.out.persistence.postgres.entity.enumerate.ChatRoomUserRole
 import com.stark.shoot.domain.chat.room.ChatRoom
-import com.stark.shoot.domain.chat.room.ChatRoomType
+import com.stark.shoot.domain.chat.room.type.ChatRoomType
 import com.stark.shoot.domain.chat.user.UserStatus
 import java.time.Instant
 


### PR DESCRIPTION
## Summary
- move scattered value objects into dedicated `vo` packages
- separate enums into `type` packages
- update imports across application and tests

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68559ea1112c8320a6d67ce8e4c14a75