### PR TITLE
Refactor friend request workflow

### DIFF
--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/user/friend/FriendRequestJpaAdapter.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/user/friend/FriendRequestJpaAdapter.kt
@@ -1,0 +1,37 @@
+package com.stark.shoot.adapter.out.persistence.postgres.adapter.user.friend
+
+import com.stark.shoot.adapter.out.persistence.postgres.entity.FriendRequestEntity
+import com.stark.shoot.adapter.out.persistence.postgres.repository.FriendRequestRepository
+import com.stark.shoot.adapter.out.persistence.postgres.repository.UserRepository
+import com.stark.shoot.application.port.out.user.friend.FriendRequestPort
+import com.stark.shoot.domain.user.FriendRequest
+import com.stark.shoot.domain.user.type.FriendRequestStatus
+import com.stark.shoot.domain.user.vo.UserId
+import com.stark.shoot.infrastructure.annotation.Adapter
+import com.stark.shoot.infrastructure.exception.web.ResourceNotFoundException
+import java.time.Instant
+
+@Adapter
+class FriendRequestJpaAdapter(
+    private val userRepository: UserRepository,
+    private val friendRequestRepository: FriendRequestRepository
+) : FriendRequestPort {
+
+    override fun saveFriendRequest(request: FriendRequest) {
+        val sender = userRepository.findById(request.senderId.value)
+            .orElseThrow { ResourceNotFoundException("사용자를 찾을 수 없습니다: ${'$'}{request.senderId.value}") }
+        val receiver = userRepository.findById(request.receiverId.value)
+            .orElseThrow { ResourceNotFoundException("사용자를 찾을 수 없습니다: ${'$'}{request.receiverId.value}") }
+        val entity = FriendRequestEntity(sender, receiver, request.status)
+        friendRequestRepository.save(entity)
+    }
+
+    override fun updateStatus(senderId: UserId, receiverId: UserId, status: FriendRequestStatus) {
+        val requests = friendRequestRepository.findAllBySenderIdAndReceiverId(senderId.value, receiverId.value)
+        for (entity in requests) {
+            entity.status = status
+            entity.respondedAt = Instant.now()
+            friendRequestRepository.save(entity)
+        }
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/application/port/out/user/friend/FriendRequestPort.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/out/user/friend/FriendRequestPort.kt
@@ -1,0 +1,16 @@
+package com.stark.shoot.application.port.out.user.friend
+
+import com.stark.shoot.domain.user.FriendRequest
+import com.stark.shoot.domain.user.type.FriendRequestStatus
+import com.stark.shoot.domain.user.vo.UserId
+
+/**
+ * 친구 요청을 저장하고 상태를 변경하기 위한 포트
+ */
+interface FriendRequestPort {
+    /** 친구 요청 저장 */
+    fun saveFriendRequest(request: FriendRequest)
+
+    /** 상태 업데이트 */
+    fun updateStatus(senderId: UserId, receiverId: UserId, status: FriendRequestStatus)
+}

--- a/src/main/kotlin/com/stark/shoot/application/service/user/friend/FriendReceiveService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/user/friend/FriendReceiveService.kt
@@ -4,6 +4,8 @@ import com.stark.shoot.application.port.`in`.user.friend.FriendReceiveUseCase
 import com.stark.shoot.application.port.out.event.EventPublisher
 import com.stark.shoot.application.port.out.user.FindUserPort
 import com.stark.shoot.application.port.out.user.friend.UpdateFriendPort
+import com.stark.shoot.application.port.out.user.friend.FriendRequestPort
+import com.stark.shoot.domain.user.type.FriendRequestStatus
 import com.stark.shoot.domain.user.User
 import com.stark.shoot.domain.user.vo.UserId
 import com.stark.shoot.domain.user.service.FriendDomainService
@@ -17,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional
 class FriendReceiveService(
     private val findUserPort: FindUserPort,
     private val updateFriendPort: UpdateFriendPort,
+    private val friendRequestPort: FriendRequestPort,
     private val eventPublisher: EventPublisher,
     private val friendDomainService: FriendDomainService,
     private val friendCacheManager: FriendCacheManager
@@ -46,9 +49,8 @@ class FriendReceiveService(
             requesterId = requesterId
         )
 
-        // 업데이트된 사용자 정보 저장
-        updateFriendPort.removeIncomingFriendRequest(currentUserId, requesterId)
-        updateFriendPort.removeOutgoingFriendRequest(requesterId, currentUserId)
+        // 친구 요청 상태 업데이트
+        friendRequestPort.updateStatus(requesterId, currentUserId, FriendRequestStatus.ACCEPTED)
         updateFriendPort.addFriendRelation(currentUserId, requesterId)
         updateFriendPort.addFriendRelation(requesterId, currentUserId)
 
@@ -85,9 +87,8 @@ class FriendReceiveService(
             requesterId = requesterId
         )
 
-        // 업데이트된 사용자 정보 저장
-        updateFriendPort.removeIncomingFriendRequest(currentUserId, requesterId)
-        updateFriendPort.removeOutgoingFriendRequest(requesterId, currentUserId)
+        // 친구 요청 상태 업데이트
+        friendRequestPort.updateStatus(requesterId, currentUserId, FriendRequestStatus.REJECTED)
 
         // 캐시 무효화
         friendCacheManager.invalidateFriendshipCaches(currentUserId, requesterId)


### PR DESCRIPTION
## Summary
- add `FriendRequestPort` to expose friend request persistence
- implement `FriendRequestJpaAdapter`
- inject the new port into friend services
- store and update friend request state through the new port

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6857eb9f60b08320859bb83fa956f260