### PR TITLE
Add VO and enum unit tests

### DIFF
--- a/src/test/kotlin/com/stark/shoot/domain/chat/message/MessageEnumsTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/chat/message/MessageEnumsTest.kt
@@ -1,0 +1,43 @@
+package com.stark.shoot.domain.chat.message
+
+import com.stark.shoot.domain.chat.message.type.MessageStatus
+import com.stark.shoot.domain.chat.message.type.MessageType
+import com.stark.shoot.domain.chat.message.type.ScheduledMessageStatus
+import com.stark.shoot.domain.chat.message.type.SyncDirection
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("메시지 관련 enum 테스트")
+class MessageEnumsTest {
+
+    @Test
+    fun `MessageType 은 TEXT FILE URL EMOTICON 4가지를 가진다`() {
+        val values = MessageType.values()
+        assertThat(values.map { it.name }).containsExactlyInAnyOrder("TEXT", "FILE", "URL", "EMOTICON")
+    }
+
+    @Test
+    fun `MessageStatus 값 확인`() {
+        val values = MessageStatus.values()
+        assertThat(values.map { it.name }).containsExactly(
+            "SENDING",
+            "PROCESSING",
+            "SENT_TO_KAFKA",
+            "SAVED",
+            "FAILED"
+        )
+    }
+
+    @Test
+    fun `ScheduledMessageStatus 값 확인`() {
+        val values = ScheduledMessageStatus.values()
+        assertThat(values.map { it.name }).containsExactly("PENDING", "SENT", "CANCELED")
+    }
+
+    @Test
+    fun `SyncDirection 값 확인`() {
+        val values = SyncDirection.values()
+        assertThat(values.map { it.name }).containsExactly("BEFORE", "AFTER", "INITIAL")
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/domain/chat/message/vo/MessageValueObjectsTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/chat/message/vo/MessageValueObjectsTest.kt
@@ -1,0 +1,26 @@
+package com.stark.shoot.domain.chat.message.vo
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("메시지 VO 테스트")
+class MessageValueObjectsTest {
+
+    @Nested
+    inner class MessageIdTest {
+        @Test
+        fun `정상 생성`() {
+            val id = MessageId.from("id1")
+            assertThat(id.value).isEqualTo("id1")
+        }
+
+        @Test
+        fun `blank 는 예외`() {
+            assertThatThrownBy { MessageId.from(" ") }
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/domain/chatroom/vo/ChatRoomValueObjectsTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/chatroom/vo/ChatRoomValueObjectsTest.kt
@@ -1,0 +1,78 @@
+package com.stark.shoot.domain.chatroom.vo
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("채팅방 VO 테스트")
+class ChatRoomValueObjectsTest {
+
+    @Nested
+    inner class ChatRoomTitleTest {
+        @Test
+        fun `유효한 값으로 생성`() {
+            val title = ChatRoomTitle.from("title")
+            assertThat(title.value).isEqualTo("title")
+        }
+
+        @Test
+        fun `빈 값은 예외`() {
+            assertThatThrownBy { ChatRoomTitle.from(" ") }
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+    }
+
+    @Nested
+    inner class ChatRoomAnnouncementTest {
+        @Test
+        fun `유효한 값으로 생성`() {
+            val ann = ChatRoomAnnouncement.from("hello")
+            assertThat(ann.value).isEqualTo("hello")
+        }
+
+        @Test
+        fun `빈 값은 예외`() {
+            assertThatThrownBy { ChatRoomAnnouncement.from("") }
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+
+        @Test
+        fun `200자 초과시 예외`() {
+            val long = "a".repeat(201)
+            assertThatThrownBy { ChatRoomAnnouncement.from(long) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+    }
+
+    @Nested
+    inner class ChatRoomIdTest {
+        @Test
+        fun `양수 값으로 생성`() {
+            val id = ChatRoomId.from(1L)
+            assertThat(id.value).isEqualTo(1L)
+        }
+
+        @Test
+        fun `0이하 값은 예외`() {
+            assertThatThrownBy { ChatRoomId.from(0) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+    }
+
+    @Nested
+    inner class RetentionDaysTest {
+        @Test
+        fun `양수 값으로 생성`() {
+            val d = RetentionDays.from(5)
+            assertThat(d.value).isEqualTo(5)
+        }
+
+        @Test
+        fun `0이하 값은 예외`() {
+            assertThatThrownBy { RetentionDays.from(0) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/domain/event/EventTypeTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/event/EventTypeTest.kt
@@ -1,0 +1,16 @@
+package com.stark.shoot.domain.event
+
+import com.stark.shoot.domain.event.type.EventType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("이벤트 타입 enum 테스트")
+class EventTypeTest {
+
+    @Test
+    fun `EventType 은 MESSAGE_CREATED MESSAGE_UPDATED MESSAGE_DELETED 세 가지가 존재한다`() {
+        val names = EventType.values().map { it.name }
+        assertThat(names).containsExactly("MESSAGE_CREATED", "MESSAGE_UPDATED", "MESSAGE_DELETED")
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/domain/notification/NotificationEnumsTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/notification/NotificationEnumsTest.kt
@@ -1,0 +1,42 @@
+package com.stark.shoot.domain.notification
+
+import com.stark.shoot.domain.notification.type.NotificationType
+import com.stark.shoot.domain.notification.type.SourceType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("알림 관련 enum 테스트")
+class NotificationEnumsTest {
+
+    @Test
+    fun `NotificationType enum 모든 값 존재 확인`() {
+        val names = NotificationType.values().map { it.name }
+        assertThat(names).contains(
+            "NEW_MESSAGE",
+            "MENTION",
+            "REACTION",
+            "PIN",
+            "FRIEND_REQUEST",
+            "FRIEND_ACCEPTED",
+            "FRIEND_REJECTED",
+            "FRIEND_REMOVED",
+            "SYSTEM_ANNOUNCEMENT",
+            "SYSTEM_MAINTENANCE",
+            "OTHER"
+        )
+    }
+
+    @Test
+    fun `SourceType enum 모든 값 존재 확인`() {
+        val names = SourceType.values().map { it.name }
+        assertThat(names).contains(
+            "CHAT",
+            "CHAT_ROOM",
+            "USER",
+            "FRIEND",
+            "SYSTEM",
+            "OTHER"
+        )
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/domain/notification/vo/NotificationValueObjectsTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/notification/vo/NotificationValueObjectsTest.kt
@@ -1,0 +1,53 @@
+package com.stark.shoot.domain.notification.vo
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("알림 VO 테스트")
+class NotificationValueObjectsTest {
+
+    @Nested
+    inner class NotificationIdTest {
+        @Test
+        fun `정상 생성`() {
+            val id = NotificationId.from("id")
+            assertThat(id.value).isEqualTo("id")
+        }
+        @Test
+        fun `blank 는 예외`() {
+            assertThatThrownBy { NotificationId.from("") }
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+    }
+
+    @Nested
+    inner class NotificationTitleTest {
+        @Test
+        fun `정상 생성`() {
+            val t = NotificationTitle.from("t")
+            assertThat(t.value).isEqualTo("t")
+        }
+        @Test
+        fun `blank 는 예외`() {
+            assertThatThrownBy { NotificationTitle.from(" ") }
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+    }
+
+    @Nested
+    inner class NotificationMessageTest {
+        @Test
+        fun `정상 생성`() {
+            val m = NotificationMessage.from("m")
+            assertThat(m.value).isEqualTo("m")
+        }
+        @Test
+        fun `blank 는 예외`() {
+            assertThatThrownBy { NotificationMessage.from("") }
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/domain/user/UserEnumsTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/user/UserEnumsTest.kt
@@ -1,0 +1,23 @@
+package com.stark.shoot.domain.user
+
+import com.stark.shoot.domain.user.type.FriendRequestStatus
+import com.stark.shoot.domain.user.type.UserStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("유저 관련 enum 테스트")
+class UserEnumsTest {
+
+    @Test
+    fun `FriendRequestStatus 값 확인`() {
+        val names = FriendRequestStatus.values().map { it.name }
+        assertThat(names).containsExactly("PENDING", "ACCEPTED", "REJECTED", "CANCELLED")
+    }
+
+    @Test
+    fun `UserStatus 값 확인`() {
+        val names = UserStatus.values().map { it.name }
+        assertThat(names).containsExactly("OFFLINE", "ONLINE", "BUSY", "AWAY", "INVISIBLE", "DO_NOT_DISTURB", "IDLE")
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/domain/user/vo/UserValueObjectsTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/user/vo/UserValueObjectsTest.kt
@@ -1,0 +1,160 @@
+package com.stark.shoot.domain.user.vo
+
+import com.stark.shoot.infrastructure.exception.InvalidUserDataException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("사용자 VO 테스트")
+class UserValueObjectsTest {
+
+    @Nested
+    inner class UserIdTest {
+        @Test
+        fun `양수로 생성`() {
+            val id = UserId.from(1L)
+            assertThat(id.value).isEqualTo(1L)
+        }
+        @Test
+        fun `0 이하는 예외`() {
+            assertThatThrownBy { UserId.from(0) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+    }
+
+    @Nested
+    inner class UsernameTest {
+        @Test
+        fun `정상 생성`() {
+            val u = Username.from("user")
+            assertThat(u.value).isEqualTo("user")
+        }
+        @Test
+        fun `빈값 예외`() {
+            assertThatThrownBy { Username.from(" ") }
+                .isInstanceOf(InvalidUserDataException::class.java)
+        }
+        @Test
+        fun `길이 제한 예외`() {
+            assertThatThrownBy { Username.from("ab") }
+                .isInstanceOf(InvalidUserDataException::class.java)
+        }
+    }
+
+    @Nested
+    inner class NicknameTest {
+        @Test
+        fun `정상 생성`() {
+            val n = Nickname.from("닉네임")
+            assertThat(n.value).isEqualTo("닉네임")
+        }
+        @Test
+        fun `빈값 예외`() {
+            assertThatThrownBy { Nickname.from("") }
+                .isInstanceOf(InvalidUserDataException::class.java)
+        }
+        @Test
+        fun `길이 제한 예외`() {
+            assertThatThrownBy { Nickname.from("a") }
+                .isInstanceOf(InvalidUserDataException::class.java)
+        }
+    }
+
+    @Nested
+    inner class UserCodeTest {
+        @Test
+        fun `정상 생성`() {
+            val code = UserCode.from("ABCD")
+            assertThat(code.value).isEqualTo("ABCD")
+        }
+        @Test
+        fun `패턴 불일치 예외`() {
+            assertThatThrownBy { UserCode.from("ab") }
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+        @Test
+        fun `generate 메서드`() {
+            val generated = UserCode.generate()
+            assertThat(generated.value).matches(Regex("^[A-Z0-9]{8}$"))
+        }
+    }
+
+    @Nested
+    inner class ProfileImageUrlTest {
+        @Test
+        fun `정상 생성`() {
+            val url = ProfileImageUrl.from("https://a.com/img.png")
+            assertThat(url.value).isEqualTo("https://a.com/img.png")
+        }
+        @Test
+        fun `잘못된 형식 예외`() {
+            assertThatThrownBy { ProfileImageUrl.from("abc") }
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+    }
+
+    @Nested
+    inner class BackgroundImageUrlTest {
+        @Test
+        fun `정상 생성`() {
+            val url = BackgroundImageUrl.from("https://a.com/bg.png")
+            assertThat(url.value).isEqualTo("https://a.com/bg.png")
+        }
+        @Test
+        fun `잘못된 형식 예외`() {
+            assertThatThrownBy { BackgroundImageUrl.from("abc") }
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+    }
+
+    @Nested
+    inner class UserBioTest {
+        @Test
+        fun `200자 이내 생성`() {
+            val bio = UserBio.from("a".repeat(200))
+            assertThat(bio.value).hasSize(200)
+        }
+        @Test
+        fun `200자 초과 예외`() {
+            val long = "a".repeat(201)
+            assertThatThrownBy { UserBio.from(long) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+    }
+
+    @Nested
+    inner class FriendGroupNameTest {
+        @Test
+        fun `정상 생성`() {
+            val name = FriendGroupName.from("친구")
+            assertThat(name.value).isEqualTo("친구")
+        }
+        @Test
+        fun `빈값 예외`() {
+            assertThatThrownBy { FriendGroupName.from(" ") }
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+        @Test
+        fun `길이초과 예외`() {
+            val long = "a".repeat(51)
+            assertThatThrownBy { FriendGroupName.from(long) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+    }
+
+    @Nested
+    inner class RefreshTokenValueTest {
+        @Test
+        fun `정상 생성`() {
+            val token = RefreshTokenValue.from("token")
+            assertThat(token.value).isEqualTo("token")
+        }
+        @Test
+        fun `blank 예외`() {
+            assertThatThrownBy { RefreshTokenValue.from("") }
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- cover message enums and value objects
- cover chatroom value object edge cases
- add notification value object tests
- add user enum and value object tests
- add event enum test

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to download gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_6855ea4d1cc88320a2239a82edf0a9e2