### PR TITLE
Refactor ports for friend groups and users

### DIFF
--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/user/UserCommonPersistenceAdapter.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/user/UserCommonPersistenceAdapter.kt
@@ -2,9 +2,7 @@ package com.stark.shoot.adapter.out.persistence.postgres.adapter.user
 
 import com.stark.shoot.adapter.out.persistence.postgres.mapper.UserMapper
 import com.stark.shoot.adapter.out.persistence.postgres.repository.UserRepository
-import com.stark.shoot.application.port.out.user.UserCreatePort
-import com.stark.shoot.application.port.out.user.UserDeletePort
-import com.stark.shoot.application.port.out.user.UserUpdatePort
+import com.stark.shoot.application.port.out.user.UserCommandPort
 import com.stark.shoot.domain.user.User
 import com.stark.shoot.domain.user.vo.UserId
 import com.stark.shoot.infrastructure.annotation.Adapter
@@ -13,7 +11,7 @@ import com.stark.shoot.infrastructure.annotation.Adapter
 class UserCommonPersistenceAdapter(
     private val userRepository: UserRepository,
     private val userMapper: UserMapper
-) : UserCreatePort, UserDeletePort, UserUpdatePort {
+) : UserCommandPort {
 
     /**
      * 사용자 생성

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/user/group/FriendGroupPersistenceAdapter.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/user/group/FriendGroupPersistenceAdapter.kt
@@ -6,9 +6,7 @@ import com.stark.shoot.adapter.out.persistence.postgres.mapper.FriendGroupMapper
 import com.stark.shoot.adapter.out.persistence.postgres.repository.FriendGroupMemberRepository
 import com.stark.shoot.adapter.out.persistence.postgres.repository.FriendGroupRepository
 import com.stark.shoot.adapter.out.persistence.postgres.repository.UserRepository
-import com.stark.shoot.application.port.out.user.group.DeleteFriendGroupPort
-import com.stark.shoot.application.port.out.user.group.LoadFriendGroupPort
-import com.stark.shoot.application.port.out.user.group.SaveFriendGroupPort
+import com.stark.shoot.application.port.out.user.group.FriendGroupPort
 import com.stark.shoot.domain.user.FriendGroup
 import com.stark.shoot.domain.user.vo.UserId
 import com.stark.shoot.infrastructure.annotation.Adapter
@@ -20,7 +18,7 @@ class FriendGroupPersistenceAdapter(
     private val memberRepository: FriendGroupMemberRepository,
     private val userRepository: UserRepository,
     private val mapper: FriendGroupMapper,
-) : SaveFriendGroupPort, LoadFriendGroupPort, DeleteFriendGroupPort {
+) : FriendGroupPort {
 
     override fun save(group: FriendGroup): FriendGroup {
         val ownerEntity = userRepository.findById(group.ownerId.value)

--- a/src/main/kotlin/com/stark/shoot/application/port/out/user/UserCommandPort.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/out/user/UserCommandPort.kt
@@ -1,0 +1,3 @@
+package com.stark.shoot.application.port.out.user
+
+interface UserCommandPort : UserCreatePort, UserUpdatePort, UserDeletePort

--- a/src/main/kotlin/com/stark/shoot/application/port/out/user/UserPort.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/out/user/UserPort.kt
@@ -1,0 +1,3 @@
+package com.stark.shoot.application.port.out.user
+
+interface UserPort : UserCommandPort, FindUserPort

--- a/src/main/kotlin/com/stark/shoot/application/port/out/user/group/FriendGroupCommandPort.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/out/user/group/FriendGroupCommandPort.kt
@@ -1,0 +1,3 @@
+package com.stark.shoot.application.port.out.user.group
+
+interface FriendGroupCommandPort : SaveFriendGroupPort, DeleteFriendGroupPort

--- a/src/main/kotlin/com/stark/shoot/application/port/out/user/group/FriendGroupPort.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/out/user/group/FriendGroupPort.kt
@@ -1,0 +1,3 @@
+package com.stark.shoot.application.port.out.user.group
+
+interface FriendGroupPort : FriendGroupCommandPort, FriendGroupQueryPort

--- a/src/main/kotlin/com/stark/shoot/application/port/out/user/group/FriendGroupQueryPort.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/out/user/group/FriendGroupQueryPort.kt
@@ -1,0 +1,3 @@
+package com.stark.shoot.application.port.out.user.group
+
+interface FriendGroupQueryPort : LoadFriendGroupPort

--- a/src/main/kotlin/com/stark/shoot/application/service/user/UserCreateService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/user/UserCreateService.kt
@@ -2,7 +2,7 @@ package com.stark.shoot.application.service.user
 
 import com.stark.shoot.adapter.`in`.web.dto.user.CreateUserRequest
 import com.stark.shoot.application.port.`in`.user.UserCreateUseCase
-import com.stark.shoot.application.port.out.user.UserCreatePort
+import com.stark.shoot.application.port.out.user.UserCommandPort
 import com.stark.shoot.domain.user.User
 import com.stark.shoot.infrastructure.annotation.UseCase
 import org.springframework.security.crypto.password.PasswordEncoder
@@ -11,7 +11,7 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional
 @UseCase
 class UserCreateService(
-    private val userCreatePort: UserCreatePort,
+    private val userCommandPort: UserCommandPort,
     private val passwordEncoder: PasswordEncoder
 ) : UserCreateUseCase {
 
@@ -35,6 +35,6 @@ class UserCreateService(
         )
 
         // 영속성 계층을 통해 사용자 저장
-        return userCreatePort.createUser(user)
+        return userCommandPort.createUser(user)
     }
 }

--- a/src/main/kotlin/com/stark/shoot/application/service/user/UserDeleteService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/user/UserDeleteService.kt
@@ -1,7 +1,7 @@
 package com.stark.shoot.application.service.user
 
 import com.stark.shoot.application.port.`in`.user.UserDeleteUseCase
-import com.stark.shoot.application.port.out.user.UserDeletePort
+import com.stark.shoot.application.port.out.user.UserCommandPort
 import com.stark.shoot.domain.user.vo.UserId
 import com.stark.shoot.infrastructure.annotation.UseCase
 import org.springframework.transaction.annotation.Transactional
@@ -9,7 +9,7 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional
 @UseCase
 class UserDeleteService(
-    private val userDeletePort: UserDeletePort
+    private val userCommandPort: UserCommandPort
 ) : UserDeleteUseCase {
 
     /**
@@ -18,7 +18,7 @@ class UserDeleteService(
      * @param userId 사용자 ID
      */
     override fun deleteUser(userId: UserId) {
-        userDeletePort.deleteUser(userId)
+        userCommandPort.deleteUser(userId)
     }
 
 }

