### PR TITLE
Add missing domain service tests

### DIFF
--- a/src/test/kotlin/com/stark/shoot/domain/service/chatroom/ChatRoomDomainServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/service/chatroom/ChatRoomDomainServiceTest.kt
@@ -33,4 +33,47 @@ class ChatRoomDomainServiceTest {
         assertThat(titles[1L]).isEqualTo("room1")
         assertThat(titles[2L]).isEqualTo("1:1 채팅방")
     }
+
+    @Test
+    fun `두 사용자 간 1대1 채팅방을 찾을 수 있다`() {
+        val direct = ChatRoom(id = 1L, title = "dm", type = ChatRoomType.INDIVIDUAL, participants = mutableSetOf(1L,2L))
+        val group = ChatRoom(id = 2L, title = "group", type = ChatRoomType.GROUP, participants = mutableSetOf(1L,2L,3L))
+
+        val found = service.findDirectChatBetween(listOf(direct, group), 1L, 2L)
+
+        assertThat(found).isEqualTo(direct)
+    }
+
+    @Test
+    fun `1대1 채팅방이 없으면 null을 반환한다`() {
+        val group = ChatRoom(id = 1L, title = "group", type = ChatRoomType.GROUP, participants = mutableSetOf(1L,2L,3L))
+
+        val found = service.findDirectChatBetween(listOf(group), 1L, 2L)
+
+        assertThat(found).isNull()
+    }
+
+    @Test
+    fun `마지막 메시지 맵을 준비할 수 있다`() {
+        val rooms = listOf(
+            ChatRoom(id = 1L, title = "room", type = ChatRoomType.GROUP, participants = mutableSetOf(1L), lastMessageId = "m1"),
+            ChatRoom(id = 2L, title = "none", type = ChatRoomType.GROUP, participants = mutableSetOf(1L))
+        )
+
+        val result = service.prepareLastMessages(rooms)
+
+        assertThat(result[1L]).isEqualTo("최근 메시지")
+        assertThat(result[2L]).isEqualTo("최근 메시지가 없습니다.")
+    }
+
+    @Test
+    fun `타임스탬프 맵을 준비할 수 있다`() {
+        val rooms = listOf(
+            ChatRoom(id = 1L, title = "room", type = ChatRoomType.GROUP, participants = mutableSetOf(1L))
+        )
+
+        val result = service.prepareTimestamps(rooms)
+
+        assertThat(result[1L]).isNotBlank()
+    }
 }

--- a/src/test/kotlin/com/stark/shoot/domain/service/chatroom/ChatRoomParticipantDomainServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/service/chatroom/ChatRoomParticipantDomainServiceTest.kt
@@ -25,4 +25,24 @@ class ChatRoomParticipantDomainServiceTest {
         assertThat(updated.participants).containsExactlyInAnyOrder(1L, 3L)
         assertThat(updated.pinnedParticipants).containsExactly(1L)
     }
+
+    @Test
+    fun `참여자를 제거하면 삭제 여부를 판단할 수 있다`() {
+        val room = ChatRoom(id = 1L, title = "room", type = ChatRoomType.GROUP, participants = mutableSetOf(1L, 2L))
+
+        val result = service.removeParticipant(room, 2L)
+
+        assertThat(result.chatRoom.participants).containsExactly(1L)
+        assertThat(result.shouldDeleteRoom).isFalse()
+    }
+
+    @Test
+    fun `마지막 참여자를 제거하면 방이 삭제 대상이 된다`() {
+        val room = ChatRoom(id = 1L, title = "room", type = ChatRoomType.GROUP, participants = mutableSetOf(1L))
+
+        val result = service.removeParticipant(room, 1L)
+
+        assertThat(result.chatRoom.participants).isEmpty()
+        assertThat(result.shouldDeleteRoom).isTrue()
+    }
 }


### PR DESCRIPTION
## Summary
- expand `ChatRoomDomainServiceTest` with coverage for
  - finding direct chat rooms
  - preparing last messages and timestamps
- extend `ChatRoomParticipantDomainServiceTest` with removal logic tests

## Testing
- `./gradlew test --no-build-cache` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685644eb531483209a82a6ee0dc7510f