### PR TITLE
Use value objects across domain events

### DIFF
--- a/src/main/kotlin/com/stark/shoot/adapter/in/event/listener/sse/ChatUnreadCountEventListener.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/event/listener/sse/ChatUnreadCountEventListener.kt
@@ -21,8 +21,8 @@ class ChatUnreadCountEventListener(
     fun handle(event: MessageUnreadCountUpdatedEvent) {
         event.unreadCounts.forEach { (userId, count) ->
             sseEmitterUseCase.sendUpdate(
-                UserId.from(userId),
-                ChatRoomId.from(event.roomId),
+                userId,
+                event.roomId,
                 count,
                 event.lastMessage
             )

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/mapper/RefreshTokenMapper.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/mapper/RefreshTokenMapper.kt
@@ -3,6 +3,7 @@ package com.stark.shoot.adapter.out.persistence.postgres.mapper
 import com.stark.shoot.adapter.out.persistence.postgres.entity.RefreshTokenEntity
 import com.stark.shoot.domain.user.RefreshToken
 import com.stark.shoot.domain.user.vo.RefreshTokenValue
+import com.stark.shoot.domain.user.vo.UserId
 import org.springframework.stereotype.Component
 
 @Component
@@ -14,7 +15,7 @@ class RefreshTokenMapper {
     fun toDomain(entity: RefreshTokenEntity): RefreshToken {
         return RefreshToken(
             id = entity.id,
-            userId = entity.user.id,
+            userId = UserId.from(entity.user.id),
             token = RefreshTokenValue.from(entity.token),
             expirationDate = entity.expirationDate,
             deviceInfo = entity.deviceInfo,

--- a/src/main/kotlin/com/stark/shoot/application/service/sse/SseEmitterService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/sse/SseEmitterService.kt
@@ -306,11 +306,11 @@ class SseEmitterService : SseEmitterUseCase {
      * 채팅방 생성 이벤트 전송
      */
     override fun sendChatRoomCreatedEvent(event: ChatRoomCreatedEvent) {
-        val userId = UserId.from(event.userId)
+        val userId = event.userId
 
         val data = mapOf(
             "type" to "room_created",
-            "roomId" to event.roomId,
+            "roomId" to event.roomId.value,
             "timestamp" to System.currentTimeMillis()
         )
 
@@ -318,7 +318,7 @@ class SseEmitterService : SseEmitterUseCase {
             userId = userId,
             eventName = "chatRoomCreated",
             data = data,
-            logMessage = "Sent chatRoomCreated event to user: ${userId.value}, roomId: ${event.roomId}"
+            logMessage = "Sent chatRoomCreated event to user: ${userId.value}, roomId: ${event.roomId.value}"
         )
     }
 
@@ -326,11 +326,11 @@ class SseEmitterService : SseEmitterUseCase {
      * 친구 추가 이벤트 전송
      */
     override fun sendFriendAddedEvent(event: FriendAddedEvent) {
-        val userId = UserId.from(event.userId)
+        val userId = event.userId
 
         val data = mapOf(
             "type" to "friend_added",
-            "friendId" to event.friendId,
+            "friendId" to event.friendId.value,
             "timestamp" to System.currentTimeMillis()
         )
 
@@ -338,7 +338,7 @@ class SseEmitterService : SseEmitterUseCase {
             userId = userId,
             eventName = "friendAdded",
             data = data,
-            logMessage = "Sent friendAdded event to user: ${userId.value}, friendId: ${event.friendId}"
+            logMessage = "Sent friendAdded event to user: ${userId.value}, friendId: ${event.friendId.value}"
         )
     }
 
@@ -346,11 +346,11 @@ class SseEmitterService : SseEmitterUseCase {
      * 친구 삭제 이벤트 전송
      */
     override fun sendFriendRemovedEvent(event: FriendRemovedEvent) {
-        val userId = UserId.from(event.userId)
+        val userId = event.userId
 
         val data = mapOf(
             "type" to "friend_removed",
-            "friendId" to event.friendId,
+            "friendId" to event.friendId.value,
             "timestamp" to System.currentTimeMillis()
         )
 
@@ -358,7 +358,7 @@ class SseEmitterService : SseEmitterUseCase {
             userId = userId,
             eventName = "friendRemoved",
             data = data,
-            logMessage = "Sent friendRemoved event to user: ${userId.value}, friendId: ${event.friendId}"
+            logMessage = "Sent friendRemoved event to user: ${userId.value}, friendId: ${event.friendId.value}"
         )
     }
 

--- a/src/main/kotlin/com/stark/shoot/domain/chat/message/service/MessagePinDomainService.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/message/service/MessagePinDomainService.kt
@@ -26,10 +26,10 @@ class MessagePinDomainService {
         val messageId = message.id ?: return null
 
         return MessagePinEvent.create(
-            messageId = messageId.value,
-            roomId = message.roomId.value,
+            messageId = messageId,
+            roomId = message.roomId,
             isPinned = isPinned,
-            userId = userId.value
+            userId = userId
         )
     }
 

--- a/src/main/kotlin/com/stark/shoot/domain/chatroom/service/ChatRoomEventService.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chatroom/service/ChatRoomEventService.kt
@@ -16,13 +16,13 @@ class ChatRoomEventService {
      * @return 생성된 도메인 이벤트 목록
      */
     fun createChatRoomCreatedEvents(chatRoom: ChatRoom): List<ChatRoomCreatedEvent> {
-        val roomId = chatRoom.id?.value ?: throw IllegalArgumentException("채팅방 ID가 없습니다.")
+        val roomId = chatRoom.id ?: throw IllegalArgumentException("채팅방 ID가 없습니다.")
 
         // 각 참여자에 대한 이벤트 생성
         return chatRoom.participants.map { participantId ->
             ChatRoomCreatedEvent.create(
                 roomId = roomId,
-                userId = participantId.value
+                userId = participantId
             )
         }
     }

--- a/src/main/kotlin/com/stark/shoot/domain/event/ChatRoomCreatedEvent.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/event/ChatRoomCreatedEvent.kt
@@ -1,11 +1,13 @@
 package com.stark.shoot.domain.event
 
 import com.stark.shoot.domain.event.DomainEvent
+import com.stark.shoot.domain.chatroom.vo.ChatRoomId
+import com.stark.shoot.domain.user.vo.UserId
 
 // 새 이벤트 정의
 data class ChatRoomCreatedEvent(
-    val roomId: Long,
-    val userId: Long,
+    val roomId: ChatRoomId,
+    val userId: UserId,
     override val occurredOn: Long = System.currentTimeMillis()
 ) : DomainEvent {
     companion object {
@@ -17,8 +19,8 @@ data class ChatRoomCreatedEvent(
          * @return 생성된 ChatRoomCreatedEvent 객체
          */
         fun create(
-            roomId: Long,
-            userId: Long
+            roomId: ChatRoomId,
+            userId: UserId
         ): ChatRoomCreatedEvent {
             return ChatRoomCreatedEvent(
                 roomId = roomId,

--- a/src/main/kotlin/com/stark/shoot/domain/event/FriendAddedEvent.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/event/FriendAddedEvent.kt
@@ -1,10 +1,11 @@
 package com.stark.shoot.domain.event
 
 import com.stark.shoot.domain.event.DomainEvent
+import com.stark.shoot.domain.user.vo.UserId
 
 data class FriendAddedEvent(
-    val userId: Long,
-    val friendId: Long,
+    val userId: UserId,
+    val friendId: UserId,
     override val occurredOn: Long = System.currentTimeMillis()
 ) : DomainEvent {
     companion object {
@@ -16,8 +17,8 @@ data class FriendAddedEvent(
          * @return 생성된 FriendAddedEvent 객체
          */
         fun create(
-            userId: Long,
-            friendId: Long
+            userId: UserId,
+            friendId: UserId
         ): FriendAddedEvent {
             return FriendAddedEvent(
                 userId = userId,

--- a/src/main/kotlin/com/stark/shoot/domain/event/FriendRemovedEvent.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/event/FriendRemovedEvent.kt
@@ -1,13 +1,14 @@
 package com.stark.shoot.domain.event
 
 import com.stark.shoot.domain.event.DomainEvent
+import com.stark.shoot.domain.user.vo.UserId
 
 /**
  * 친구 삭제 도메인 이벤트
  */
 data class FriendRemovedEvent(
-    val userId: Long,
-    val friendId: Long,
+    val userId: UserId,
+    val friendId: UserId,
     override val occurredOn: Long = System.currentTimeMillis()
 ) : DomainEvent {
     companion object {
@@ -15,8 +16,8 @@ data class FriendRemovedEvent(
          * FriendRemovedEvent 생성 팩토리 메서드
          */
         fun create(
-            userId: Long,
-            friendId: Long
+            userId: UserId,
+            friendId: UserId
         ): FriendRemovedEvent {
             return FriendRemovedEvent(
                 userId = userId,

--- a/src/main/kotlin/com/stark/shoot/domain/event/MentionEvent.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/event/MentionEvent.kt
@@ -3,12 +3,14 @@ package com.stark.shoot.domain.event
 import com.stark.shoot.domain.notification.type.NotificationType
 import com.stark.shoot.domain.notification.type.SourceType
 import com.stark.shoot.domain.user.vo.UserId
+import com.stark.shoot.domain.chatroom.vo.ChatRoomId
+import com.stark.shoot.domain.chat.message.vo.MessageId
 import java.time.Instant
 
 class MentionEvent(
     id: String? = null,
-    val roomId: Long,
-    val messageId: String,
+    val roomId: ChatRoomId,
+    val messageId: MessageId,
     val senderId: UserId,
     val senderName: String,
     val mentionedUserIds: Set<UserId>,

--- a/src/main/kotlin/com/stark/shoot/domain/event/MessageBulkReadEvent.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/event/MessageBulkReadEvent.kt
@@ -1,9 +1,13 @@
 package com.stark.shoot.domain.event
 
+import com.stark.shoot.domain.chat.message.vo.MessageId
+import com.stark.shoot.domain.chatroom.vo.ChatRoomId
+import com.stark.shoot.domain.user.vo.UserId
+
 data class MessageBulkReadEvent(
-    val roomId: Long,
-    val messageIds: List<String>,
-    val userId: Long,
+    val roomId: ChatRoomId,
+    val messageIds: List<MessageId>,
+    val userId: UserId,
     override val occurredOn: Long = System.currentTimeMillis()
 ) : DomainEvent {
     companion object {
@@ -16,9 +20,9 @@ data class MessageBulkReadEvent(
          * @return 생성된 MessageBulkReadEvent 객체
          */
         fun create(
-            roomId: Long,
-            messageIds: List<String>,
-            userId: Long
+            roomId: ChatRoomId,
+            messageIds: List<MessageId>,
+            userId: UserId
         ): MessageBulkReadEvent {
             return MessageBulkReadEvent(
                 roomId = roomId,

--- a/src/main/kotlin/com/stark/shoot/domain/event/MessagePinEvent.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/event/MessagePinEvent.kt
@@ -1,12 +1,15 @@
 package com.stark.shoot.domain.event
 
 import com.stark.shoot.domain.event.DomainEvent
+import com.stark.shoot.domain.chatroom.vo.ChatRoomId
+import com.stark.shoot.domain.chat.message.vo.MessageId
+import com.stark.shoot.domain.user.vo.UserId
 
 data class MessagePinEvent(
-    val messageId: String,
-    val roomId: Long,
+    val messageId: MessageId,
+    val roomId: ChatRoomId,
     val isPinned: Boolean,
-    val userId: Long,
+    val userId: UserId,
     override val occurredOn: Long = System.currentTimeMillis()
 ) : DomainEvent {
     companion object {
@@ -20,10 +23,10 @@ data class MessagePinEvent(
          * @return 생성된 MessagePinEvent 객체
          */
         fun create(
-            messageId: String,
-            roomId: Long,
+            messageId: MessageId,
+            roomId: ChatRoomId,
             isPinned: Boolean,
-            userId: Long
+            userId: UserId
         ): MessagePinEvent {
             return MessagePinEvent(
                 messageId = messageId,

--- a/src/main/kotlin/com/stark/shoot/domain/event/MessageUnreadCountUpdatedEvent.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/event/MessageUnreadCountUpdatedEvent.kt
@@ -1,6 +1,8 @@
 package com.stark.shoot.domain.event
 
 import com.stark.shoot.domain.event.DomainEvent
+import com.stark.shoot.domain.chatroom.vo.ChatRoomId
+import com.stark.shoot.domain.user.vo.UserId
 
 /**
  * 채팅방의 각 참여자의 unreadCount 업데이트 이벤트.
@@ -9,8 +11,8 @@ import com.stark.shoot.domain.event.DomainEvent
  * @param unreadCounts 각 참여자(문자열 ID)별 읽지 않은 메시지 수
  */
 data class MessageUnreadCountUpdatedEvent(
-    val roomId: Long,
-    val unreadCounts: Map<Long, Int>,
+    val roomId: ChatRoomId,
+    val unreadCounts: Map<UserId, Int>,
     val lastMessage: String? = null,
     override val occurredOn: Long = System.currentTimeMillis()
 ) : DomainEvent {
@@ -24,8 +26,8 @@ data class MessageUnreadCountUpdatedEvent(
          * @return 생성된 MessageUnreadCountUpdatedEvent 객체
          */
         fun create(
-            roomId: Long,
-            unreadCounts: Map<Long, Int>,
+            roomId: ChatRoomId,
+            unreadCounts: Map<UserId, Int>,
             lastMessage: String? = null
         ): MessageUnreadCountUpdatedEvent {
             return MessageUnreadCountUpdatedEvent(

--- a/src/main/kotlin/com/stark/shoot/domain/event/NewMessageEvent.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/event/NewMessageEvent.kt
@@ -3,11 +3,12 @@ package com.stark.shoot.domain.event
 import com.stark.shoot.domain.notification.type.NotificationType
 import com.stark.shoot.domain.notification.type.SourceType
 import com.stark.shoot.domain.user.vo.UserId
+import com.stark.shoot.domain.chatroom.vo.ChatRoomId
 import java.time.Instant
 
 class NewMessageEvent(
     id: String? = null,
-    val roomId: Long,
+    val roomId: ChatRoomId,
     val senderId: UserId,
     val senderName: String,
     val messageContent: String,
@@ -18,7 +19,7 @@ class NewMessageEvent(
     id = id,
     timestamp = timestamp,
     type = NotificationType.NEW_MESSAGE,
-    sourceId = roomId.toString(),
+    sourceId = roomId.value.toString(),
     sourceType = SourceType.CHAT_ROOM,
     metadata = metadata
 ) {

--- a/src/main/kotlin/com/stark/shoot/domain/user/FriendRequest.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/user/FriendRequest.kt
@@ -6,10 +6,12 @@ import com.stark.shoot.domain.user.type.FriendRequestStatus
 /**
  * 친구 요청 애그리게이트
  */
+import com.stark.shoot.domain.user.vo.UserId
+
 data class FriendRequest(
     val id: Long? = null,
-    val senderId: Long,
-    val receiverId: Long,
+    val senderId: UserId,
+    val receiverId: UserId,
     val status: FriendRequestStatus = FriendRequestStatus.PENDING,
     val createdAt: Instant = Instant.now(),
     val respondedAt: Instant? = null,

--- a/src/main/kotlin/com/stark/shoot/domain/user/RefreshToken.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/user/RefreshToken.kt
@@ -2,10 +2,11 @@ package com.stark.shoot.domain.user
 
 import java.time.Instant
 import com.stark.shoot.domain.user.vo.RefreshTokenValue
+import com.stark.shoot.domain.user.vo.UserId
 
 data class RefreshToken(
     val id: Long? = null,
-    val userId: Long,                 // 사용자 ID 참조
+    val userId: UserId,                 // 사용자 ID 참조
     val token: RefreshTokenValue,     // 리프레시 토큰 값
     val expirationDate: Instant,      // 만료 시간
     val deviceInfo: String? = null,   // 디바이스 정보 (선택적)

--- a/src/main/kotlin/com/stark/shoot/domain/user/service/FriendDomainService.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/user/service/FriendDomainService.kt
@@ -87,8 +87,8 @@ class FriendDomainService {
 
         // 이벤트 생성 (양쪽 사용자에게 친구 추가 알림)
         val events = listOf(
-            FriendAddedEvent.create(userId = currentUser.id.value, friendId = requesterId.value),
-            FriendAddedEvent.create(userId = requesterId.value, friendId = currentUser.id.value)
+            FriendAddedEvent.create(userId = currentUser.id, friendId = requesterId),
+            FriendAddedEvent.create(userId = requesterId, friendId = currentUser.id)
         )
 
         return FriendAcceptResult(
@@ -144,8 +144,8 @@ class FriendDomainService {
 
         // 이벤트 생성 (양쪽 사용자에게 친구 제거 알림)
         val events = listOf(
-            FriendRemovedEvent.create(userId = currentUser.id.value, friendId = friendId.value),
-            FriendRemovedEvent.create(userId = friendId.value, friendId = currentUser.id.value)
+            FriendRemovedEvent.create(userId = currentUser.id, friendId = friendId),
+            FriendRemovedEvent.create(userId = friendId, friendId = currentUser.id)
         )
 
         return FriendRemovalResult(

--- a/src/test/kotlin/com/stark/shoot/domain/chat/event/EventFactoryTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/chat/event/EventFactoryTest.kt
@@ -9,6 +9,9 @@ import com.stark.shoot.domain.event.MessageEvent
 import com.stark.shoot.domain.event.MessagePinEvent
 import com.stark.shoot.domain.event.MessageReactionEvent
 import com.stark.shoot.domain.event.MessageUnreadCountUpdatedEvent
+import com.stark.shoot.domain.chatroom.vo.ChatRoomId
+import com.stark.shoot.domain.chat.message.vo.MessageId
+import com.stark.shoot.domain.user.vo.UserId
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -17,7 +20,7 @@ import org.junit.jupiter.api.Test
 class EventFactoryTest {
     @Test
     fun `ChatEvent fromMessage 함수는 메시지를 기반으로 이벤트를 생성한다`() {
-        val message = ChatMessage.create(roomId = 1L, senderId = 2L, text = "hi")
+        val message = ChatMessage.create(roomId = ChatRoomId.from(1L), senderId = UserId.from(2L), text = "hi")
         val event = MessageEvent.fromMessage(message)
 
         assertThat(event.type).isEqualTo(EventType.MESSAGE_CREATED)
@@ -26,39 +29,52 @@ class EventFactoryTest {
 
     @Test
     fun `ChatBulkReadEvent create 함수는 주어진 값으로 이벤트를 생성한다`() {
-        val event = MessageBulkReadEvent.create(1L, listOf("m1", "m2"), 3L)
-        assertThat(event).isEqualTo(MessageBulkReadEvent(1L, listOf("m1", "m2"), 3L))
+        val event = MessageBulkReadEvent.create(
+            ChatRoomId.from(1L),
+            listOf(MessageId.from("m1"), MessageId.from("m2")),
+            UserId.from(3L)
+        )
+        assertThat(event).isEqualTo(
+            MessageBulkReadEvent(ChatRoomId.from(1L), listOf(MessageId.from("m1"), MessageId.from("m2")), UserId.from(3L))
+        )
     }
 
     @Test
     fun `ChatUnreadCountUpdatedEvent create 함수는 주어진 값으로 이벤트를 생성한다`() {
-        val counts = mapOf(1L to 2)
-        val event = MessageUnreadCountUpdatedEvent.create(1L, counts)
-        assertThat(event).isEqualTo(MessageUnreadCountUpdatedEvent(1L, counts, null))
+        val counts = mapOf(UserId.from(1L) to 2)
+        val event = MessageUnreadCountUpdatedEvent.create(ChatRoomId.from(1L), counts)
+        assertThat(event).isEqualTo(MessageUnreadCountUpdatedEvent(ChatRoomId.from(1L), counts, null))
     }
 
     @Test
     fun `FriendAddedEvent create 함수는 주어진 값으로 이벤트를 생성한다`() {
-        val event = FriendAddedEvent.create(1L, 2L)
-        assertThat(event).isEqualTo(FriendAddedEvent(1L, 2L))
+        val event = FriendAddedEvent.create(UserId.from(1L), UserId.from(2L))
+        assertThat(event).isEqualTo(FriendAddedEvent(UserId.from(1L), UserId.from(2L)))
     }
 
     @Test
     fun `FriendRemovedEvent create 함수는 주어진 값으로 이벤트를 생성한다`() {
-        val event = FriendRemovedEvent.create(1L, 2L)
-        assertThat(event).isEqualTo(FriendRemovedEvent(1L, 2L))
+        val event = FriendRemovedEvent.create(UserId.from(1L), UserId.from(2L))
+        assertThat(event).isEqualTo(FriendRemovedEvent(UserId.from(1L), UserId.from(2L)))
     }
 
     @Test
     fun `ChatRoomCreatedEvent create 함수는 주어진 값으로 이벤트를 생성한다`() {
-        val event = ChatRoomCreatedEvent.create(1L, 2L)
-        assertThat(event).isEqualTo(ChatRoomCreatedEvent(1L, 2L))
+        val event = ChatRoomCreatedEvent.create(ChatRoomId.from(1L), UserId.from(2L))
+        assertThat(event).isEqualTo(ChatRoomCreatedEvent(ChatRoomId.from(1L), UserId.from(2L)))
     }
 
     @Test
     fun `MessagePinEvent create 함수는 주어진 값으로 이벤트를 생성한다`() {
-        val event = MessagePinEvent.create("m1", 1L, true, 2L)
-        assertThat(event).isEqualTo(MessagePinEvent("m1", 1L, true, 2L))
+        val event = MessagePinEvent.create(
+            MessageId.from("m1"),
+            ChatRoomId.from(1L),
+            true,
+            UserId.from(2L)
+        )
+        assertThat(event).isEqualTo(
+            MessagePinEvent(MessageId.from("m1"), ChatRoomId.from(1L), true, UserId.from(2L))
+        )
     }
 
     @Test

--- a/src/test/kotlin/com/stark/shoot/domain/chat/user/FriendRequestTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/chat/user/FriendRequestTest.kt
@@ -15,7 +15,7 @@ class FriendRequestTest {
 
         @Test
         fun `친구 요청을 수락하면 ACCEPTED 상태가 된다`() {
-            val request = FriendRequest(senderId = 1L, receiverId = 2L)
+            val request = FriendRequest(senderId = UserId.from(1L), receiverId = UserId.from(2L))
             val result = request.accept()
             assertThat(result.status).isEqualTo(FriendRequestStatus.ACCEPTED)
             assertThat(result.respondedAt).isNotNull()
@@ -23,7 +23,7 @@ class FriendRequestTest {
 
         @Test
         fun `친구 요청을 거절하면 REJECTED 상태가 된다`() {
-            val request = FriendRequest(senderId = 1L, receiverId = 2L)
+            val request = FriendRequest(senderId = UserId.from(1L), receiverId = UserId.from(2L))
             val result = request.reject()
             assertThat(result.status).isEqualTo(FriendRequestStatus.REJECTED)
             assertThat(result.respondedAt).isNotNull()
@@ -31,7 +31,7 @@ class FriendRequestTest {
 
         @Test
         fun `친구 요청을 취소하면 CANCELLED 상태가 된다`() {
-            val request = FriendRequest(senderId = 1L, receiverId = 2L)
+            val request = FriendRequest(senderId = UserId.from(1L), receiverId = UserId.from(2L))
             val result = request.cancel()
             assertThat(result.status).isEqualTo(FriendRequestStatus.CANCELLED)
             assertThat(result.respondedAt).isNotNull()

--- a/src/test/kotlin/com/stark/shoot/domain/chat/user/RefreshTokenTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/chat/user/RefreshTokenTest.kt
@@ -3,6 +3,7 @@ package com.stark.shoot.domain.chat.user
 import org.assertj.core.api.Assertions.assertThat
 import com.stark.shoot.domain.chat.user.RefreshTokenValue
 import com.stark.shoot.domain.user.RefreshToken
+import com.stark.shoot.domain.user.vo.UserId
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -20,7 +21,7 @@ class RefreshTokenTest {
         @DisplayName("필수 속성으로 리프레시 토큰을 생성할 수 있다")
         fun `필수 속성으로 리프레시 토큰을 생성할 수 있다`() {
             // given
-            val userId = 1L
+            val userId = UserId.from(1L)
             val token = RefreshTokenValue.from("refresh_token_value")
             val expirationDate = Instant.now().plus(7, ChronoUnit.DAYS)
             
@@ -48,7 +49,7 @@ class RefreshTokenTest {
         fun `모든 속성으로 리프레시 토큰을 생성할 수 있다`() {
             // given
             val id = 1L
-            val userId = 2L
+            val userId = UserId.from(2L)
             val token = RefreshTokenValue.from("refresh_token_value")
             val expirationDate = Instant.now().plus(7, ChronoUnit.DAYS)
             val deviceInfo = "Android 12, Samsung Galaxy S21"
@@ -92,7 +93,7 @@ class RefreshTokenTest {
         fun `만료되지 않고 취소되지 않은 토큰은 유효하다`() {
             // given
             val refreshToken = RefreshToken(
-                userId = 1L,
+                userId = UserId.from(1L),
                 token = RefreshTokenValue.from("valid_token"),
                 expirationDate = Instant.now().plus(7, ChronoUnit.DAYS),
                 isRevoked = false
@@ -110,7 +111,7 @@ class RefreshTokenTest {
         fun `만료된 토큰은 유효하지 않다`() {
             // given
             val refreshToken = RefreshToken(
-                userId = 1L,
+                userId = UserId.from(1L),
                 token = RefreshTokenValue.from("expired_token"),
                 expirationDate = Instant.now().minus(1, ChronoUnit.DAYS),
                 isRevoked = false
@@ -128,7 +129,7 @@ class RefreshTokenTest {
         fun `취소된 토큰은 유효하지 않다`() {
             // given
             val refreshToken = RefreshToken(
-                userId = 1L,
+                userId = UserId.from(1L),
                 token = RefreshTokenValue.from("revoked_token"),
                 expirationDate = Instant.now().plus(7, ChronoUnit.DAYS),
                 isRevoked = true
@@ -146,7 +147,7 @@ class RefreshTokenTest {
         fun `만료되고 취소된 토큰은 유효하지 않다`() {
             // given
             val refreshToken = RefreshToken(
-                userId = 1L,
+                userId = UserId.from(1L),
                 token = RefreshTokenValue.from("expired_and_revoked_token"),
                 expirationDate = Instant.now().minus(1, ChronoUnit.DAYS),
                 isRevoked = true
@@ -169,7 +170,7 @@ class RefreshTokenTest {
         fun `마지막 사용 시간을 현재 시간으로 업데이트할 수 있다`() {
             // given
             val refreshToken = RefreshToken(
-                userId = 1L,
+                userId = UserId.from(1L),
                 token = RefreshTokenValue.from("token"),
                 expirationDate = Instant.now().plus(7, ChronoUnit.DAYS)
             )
@@ -201,7 +202,7 @@ class RefreshTokenTest {
             // given
             val oldLastUsedAt = Instant.now().minus(1, ChronoUnit.HOURS)
             val refreshToken = RefreshToken(
-                userId = 1L,
+                userId = UserId.from(1L),
                 token = RefreshTokenValue.from("token"),
                 expirationDate = Instant.now().plus(7, ChronoUnit.DAYS),
                 lastUsedAt = oldLastUsedAt
@@ -229,7 +230,7 @@ class RefreshTokenTest {
         fun `토큰을 취소할 수 있다`() {
             // given
             val refreshToken = RefreshToken(
-                userId = 1L,
+                userId = UserId.from(1L),
                 token = RefreshTokenValue.from("token_to_revoke"),
                 expirationDate = Instant.now().plus(7, ChronoUnit.DAYS),
                 isRevoked = false
@@ -257,7 +258,7 @@ class RefreshTokenTest {
         fun `이미 취소된 토큰도 다시 취소할 수 있다`() {
             // given
             val refreshToken = RefreshToken(
-                userId = 1L,
+                userId = UserId.from(1L),
                 token = RefreshTokenValue.from("already_revoked_token"),
                 expirationDate = Instant.now().plus(7, ChronoUnit.DAYS),
                 isRevoked = true

--- a/src/test/kotlin/com/stark/shoot/domain/service/chatroom/ChatRoomEventServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/service/chatroom/ChatRoomEventServiceTest.kt
@@ -4,6 +4,9 @@ import com.stark.shoot.domain.event.ChatRoomCreatedEvent
 import com.stark.shoot.domain.chatroom.ChatRoom
 import com.stark.shoot.domain.chatroom.service.ChatRoomEventService
 import com.stark.shoot.domain.chatroom.type.ChatRoomType
+import com.stark.shoot.domain.chatroom.vo.ChatRoomId
+import com.stark.shoot.domain.chatroom.vo.ChatRoomTitle
+import com.stark.shoot.domain.user.vo.UserId
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -14,16 +17,25 @@ class ChatRoomEventServiceTest {
 
     @Test
     fun `채팅방 생성 이벤트를 생성할 수 있다`() {
-        val room = ChatRoom(id = 1L, title = "room", type = ChatRoomType.GROUP, participants = mutableSetOf(1L,2L))
+        val room = ChatRoom(
+            id = ChatRoomId.from(1L),
+            title = ChatRoomTitle.from("room"),
+            type = ChatRoomType.GROUP,
+            participants = mutableSetOf(UserId.from(1L), UserId.from(2L))
+        )
         val events = service.createChatRoomCreatedEvents(room)
         assertThat(events).hasSize(2)
-        assertThat(events[0]).isEqualTo(ChatRoomCreatedEvent.create(1L, 1L))
-        assertThat(events[1]).isEqualTo(ChatRoomCreatedEvent.create(1L, 2L))
+        assertThat(events[0]).isEqualTo(ChatRoomCreatedEvent.create(ChatRoomId.from(1L), UserId.from(1L)))
+        assertThat(events[1]).isEqualTo(ChatRoomCreatedEvent.create(ChatRoomId.from(1L), UserId.from(2L)))
     }
 
     @Test
     fun `ID가 없는 채팅방 이벤트 생성 시 예외가 발생한다`() {
-        val room = ChatRoom(title = "room", type = ChatRoomType.GROUP, participants = mutableSetOf(1L))
+        val room = ChatRoom(
+            title = ChatRoomTitle.from("room"),
+            type = ChatRoomType.GROUP,
+            participants = mutableSetOf(UserId.from(1L))
+        )
         org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
             service.createChatRoomCreatedEvents(room)
         }

--- a/src/test/kotlin/com/stark/shoot/domain/service/message/MessagePinDomainServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/service/message/MessagePinDomainServiceTest.kt
@@ -4,8 +4,11 @@ import com.stark.shoot.domain.event.MessagePinEvent
 import com.stark.shoot.domain.chat.message.ChatMessage
 import com.stark.shoot.domain.chat.message.service.MessagePinDomainService
 import com.stark.shoot.domain.chat.message.vo.MessageContent
+import com.stark.shoot.domain.chat.message.vo.MessageId
 import com.stark.shoot.domain.chat.message.type.MessageStatus
 import com.stark.shoot.domain.chat.message.type.MessageType
+import com.stark.shoot.domain.chatroom.vo.ChatRoomId
+import com.stark.shoot.domain.user.vo.UserId
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -22,7 +25,7 @@ class MessagePinDomainServiceTest {
         fun `메시지 ID가 없으면 null을 반환한다`() {
             val message = ChatMessage(
                 roomId = 1L,
-                senderId = 2L,
+                senderId = UserId.from(2L),
                 content = MessageContent("hi", MessageType.TEXT),
                 status = MessageStatus.SAVED,
                 createdAt = Instant.now()
@@ -43,13 +46,13 @@ class MessagePinDomainServiceTest {
                 createdAt = Instant.now()
             )
 
-            val event = service.createPinEvent(message, 1L, true)
+            val event = service.createPinEvent(message, UserId.from(1L), true)
             assertThat(event).isEqualTo(
                 MessagePinEvent.create(
-                    messageId = "m1",
-                    roomId = 1L,
+                    messageId = MessageId.from("m1"),
+                    roomId = ChatRoomId.from(1L),
                     isPinned = true,
-                    userId = 1L
+                    userId = UserId.from(1L)
                 )
             )
         }

--- a/src/test/kotlin/com/stark/shoot/domain/service/user/FriendDomainServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/service/user/FriendDomainServiceTest.kt
@@ -22,32 +22,34 @@ class FriendDomainServiceTest {
         @Test
         fun `자신에게 요청하면 예외`() {
             assertThrows<IllegalArgumentException> {
-                service.validateFriendRequest(1L,1L,false,false,false)
+                service.validateFriendRequest(UserId.from(1L), UserId.from(1L), false, false, false)
             }
         }
     }
 
     @Test
     fun `친구 요청 수락을 처리할 수 있다`() {
-        val current = User(id=1L, username=Username.from("a"), nickname=Nickname.from("A"), userCode=UserCode.from("A1"), incomingFriendRequestIds=setOf(2L))
-        val requester = User(id=2L, username=Username.from("b"), nickname=Nickname.from("B"), userCode=UserCode.from("B1"))
-        val result = service.processFriendAccept(current, requester, 2L)
-        assertThat(result.updatedCurrentUser.friendIds).contains(2L)
-        assertThat(result.updatedRequester.friendIds).contains(1L)
+        val current = User(id=UserId.from(1L), username=Username.from("a"), nickname=Nickname.from("A"), userCode=UserCode.from("A1"), incomingFriendRequestIds=setOf(UserId.from(2L)))
+        val requester = User(id=UserId.from(2L), username=Username.from("b"), nickname=Nickname.from("B"), userCode=UserCode.from("B1"))
+        val result = service.processFriendAccept(current, requester, UserId.from(2L))
+        assertThat(result.updatedCurrentUser.friendIds).contains(UserId.from(2L))
+        assertThat(result.updatedRequester.friendIds).contains(UserId.from(1L))
         assertThat(result.events).containsExactly(
-            FriendAddedEvent.create(1L,2L), FriendAddedEvent.create(2L,1L)
+            FriendAddedEvent.create(UserId.from(1L), UserId.from(2L)),
+            FriendAddedEvent.create(UserId.from(2L), UserId.from(1L))
         )
     }
 
     @Test
     fun `친구 관계 삭제를 처리할 수 있다`() {
-        val current = User(id=1L, username=Username.from("a"), nickname=Nickname.from("A"), userCode=UserCode.from("A1"), friendIds=setOf(2L))
-        val friend = User(id=2L, username=Username.from("b"), nickname=Nickname.from("B"), userCode=UserCode.from("B1"), friendIds=setOf(1L))
-        val result = service.processFriendRemoval(current, friend, 2L)
-        assertThat(result.updatedCurrentUser.friendIds).doesNotContain(2L)
-        assertThat(result.updatedFriend.friendIds).doesNotContain(1L)
+        val current = User(id=UserId.from(1L), username=Username.from("a"), nickname=Nickname.from("A"), userCode=UserCode.from("A1"), friendIds=setOf(UserId.from(2L)))
+        val friend = User(id=UserId.from(2L), username=Username.from("b"), nickname=Nickname.from("B"), userCode=UserCode.from("B1"), friendIds=setOf(UserId.from(1L)))
+        val result = service.processFriendRemoval(current, friend, UserId.from(2L))
+        assertThat(result.updatedCurrentUser.friendIds).doesNotContain(UserId.from(2L))
+        assertThat(result.updatedFriend.friendIds).doesNotContain(UserId.from(1L))
         assertThat(result.events).containsExactly(
-            FriendRemovedEvent.create(1L,2L), FriendRemovedEvent.create(2L,1L)
+            FriendRemovedEvent.create(UserId.from(1L), UserId.from(2L)),
+            FriendRemovedEvent.create(UserId.from(2L), UserId.from(1L))
         )
     }
 }


### PR DESCRIPTION
## Summary
- apply `UserId`, `ChatRoomId`, and `MessageId` value objects to remaining domain classes
- update events and domain services accordingly
- update persistence mappers and SSE adapters
- fix tests to work with new value object types

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6855e6b8dc388320a90d5658c97152f1