--- a/src/main/kotlin/com/stark/shoot/application/service/user/group/FriendGroupService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/user/group/FriendGroupService.kt
@@ -3,9 +3,8 @@ package com.stark.shoot.application.service.user.group
 import com.stark.shoot.application.port.`in`.user.group.FindFriendGroupUseCase
 import com.stark.shoot.application.port.`in`.user.group.ManageFriendGroupUseCase
 import com.stark.shoot.application.port.out.user.FindUserPort
-import com.stark.shoot.application.port.out.user.group.DeleteFriendGroupPort
-import com.stark.shoot.application.port.out.user.group.LoadFriendGroupPort
-import com.stark.shoot.application.port.out.user.group.SaveFriendGroupPort
+import com.stark.shoot.application.port.out.user.group.FriendGroupCommandPort
+import com.stark.shoot.application.port.out.user.group.FriendGroupQueryPort
 import com.stark.shoot.domain.user.FriendGroup
 import com.stark.shoot.domain.user.service.group.FriendGroupDomainService
 import com.stark.shoot.domain.user.vo.UserId
@@ -17,9 +16,8 @@ import org.springframework.transaction.annotation.Transactional
 @UseCase
 class FriendGroupService(
     private val findUserPort: FindUserPort,
-    private val loadFriendGroupPort: LoadFriendGroupPort,
-    private val saveFriendGroupPort: SaveFriendGroupPort,
-    private val deleteFriendGroupPort: DeleteFriendGroupPort,
+    private val friendGroupQueryPort: FriendGroupQueryPort,
+    private val friendGroupCommandPort: FriendGroupCommandPort,
     private val domainService: FriendGroupDomainService,
 ) : ManageFriendGroupUseCase, FindFriendGroupUseCase {
 
@@ -32,27 +30,27 @@ class FriendGroupService(
             throw ResourceNotFoundException("사용자를 찾을 수 없습니다: $ownerId")
         }
         val group = domainService.create(ownerId, name, description)
-        return saveFriendGroupPort.save(group)
+        return friendGroupCommandPort.save(group)
     }
 
     override fun renameGroup(
         groupId: Long,
         newName: String
     ): FriendGroup {
-        val group = loadFriendGroupPort.findById(groupId)
+        val group = friendGroupQueryPort.findById(groupId)
             ?: throw ResourceNotFoundException("그룹을 찾을 수 없습니다: $groupId")
         val updated = domainService.rename(group, newName)
-        return saveFriendGroupPort.save(updated)
+        return friendGroupCommandPort.save(updated)
     }
 
     override fun updateDescription(
         groupId: Long,
         description: String?
     ): FriendGroup {
-        val group = loadFriendGroupPort.findById(groupId)
+        val group = friendGroupQueryPort.findById(groupId)
             ?: throw ResourceNotFoundException("그룹을 찾을 수 없습니다: $groupId")
         val updated = domainService.updateDescription(group, description)
-        return saveFriendGroupPort.save(updated)
+        return friendGroupCommandPort.save(updated)
     }
 
     override fun addMember(
@@ -63,34 +61,34 @@ class FriendGroupService(
             throw ResourceNotFoundException("사용자를 찾을 수 없습니다: $memberId")
         }
 
-        val group = loadFriendGroupPort.findById(groupId)
+        val group = friendGroupQueryPort.findById(groupId)
             ?: throw ResourceNotFoundException("그룹을 찾을 수 없습니다: $groupId")
 
         val updated = domainService.addMember(group, memberId)
 
-        return saveFriendGroupPort.save(updated)
+        return friendGroupCommandPort.save(updated)
     }
 
     override fun removeMember(
         groupId: Long,
         memberId: UserId
     ): FriendGroup {
-        val group = loadFriendGroupPort.findById(groupId)
+        val group = friendGroupQueryPort.findById(groupId)
             ?: throw ResourceNotFoundException("그룹을 찾을 수 없습니다: $groupId")
 
         val updated = domainService.removeMember(group, memberId)
-        return saveFriendGroupPort.save(updated)
+        return friendGroupCommandPort.save(updated)
     }
 
     override fun deleteGroup(groupId: Long) {
-        deleteFriendGroupPort.deleteById(groupId)
+        friendGroupCommandPort.deleteById(groupId)
     }
 
     override fun getGroup(groupId: Long): FriendGroup? {
-        return loadFriendGroupPort.findById(groupId)
+        return friendGroupQueryPort.findById(groupId)
     }
 
     override fun getGroups(ownerId: UserId): List<FriendGroup> {
-        return loadFriendGroupPort.findByOwnerId(ownerId)
+        return friendGroupQueryPort.findByOwnerId(ownerId)
     }
 }

