### PR TITLE
Add tests for misc utilities and adapters

### DIFF
--- a/src/test/kotlin/com/stark/shoot/adapter/in/web/MongoTestControllerTest.kt
+++ b/src/test/kotlin/com/stark/shoot/adapter/in/web/MongoTestControllerTest.kt
@@ -1,0 +1,28 @@
+package com.stark.shoot.adapter.`in`.web
+
+import com.mongodb.client.MongoDatabase
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+import org.springframework.data.mongodb.core.MongoTemplate
+
+@DisplayName("MongoTestController 단위 테스트")
+class MongoTestControllerTest {
+
+    private val mongoTemplate = mock(MongoTemplate::class.java)
+    private val controller = MongoTestController(mongoTemplate)
+
+    @Test
+    fun `MongoDB 연결 성공 메시지를 반환한다`() {
+        val db = mock(MongoDatabase::class.java)
+        `when`(mongoTemplate.db).thenReturn(db)
+        `when`(db.name).thenReturn("test-db")
+
+        val response = controller.testMongo()
+
+        assertThat(response.data).isEqualTo("MongoDB 연결 성공: test-db")
+        assertThat(response.success).isTrue()
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/adapter/persistence/message/preview/RedisUrlPreviewCacheAdapterTest.kt
+++ b/src/test/kotlin/com/stark/shoot/adapter/persistence/message/preview/RedisUrlPreviewCacheAdapterTest.kt
@@ -1,0 +1,52 @@
+package com.stark.shoot.adapter.persistence.message.preview
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.stark.shoot.adapter.out.persistence.mongodb.adapter.message.preview.RedisUrlPreviewCacheAdapter
+import com.stark.shoot.domain.chat.message.vo.ChatMessageMetadata
+import com.stark.shoot.infrastructure.config.redis.RedisUtilService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.*
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.data.redis.core.ValueOperations
+import java.time.Duration
+import java.time.Instant
+
+@DisplayName("Redis URL 프리뷰 캐시 어댑터 테스트")
+class RedisUrlPreviewCacheAdapterTest {
+
+    private val redisTemplate = mock(StringRedisTemplate::class.java)
+    private val valueOps = mock(ValueOperations::class.java) as ValueOperations<String, String>
+    private val objectMapper = ObjectMapper()
+    private val redisUtilService = mock(RedisUtilService::class.java)
+
+    private val adapter = RedisUrlPreviewCacheAdapter(redisTemplate, objectMapper, redisUtilService)
+
+    @Test
+    fun `캐시된 URL 프리뷰를 조회할 수 있다`() {
+        val url = "https://example.com"
+        val key = "url_preview:hash"
+        val preview = ChatMessageMetadata.UrlPreview(url, "t", "d", "i", "s", Instant.now())
+        `when`(redisUtilService.createHashKey("url_preview:", url)).thenReturn(key)
+        `when`(redisTemplate.opsForValue()).thenReturn(valueOps)
+        `when`(valueOps.get(key)).thenReturn(objectMapper.writeValueAsString(preview))
+
+        val result = adapter.getCachedUrlPreview(url)
+
+        assertThat(result).usingRecursiveComparison().ignoringFields("fetchedAt").isEqualTo(preview)
+    }
+
+    @Test
+    fun `URL 프리뷰를 캐시에 저장할 수 있다`() {
+        val url = "https://example.com"
+        val key = "url_preview:hash"
+        val preview = ChatMessageMetadata.UrlPreview(url, "t", "d", "i", "s", Instant.now())
+        `when`(redisUtilService.createHashKey("url_preview:", url)).thenReturn(key)
+        `when`(redisTemplate.opsForValue()).thenReturn(valueOps)
+
+        adapter.cacheUrlPreview(url, preview)
+
+        verify(valueOps).set(eq(key), eq(objectMapper.writeValueAsString(preview)), eq(Duration.ofDays(7)))
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/adapter/persistence/message/preview/RegexUrlExtractorAdapterTest.kt
+++ b/src/test/kotlin/com/stark/shoot/adapter/persistence/message/preview/RegexUrlExtractorAdapterTest.kt
@@ -1,0 +1,37 @@
+package com.stark.shoot.adapter.persistence.message.preview
+
+import com.stark.shoot.adapter.out.persistence.mongodb.adapter.message.preview.RegexUrlExtractorAdapter
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("URL 추출 어댑터(Regex) 테스트")
+class RegexUrlExtractorAdapterTest {
+
+    private val adapter = RegexUrlExtractorAdapter()
+
+    @Nested
+    @DisplayName("extractUrls")
+    inner class ExtractUrls {
+
+        @Test
+        fun `텍스트에서 단일 URL을 추출한다`() {
+            val result = adapter.extractUrls("Visit https://example.com for info")
+            assertThat(result).containsExactly("https://example.com")
+        }
+
+        @Test
+        fun `텍스트에서 여러 URL을 추출한다`() {
+            val text = "Links: https://a.com https://b.org/path"
+            val result = adapter.extractUrls(text)
+            assertThat(result).containsExactly("https://a.com", "https://b.org/path")
+        }
+
+        @Test
+        fun `URL이 없으면 빈 리스트를 반환한다`() {
+            val result = adapter.extractUrls("no url here")
+            assertThat(result).isEmpty()
+        }
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/infrastructure/config/jwt/JwtProviderTest.kt
+++ b/src/test/kotlin/com/stark/shoot/infrastructure/config/jwt/JwtProviderTest.kt
@@ -1,0 +1,39 @@
+package com.stark.shoot.infrastructure.config.jwt
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("JwtProvider 테스트")
+class JwtProviderTest {
+
+    private val jwtProvider = JwtProvider(
+        secret = "mysecretkeymysecretkeymysecretkey12",
+        expiration = 60,
+        refreshExpiration = 120,
+        issuer = "shoot-app",
+        audience = "shoot-clients"
+    )
+
+    @Test
+    fun `토큰을 생성하고 값을 추출할 수 있다`() {
+        val token = jwtProvider.generateToken("1", "user")
+
+        assertThat(jwtProvider.isTokenValid(token)).isTrue()
+        assertThat(jwtProvider.extractId(token)).isEqualTo("1")
+        assertThat(jwtProvider.extractUsername(token)).isEqualTo("user")
+    }
+
+    @Test
+    fun `리프레시 토큰을 생성하고 검증할 수 있다`() {
+        val refresh = jwtProvider.generateRefreshToken("1", "user")
+
+        assertThat(jwtProvider.isRefreshTokenValid(refresh)).isTrue()
+        assertThat(jwtProvider.isTokenValid(refresh.value)).isFalse()
+    }
+
+    @Test
+    fun `잘못된 토큰은 유효하지 않다`() {
+        assertThat(jwtProvider.isTokenValid("wrong.token.value")).isFalse()
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/infrastructure/util/AwaitResultUtilTest.kt
+++ b/src/test/kotlin/com/stark/shoot/infrastructure/util/AwaitResultUtilTest.kt
@@ -1,0 +1,31 @@
+package com.stark.shoot.infrastructure.util
+
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.concurrent.CompletableFuture
+
+@DisplayName("awaitResult 및 runAsync 유틸 테스트")
+class AwaitResultUtilTest {
+
+    @Test
+    fun `CompletableFuture를 awaitResult 로 변환하여 값을 얻을 수 있다`() = runBlocking {
+        val future = CompletableFuture.completedFuture(42)
+        val result = future.awaitResult()
+        assertThat(result).isEqualTo(42)
+    }
+
+    @Test
+    fun `runAsync 는 결과를 가진 CompletableFuture 를 반환한다`() {
+        val future = runAsync { 21 * 2 }
+        assertThat(future.join()).isEqualTo(42)
+    }
+
+    @Test
+    fun `runAsync 에서 예외가 발생하면 future 도 예외를 전달한다`() {
+        val future = runAsync<Int> { throw IllegalStateException("fail") }
+        assertThrows<IllegalStateException> { future.join() }
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/infrastructure/util/ParticipantsConverterTest.kt
+++ b/src/test/kotlin/com/stark/shoot/infrastructure/util/ParticipantsConverterTest.kt
@@ -1,0 +1,35 @@
+package com.stark.shoot.infrastructure.util
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("ParticipantsConverter 테스트")
+class ParticipantsConverterTest {
+
+    private val converter = ParticipantsConverter()
+
+    @Test
+    fun `리스트를 JSON 문자열로 변환한다`() {
+        val json = converter.convertToDatabaseColumn(listOf(1L, 2L))
+        assertThat(json.replace(" ", "")).isEqualTo("[1,2]")
+    }
+
+    @Test
+    fun `null 리스트는 빈 배열 문자열을 반환한다`() {
+        val json = converter.convertToDatabaseColumn(null)
+        assertThat(json).isEqualTo("[]")
+    }
+
+    @Test
+    fun `JSON 문자열을 리스트로 변환한다`() {
+        val list = converter.convertToEntityAttribute("[1,2,3]")
+        assertThat(list).containsExactly(1L, 2L, 3L)
+    }
+
+    @Test
+    fun `null 문자열은 빈 리스트를 반환한다`() {
+        val list = converter.convertToEntityAttribute(null)
+        assertThat(list).isEmpty()
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/infrastructure/util/ToObjectIdTest.kt
+++ b/src/test/kotlin/com/stark/shoot/infrastructure/util/ToObjectIdTest.kt
@@ -1,0 +1,25 @@
+package com.stark.shoot.infrastructure.util
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.bson.types.ObjectId
+
+@DisplayName("toObjectId 확장 함수 테스트")
+class ToObjectIdTest {
+
+    @Test
+    fun `문자열을 ObjectId 로 변환한다`() {
+        val id = ObjectId().toHexString()
+        val result = id.toObjectId()
+        assertThat(result).isEqualTo(ObjectId(id))
+    }
+
+    @Test
+    fun `잘못된 문자열이면 예외가 발생한다`() {
+        assertThrows<IllegalArgumentException> {
+            "invalid".toObjectId()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add more unit tests across utilities and adapters
- cover Redis URL preview caching, MongoDB controller, JWT provider, and other helpers

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6855ee2526d08320a0e93ad7499c31da