--- a/src/main/kotlin/com/stark/shoot/application/service/user/profile/ManageUserCodeService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/user/profile/ManageUserCodeService.kt
@@ -2,7 +2,7 @@ package com.stark.shoot.application.service.user.profile
 
 import com.stark.shoot.application.port.`in`.user.code.ManageUserCodeUseCase
 import com.stark.shoot.application.port.out.user.FindUserPort
-import com.stark.shoot.application.port.out.user.UserUpdatePort
+import com.stark.shoot.application.port.out.user.UserCommandPort
 import com.stark.shoot.application.port.out.user.code.UpdateUserCodePort
 import com.stark.shoot.domain.user.vo.UserCode
 import com.stark.shoot.domain.user.vo.UserId
@@ -16,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional
 class ManageUserCodeService(
     private val findUserPort: FindUserPort,
     private val updateUserCodePort: UpdateUserCodePort,
-    private val userUpdatePort: UserUpdatePort
+    private val userCommandPort: UserCommandPort
 ) : ManageUserCodeUseCase {
 
     /**
@@ -61,7 +61,7 @@ class ManageUserCodeService(
 
         // 유저 코드 업데이트
         val updatedUser = user.copy(id = user.id, userCode = randomCode)
-        userUpdatePort.updateUser(updatedUser)
+        userCommandPort.updateUser(updatedUser)
     }
 
 }

--- a/src/main/kotlin/com/stark/shoot/application/service/user/profile/UserStatusService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/user/profile/UserStatusService.kt
@@ -2,7 +2,7 @@ package com.stark.shoot.application.service.user.profile
 
 import com.stark.shoot.application.port.`in`.user.profile.UserStatusUseCase
 import com.stark.shoot.application.port.out.user.FindUserPort
-import com.stark.shoot.application.port.out.user.UserUpdatePort
+import com.stark.shoot.application.port.out.user.UserCommandPort
 import com.stark.shoot.domain.user.User
 import com.stark.shoot.domain.user.type.UserStatus
 import com.stark.shoot.domain.user.vo.UserId
@@ -15,7 +15,7 @@ import java.time.Instant
 @Transactional
 @UseCase
 class UserStatusService(
-    private val userUpdatePort: UserUpdatePort,
+    private val userCommandPort: UserCommandPort,
     private val findUserPort: FindUserPort
 ) : UserStatusUseCase {
 
@@ -50,7 +50,7 @@ class UserStatusService(
         )
 
         // 변경된 사용자 정보 저장
-        return userUpdatePort.updateUser(updatedUser)
+        return userCommandPort.updateUser(updatedUser)
     }
 
 }

--- a/src/main/kotlin/com/stark/shoot/application/service/user/profile/UserUpdateProfileService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/user/profile/UserUpdateProfileService.kt
@@ -5,7 +5,7 @@ import com.stark.shoot.adapter.`in`.web.dto.user.SetProfileImageRequest
 import com.stark.shoot.adapter.`in`.web.dto.user.UpdateProfileRequest
 import com.stark.shoot.application.port.`in`.user.profile.UserUpdateProfileUseCase
 import com.stark.shoot.application.port.out.user.FindUserPort
-import com.stark.shoot.application.port.out.user.UserUpdatePort
+import com.stark.shoot.application.port.out.user.UserCommandPort
 import com.stark.shoot.domain.user.User
 import com.stark.shoot.domain.user.vo.UserId
 import com.stark.shoot.infrastructure.annotation.UseCase
@@ -16,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional
 @UseCase
 class UserUpdateProfileService(
     private val findUserPort: FindUserPort,
-    private val userUpdatePort: UserUpdatePort
+    private val userCommandPort: UserCommandPort
 ) : UserUpdateProfileUseCase {
 
     /**
@@ -42,7 +42,7 @@ class UserUpdateProfileService(
             backgroundImageUrl = request.backgroundImageUrl
         )
 
-        return userUpdatePort.updateUser(updatedUser)
+        return userCommandPort.updateUser(updatedUser)
     }
 
     /**
@@ -65,7 +65,7 @@ class UserUpdateProfileService(
             imageUrl = request.profileImageUrl
         )
 
-        return userUpdatePort.updateUser(updatedUser)
+        return userCommandPort.updateUser(updatedUser)
     }
 
     /**
@@ -88,7 +88,7 @@ class UserUpdateProfileService(
             imageUrl = request.backgroundImageUrl
         )
 
-        return userUpdatePort.updateUser(updatedUser)
+        return userCommandPort.updateUser(updatedUser)
     }
 
 }


### PR DESCRIPTION
## Summary
- introduce `FriendGroupCommandPort`, `FriendGroupQueryPort`, and `FriendGroupPort`
- add `UserCommandPort` and `UserPort`
- refactor persistence adapters to implement new ports
- update services to rely on command/query ports

## Testing
- `./gradlew test -q` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6858141159dc8320802890a6dd412c49