### PR TITLE
Implement repository-based aggregate adapters

### DIFF
--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/adapter/message/MessageMongoAdapter.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/adapter/message/MessageMongoAdapter.kt
@@ -1,0 +1,199 @@
+package com.stark.shoot.adapter.out.persistence.mongodb.adapter.message
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.stark.shoot.adapter.`in`.web.dto.message.ChatMessageRequest
+import com.stark.shoot.adapter.`in`.web.dto.message.read.ReadStatus
+import com.stark.shoot.adapter.out.persistence.mongodb.document.message.ChatMessageDocument
+import com.stark.shoot.adapter.out.persistence.mongodb.document.message.bookmark.MessageBookmarkDocument
+import com.stark.shoot.adapter.out.persistence.mongodb.mapper.ChatMessageMapper
+import com.stark.shoot.adapter.out.persistence.mongodb.repository.ChatMessageMongoRepository
+import com.stark.shoot.adapter.out.persistence.mongodb.repository.MessageBookmarkMongoRepository
+import com.stark.shoot.application.port.out.message.MessagePort
+import com.stark.shoot.domain.chat.bookmark.MessageBookmark
+import com.stark.shoot.domain.chat.message.ChatMessage
+import com.stark.shoot.domain.chat.message.vo.MessageId
+import com.stark.shoot.domain.chatroom.vo.ChatRoomId
+import com.stark.shoot.domain.user.vo.UserId
+import com.stark.shoot.infrastructure.annotation.Adapter
+import com.stark.shoot.infrastructure.util.toObjectId
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import org.bson.types.ObjectId
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.data.redis.connection.stream.StreamRecords
+import org.springframework.data.redis.core.StringRedisTemplate
+
+@Adapter
+class MessageMongoAdapter(
+    private val chatMessageRepository: ChatMessageMongoRepository,
+    private val bookmarkRepository: MessageBookmarkMongoRepository,
+    private val chatMessageMapper: ChatMessageMapper,
+    private val redisTemplate: StringRedisTemplate,
+    private val objectMapper: ObjectMapper,
+) : MessagePort {
+
+    private val logger = KotlinLogging.logger {}
+
+    override fun save(message: ChatMessage): ChatMessage {
+        val document = chatMessageMapper.toDocument(message)
+        return chatMessageRepository.save(document).let(chatMessageMapper::toDomain)
+    }
+
+    override fun saveAll(messages: List<ChatMessage>): List<ChatMessage> {
+        val docs = messages.map(chatMessageMapper::toDocument)
+        return chatMessageRepository.saveAll(docs).map(chatMessageMapper::toDomain).toList()
+    }
+
+    override fun findById(messageId: MessageId): ChatMessage? {
+        return chatMessageRepository.findById(messageId.value.toObjectId())
+            .map(chatMessageMapper::toDomain)
+            .orElse(null)
+    }
+
+    override fun findByRoomId(roomId: ChatRoomId, limit: Int): List<ChatMessage> {
+        val pageable = PageRequest.of(0, limit, Sort.by(Sort.Direction.DESC, "_id"))
+        return chatMessageRepository.findByRoomId(roomId.value, pageable).map(chatMessageMapper::toDomain)
+    }
+
+    override fun findByRoomIdAndBeforeId(roomId: ChatRoomId, beforeMessageId: MessageId, limit: Int): List<ChatMessage> {
+        val pageable = PageRequest.of(0, limit, Sort.by(Sort.Direction.DESC, "_id"))
+        return chatMessageRepository.findByRoomIdAndIdBefore(roomId.value, beforeMessageId.value.toObjectId(), pageable)
+            .map(chatMessageMapper::toDomain)
+    }
+
+    override fun findByRoomIdAndAfterId(roomId: ChatRoomId, afterMessageId: MessageId, limit: Int): List<ChatMessage> {
+        val pageable = PageRequest.of(0, limit, Sort.by(Sort.Direction.ASC, "_id"))
+        return chatMessageRepository.findByRoomIdAndIdAfter(roomId.value, afterMessageId.value.toObjectId(), pageable)
+            .map(chatMessageMapper::toDomain)
+    }
+
+    override fun findUnreadByRoomId(roomId: ChatRoomId, userId: UserId, limit: Int): List<ChatMessage> {
+        val pageable = PageRequest.of(0, limit, Sort.by(Sort.Direction.DESC, "createdAt"))
+        return chatMessageRepository.findUnreadMessages(roomId.value, userId.value, pageable)
+            .map(chatMessageMapper::toDomain)
+    }
+
+    override fun findPinnedMessagesByRoomId(roomId: ChatRoomId, limit: Int): List<ChatMessage> {
+        val pageable = PageRequest.of(0, limit, Sort.by(Sort.Direction.DESC, "createdAt"))
+        return chatMessageRepository.findPinnedMessagesByRoomId(roomId.value, pageable)
+            .map(chatMessageMapper::toDomain)
+    }
+
+    override fun findByRoomIdFlow(roomId: ChatRoomId, limit: Int): Flow<ChatMessage> = flow {
+        val messages = findByRoomId(roomId, limit)
+        messages.forEach { emit(it) }
+    }
+
+    override fun findByRoomIdAndBeforeIdFlow(roomId: ChatRoomId, beforeMessageId: MessageId, limit: Int): Flow<ChatMessage> = flow {
+        val messages = findByRoomIdAndBeforeId(roomId, beforeMessageId, limit)
+        messages.forEach { emit(it) }
+    }
+
+    override fun findByRoomIdAndAfterIdFlow(roomId: ChatRoomId, afterMessageId: MessageId, limit: Int): Flow<ChatMessage> = flow {
+        val messages = findByRoomIdAndAfterId(roomId, afterMessageId, limit)
+        messages.forEach { emit(it) }
+    }
+
+    override fun findByThreadId(threadId: MessageId, limit: Int): List<ChatMessage> {
+        val pageable = PageRequest.of(0, limit, Sort.by(Sort.Direction.ASC, "_id"))
+        return chatMessageRepository.findByThreadId(threadId.value.toObjectId(), pageable)
+            .map(chatMessageMapper::toDomain)
+    }
+
+    override fun findByThreadIdAndBeforeId(threadId: MessageId, beforeMessageId: MessageId, limit: Int): List<ChatMessage> {
+        val pageable = PageRequest.of(0, limit, Sort.by(Sort.Direction.DESC, "_id"))
+        return chatMessageRepository.findByThreadIdAndIdBefore(threadId.value.toObjectId(), beforeMessageId.value.toObjectId(), pageable)
+            .map(chatMessageMapper::toDomain)
+    }
+
+    override fun findThreadRootsByRoomId(roomId: ChatRoomId, limit: Int): List<ChatMessage> {
+        val pageable = PageRequest.of(0, limit, Sort.by(Sort.Direction.DESC, "_id"))
+        return chatMessageRepository.findThreadRootsByRoomId(roomId.value, pageable)
+            .map(chatMessageMapper::toDomain)
+    }
+
+    override fun findThreadRootsByRoomIdAndBeforeId(roomId: ChatRoomId, beforeMessageId: MessageId, limit: Int): List<ChatMessage> {
+        val pageable = PageRequest.of(0, limit, Sort.by(Sort.Direction.DESC, "_id"))
+        return chatMessageRepository.findThreadRootsByRoomIdAndIdBefore(roomId.value, beforeMessageId.value.toObjectId(), pageable)
+            .map(chatMessageMapper::toDomain)
+    }
+
+    override fun countByThreadId(threadId: MessageId): Long {
+        return chatMessageRepository.countByThreadId(threadId.value.toObjectId())
+    }
+
+    override suspend fun publish(message: ChatMessageRequest) {
+        val streamKey = "stream:chat:room:${message.roomId}"
+        val messageJson = objectMapper.writeValueAsString(message)
+        val map = mapOf("message" to messageJson)
+        val record = StreamRecords.newRecord().ofMap(map).withStreamKey(streamKey)
+        redisTemplate.opsForStream<String, String>().add(record)
+    }
+
+    override fun saveBookmark(bookmark: MessageBookmark): MessageBookmark {
+        val document = MessageBookmarkDocument.fromDomain(bookmark)
+        val saved = bookmarkRepository.save(document)
+        return saved.toDomain()
+    }
+
+    override fun deleteBookmark(messageId: MessageId, userId: UserId) {
+        bookmarkRepository.deleteByMessageIdAndUserId(messageId.value, userId.value)
+    }
+
+    override fun findBookmarksByUser(userId: UserId, roomId: ChatRoomId?): List<MessageBookmark> {
+        val documents = bookmarkRepository.findByUserId(userId.value)
+        if (roomId == null) {
+            return documents.map { it.toDomain() }
+        }
+
+        return documents.filter { doc ->
+            val message = chatMessageRepository.findById(ObjectId(doc.messageId))
+            message.isPresent && message.get().roomId == roomId.value
+        }.map { it.toDomain() }
+    }
+
+    override fun exists(messageId: MessageId, userId: UserId): Boolean {
+        return bookmarkRepository.existsByMessageIdAndUserId(messageId.value, userId.value)
+    }
+
+    private fun key(roomId: ChatRoomId, userId: UserId): String = "read:status:${roomId.value}:${userId.value}"
+
+    override fun save(readStatus: ReadStatus): ReadStatus {
+        val key = key(readStatus.roomId, readStatus.userId)
+        val value = objectMapper.writeValueAsString(readStatus)
+        redisTemplate.opsForValue().set(key, value)
+        return readStatus
+    }
+
+    override fun updateLastReadMessageId(roomId: ChatRoomId, userId: UserId, messageId: MessageId): ReadStatus {
+        val current = findByRoomIdAndUserId(roomId, userId) ?: ReadStatus.create(roomId, userId)
+        val updated = current.markAsRead(messageId)
+        return save(updated)
+    }
+
+    override fun incrementUnreadCount(roomId: ChatRoomId, userId: UserId): ReadStatus {
+        val current = findByRoomIdAndUserId(roomId, userId) ?: ReadStatus.create(roomId, userId)
+        val updated = current.incrementUnreadCount()
+        return save(updated)
+    }
+
+    override fun resetUnreadCount(roomId: ChatRoomId, userId: UserId): ReadStatus {
+        val current = findByRoomIdAndUserId(roomId, userId) ?: ReadStatus.create(roomId, userId)
+        val updated = current.copy(unreadCount = 0)
+        return save(updated)
+    }
+
+    override fun findByRoomIdAndUserId(roomId: ChatRoomId, userId: UserId): ReadStatus? {
+        val value = redisTemplate.opsForValue().get(key(roomId, userId)) ?: return null
+        return objectMapper.readValue(value, ReadStatus::class.java)
+    }
+
+    override fun findAllByRoomId(roomId: ChatRoomId): List<ReadStatus> {
+        val pattern = "read:status:${roomId.value}:*"
+        return redisTemplate.keys(pattern).mapNotNull { k ->
+            redisTemplate.opsForValue().get(k)?.let { objectMapper.readValue(it, ReadStatus::class.java) }
+        }
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/adapter/notification/NotificationMongoAdapter.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/adapter/notification/NotificationMongoAdapter.kt
@@ -1,0 +1,149 @@
+package com.stark.shoot.adapter.out.persistence.mongodb.adapter.notification
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.stark.shoot.adapter.out.persistence.mongodb.document.notification.NotificationDocument
+import com.stark.shoot.adapter.out.persistence.mongodb.repository.NotificationMongoRepository
+import com.stark.shoot.domain.event.NotificationEvent
+import com.stark.shoot.domain.notification.Notification
+import com.stark.shoot.domain.notification.type.NotificationType
+import com.stark.shoot.domain.notification.type.SourceType
+import com.stark.shoot.domain.notification.vo.NotificationId
+import com.stark.shoot.domain.user.vo.UserId
+import com.stark.shoot.infrastructure.annotation.Adapter
+import com.stark.shoot.infrastructure.exception.web.KafkaPublishException
+import com.stark.shoot.infrastructure.exception.web.MongoOperationException
+import com.stark.shoot.infrastructure.exception.web.RedisOperationException
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.mongodb.core.query.Criteria
+import org.springframework.data.mongodb.core.query.Query
+import org.springframework.data.mongodb.core.query.isEqualTo
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.kafka.core.KafkaTemplate
+
+@Adapter
+class NotificationMongoAdapter(
+    private val notificationMongoRepository: NotificationMongoRepository,
+    private val mongoTemplate: MongoTemplate,
+    private val redisTemplate: StringRedisTemplate,
+    private val kafkaTemplate: KafkaTemplate<String, String>,
+    private val objectMapper: ObjectMapper,
+) : NotificationPort {
+
+    private val logger = KotlinLogging.logger {}
+
+    companion object {
+        private const val NOTIFICATION_CHANNEL_PREFIX = "notification:user:"
+        private const val NOTIFICATION_EVENTS_TOPIC = "notification-events"
+    }
+
+    override fun saveNotification(notification: Notification): Notification {
+        val document = NotificationDocument.fromDomain(notification)
+        val saved = notificationMongoRepository.save(document)
+        return saved.toDomain()
+    }
+
+    override fun saveNotifications(notifications: List<Notification>): List<Notification> {
+        val docs = notifications.map { NotificationDocument.fromDomain(it) }
+        val saved = notificationMongoRepository.saveAll(docs)
+        return saved.map { it.toDomain() }
+    }
+
+    override fun deleteNotification(notificationId: NotificationId) {
+        try {
+            if (notificationMongoRepository.existsById(notificationId.value)) {
+                notificationMongoRepository.deleteById(notificationId.value)
+            } else {
+                throw MongoOperationException("알림을 찾을 수 없습니다: $notificationId")
+            }
+        } catch (e: Exception) {
+            throw MongoOperationException("알림 삭제 중 오류가 발생했습니다: ${e.message}", e)
+        }
+    }
+
+    override fun deleteAllNotificationsForUser(userId: UserId): Int {
+        return notificationMongoRepository.deleteByUserId(userId.value)
+    }
+
+    override fun deleteNotificationsByType(userId: UserId, type: String): Int {
+        val query = Query.query(
+            Criteria.where("userId").isEqualTo(userId.value).and("type").isEqualTo(type)
+        )
+        val result = mongoTemplate.remove(query, "notifications")
+        return result.deletedCount.toInt()
+    }
+
+    override fun deleteNotificationsBySource(userId: UserId, sourceType: String, sourceId: String?): Int {
+        val criteria = Criteria.where("userId").isEqualTo(userId.value)
+            .and("sourceType").isEqualTo(sourceType)
+        if (sourceId != null) {
+            criteria.and("sourceId").isEqualTo(sourceId)
+        }
+        val query = Query.query(criteria)
+        val result = mongoTemplate.remove(query, "notifications")
+        return result.deletedCount.toInt()
+    }
+
+    override fun loadNotificationById(id: NotificationId): Notification? {
+        return notificationMongoRepository.findById(id.value).map { it.toDomain() }.orElse(null)
+    }
+
+    override fun loadNotificationsForUser(userId: UserId, limit: Int, offset: Int): List<Notification> {
+        val pageable = PageRequest.of(offset / limit, limit, Sort.by(Sort.Direction.DESC, "createdAt"))
+        return notificationMongoRepository.findByUserId(userId.value, pageable).map { it.toDomain() }
+    }
+
+    override fun loadUnreadNotificationsForUser(userId: UserId, limit: Int, offset: Int): List<Notification> {
+        val pageable = PageRequest.of(offset / limit, limit, Sort.by(Sort.Direction.DESC, "createdAt"))
+        return notificationMongoRepository.findByUserIdAndIsReadFalse(userId.value, pageable)
+            .map { it.toDomain() }
+    }
+
+    override fun loadNotificationsByType(userId: UserId, type: NotificationType, limit: Int, offset: Int): List<Notification> {
+        val pageable = PageRequest.of(offset / limit, limit, Sort.by(Sort.Direction.DESC, "createdAt"))
+        return notificationMongoRepository.findByUserIdAndType(userId.value, type.name, pageable)
+            .map { it.toDomain() }
+    }
+
+    override fun loadNotificationsBySource(userId: UserId, sourceType: SourceType, sourceId: String?, limit: Int, offset: Int): List<Notification> {
+        val pageable = PageRequest.of(offset / limit, limit, Sort.by(Sort.Direction.DESC, "createdAt"))
+        return if (sourceId != null) {
+            notificationMongoRepository.findByUserIdAndSourceTypeAndSourceId(userId.value, sourceType.name, sourceId, pageable)
+                .map { it.toDomain() }
+        } else {
+            notificationMongoRepository.findByUserIdAndSourceType(userId.value, sourceType.name, pageable)
+                .map { it.toDomain() }
+        }
+    }
+
+    override fun countUnreadNotifications(userId: UserId): Int {
+        return notificationMongoRepository.countByUserIdAndIsReadFalse(userId.value)
+    }
+
+    override fun sendNotification(notification: Notification) {
+        try {
+            val channel = "$NOTIFICATION_CHANNEL_PREFIX${notification.userId.value}"
+            val json = objectMapper.writeValueAsString(notification)
+            redisTemplate.convertAndSend(channel, json)
+        } catch (e: Exception) {
+            logger.error(e) { "Redis를 통한 알림 전송 중 오류가 발생했습니다" }
+            throw RedisOperationException("Redis 전송 실패", e)
+        }
+    }
+
+    override fun sendNotifications(notifications: List<Notification>) {
+        notifications.forEach { sendNotification(it) }
+    }
+
+    override fun publishEvent(event: NotificationEvent) {
+        try {
+            val eventJson = objectMapper.writeValueAsString(event)
+            kafkaTemplate.send(NOTIFICATION_EVENTS_TOPIC, event.sourceId, eventJson)
+        } catch (e: Exception) {
+            logger.error(e) { "Kafka 이벤트 발행 실패" }
+            throw KafkaPublishException("Kafka 이벤트 발행 실패", e)
+        }
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/chatroom/ChatRoomPersistenceAdapter.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/chatroom/ChatRoomPersistenceAdapter.kt
@@ -1,0 +1,155 @@
+package com.stark.shoot.adapter.out.persistence.postgres.adapter.chatroom
+
+import com.stark.shoot.adapter.out.persistence.postgres.entity.ChatRoomUserEntity
+import com.stark.shoot.adapter.out.persistence.postgres.mapper.ChatRoomMapper
+import com.stark.shoot.adapter.out.persistence.postgres.repository.ChatRoomRepository
+import com.stark.shoot.adapter.out.persistence.postgres.repository.ChatRoomUserRepository
+import com.stark.shoot.adapter.out.persistence.postgres.repository.UserRepository
+import com.stark.shoot.application.port.out.chatroom.ChatRoomPort
+import com.stark.shoot.domain.chat.message.vo.MessageId
+import com.stark.shoot.domain.chatroom.ChatRoom
+import com.stark.shoot.domain.chatroom.vo.ChatRoomAnnouncement
+import com.stark.shoot.domain.chatroom.vo.ChatRoomId
+import com.stark.shoot.domain.chatroom.vo.ChatRoomTitle
+import com.stark.shoot.domain.user.vo.UserId
+import com.stark.shoot.infrastructure.annotation.Adapter
+
+@Adapter
+class ChatRoomPersistenceAdapter(
+    private val chatRoomRepository: ChatRoomRepository,
+    private val chatRoomUserRepository: ChatRoomUserRepository,
+    private val userRepository: UserRepository,
+    private val chatRoomMapper: ChatRoomMapper,
+) : ChatRoomPort {
+
+    override fun save(chatRoom: ChatRoom): ChatRoom {
+        val savedChatRoomEntity = if (chatRoom.id != null) {
+            val existingEntity = chatRoomRepository.findById(chatRoom.id.value).orElseThrow {
+                IllegalStateException("채팅방을 찾을 수 없습니다. id=${chatRoom.id}")
+            }
+
+            existingEntity.update(
+                title = chatRoom.title?.value,
+                type = chatRoom.type,
+                announcement = chatRoom.announcement?.value,
+                lastMessageId = chatRoom.lastMessageId?.value?.toLongOrNull(),
+                lastActiveAt = chatRoom.lastActiveAt
+            )
+
+            chatRoomRepository.save(existingEntity)
+        } else {
+            val chatRoomEntity = chatRoomMapper.toEntity(chatRoom)
+            chatRoomRepository.save(chatRoomEntity)
+        }
+
+        val existingParticipants = if (chatRoom.id != null) {
+            chatRoomUserRepository.findByChatRoomId(savedChatRoomEntity.id)
+                .associateBy { it.user.id }
+        } else {
+            emptyMap()
+        }
+
+        val participantLongIds = chatRoom.participants.map { it.value }
+        val allUsers = userRepository.findAllById(participantLongIds)
+        val userMap = allUsers.associateBy { it.id }
+
+        val currentParticipantIds = existingParticipants.keys
+
+        val existingChatRoom = ChatRoom(
+            id = ChatRoomId.from(savedChatRoomEntity.id),
+            title = savedChatRoomEntity.title?.let { ChatRoomTitle.from(it) },
+            type = savedChatRoomEntity.type,
+            participants = currentParticipantIds.map { UserId.from(it) }.toMutableSet(),
+            pinnedParticipants = existingParticipants.filter { it.value.isPinned }.keys.map { UserId.from(it) }
+                .toMutableSet(),
+            announcement = savedChatRoomEntity.announcement?.let { ChatRoomAnnouncement.from(it) }
+        )
+
+        val participantChanges = existingChatRoom.calculateParticipantChanges(
+            newParticipants = chatRoom.participants,
+            newPinnedParticipants = chatRoom.pinnedParticipants
+        )
+
+        participantChanges.participantsToAdd.forEach { participantId ->
+            val user = userMap[participantId.value] ?: return@forEach
+            val isPinned = chatRoom.pinnedParticipants.contains(participantId)
+
+            val chatRoomUser = ChatRoomUserEntity(
+                chatRoom = savedChatRoomEntity,
+                user = user,
+                isPinned = isPinned
+            )
+            chatRoomUserRepository.save(chatRoomUser)
+        }
+
+        participantChanges.pinnedStatusChanges.forEach { (participantId, isPinned) ->
+            val existingUser = existingParticipants[participantId.value] ?: return@forEach
+
+            if (existingUser.isPinned != isPinned) {
+                existingUser.isPinned = isPinned
+                chatRoomUserRepository.save(existingUser)
+            }
+        }
+
+        if (participantChanges.participantsToRemove.isNotEmpty()) {
+            val userIdsToRemove = participantChanges.participantsToRemove.map { it.value }
+            chatRoomUserRepository.deleteAllByIdInBatch(
+                existingParticipants.filterKeys { it in userIdsToRemove }.values.map { it.id }
+            )
+        }
+
+        val updatedParticipants = chatRoomUserRepository.findByChatRoomId(savedChatRoomEntity.id)
+        return chatRoomMapper.toDomain(savedChatRoomEntity, updatedParticipants)
+    }
+
+    override fun deleteById(roomId: ChatRoomId): Boolean {
+        return try {
+            if (!chatRoomRepository.existsById(roomId.value)) {
+                return false
+            }
+
+            chatRoomRepository.deleteById(roomId.value)
+            true
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    override fun updateLastReadMessageId(roomId: ChatRoomId, userId: UserId, messageId: MessageId) {
+        chatRoomUserRepository.updateLastReadMessageId(roomId.value, userId.value, messageId.value)
+    }
+
+    override fun findById(roomId: ChatRoomId): ChatRoom? {
+        val chatRoomEntity = chatRoomRepository.findById(roomId.value).orElse(null) ?: return null
+        val participants = chatRoomUserRepository.findByChatRoomId(roomId.value)
+        return chatRoomMapper.toDomain(chatRoomEntity, participants)
+    }
+
+    override fun findByParticipantId(participantId: UserId): List<ChatRoom> {
+        val chatRoomUsers = chatRoomUserRepository.findByUserId(participantId.value)
+        if (chatRoomUsers.isEmpty()) {
+            return emptyList()
+        }
+
+        val chatRoomIds = chatRoomUsers.map { it.chatRoom.id }
+        return chatRoomRepository.findAllById(chatRoomIds).map { entity ->
+            val allParticipants = chatRoomUserRepository.findByChatRoomId(entity.id)
+            chatRoomMapper.toDomain(entity, allParticipants)
+        }
+    }
+
+    override fun findByUserId(userId: UserId): List<ChatRoom> {
+        val pinnedChatRoomUsers = chatRoomUserRepository.findByUserIdAndIsPinnedTrue(userId.value)
+        if (pinnedChatRoomUsers.isEmpty()) {
+            return emptyList()
+        }
+
+        val pinnedRoomIds = pinnedChatRoomUsers.map { it.chatRoom.id }
+        val chatRoomEntities = chatRoomRepository.findAllById(pinnedRoomIds)
+
+        return chatRoomEntities.map { entity ->
+            val participants = chatRoomUserRepository.findByChatRoomId(entity.id)
+            chatRoomMapper.toDomain(entity, participants)
+        }
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/application/filter/message/impl/ChatRoomLoadFilter.kt
+++ b/src/main/kotlin/com/stark/shoot/application/filter/message/impl/ChatRoomLoadFilter.kt
@@ -2,7 +2,7 @@ package com.stark.shoot.application.filter.message.impl
 
 import com.stark.shoot.application.filter.common.MessageProcessingFilter
 import com.stark.shoot.application.filter.message.chain.MessageProcessingChain
-import com.stark.shoot.application.port.out.chatroom.LoadChatRoomPort
+import com.stark.shoot.application.port.out.chatroom.ChatRoomQueryPort
 import com.stark.shoot.domain.chat.message.ChatMessage
 import com.stark.shoot.infrastructure.exception.web.ResourceNotFoundException
 import org.springframework.stereotype.Component
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component
  */
 @Component
 class ChatRoomLoadFilter(
-    private val loadChatRoomPort: LoadChatRoomPort
+    private val chatRoomQueryPort: ChatRoomQueryPort
 ) : MessageProcessingFilter {
 
     companion object {
@@ -27,7 +27,7 @@ class ChatRoomLoadFilter(
         chain: MessageProcessingChain
     ): ChatMessage {
         // 채팅방 로딩
-        val chatRoom = loadChatRoomPort.findById(message.roomId)
+        val chatRoom = chatRoomQueryPort.findById(message.roomId)
             ?: throw ResourceNotFoundException("채팅방을 찾을 수 없습니다. roomId=${message.roomId}")
 
         // 필터 체인 컨텍스트에 채팅방 정보 저장

--- a/src/main/kotlin/com/stark/shoot/application/port/out/chatroom/ChatRoomCommandPort.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/out/chatroom/ChatRoomCommandPort.kt
@@ -1,0 +1,3 @@
+package com.stark.shoot.application.port.out.chatroom
+
+interface ChatRoomCommandPort : SaveChatRoomPort, DeleteChatRoomPort, ReadStatusPort

--- a/src/main/kotlin/com/stark/shoot/application/port/out/chatroom/ChatRoomPort.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/out/chatroom/ChatRoomPort.kt
@@ -1,0 +1,3 @@
+package com.stark.shoot.application.port.out.chatroom
+
+interface ChatRoomPort : ChatRoomCommandPort, ChatRoomQueryPort

--- a/src/main/kotlin/com/stark/shoot/application/port/out/chatroom/ChatRoomQueryPort.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/out/chatroom/ChatRoomQueryPort.kt
@@ -1,0 +1,3 @@
+package com.stark.shoot.application.port.out.chatroom
+
+interface ChatRoomQueryPort : LoadChatRoomPort, LoadPinnedRoomsPort

--- a/src/main/kotlin/com/stark/shoot/application/port/out/message/MessageCommandPort.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/out/message/MessageCommandPort.kt
@@ -1,0 +1,3 @@
+package com.stark.shoot.application.port.out.message
+
+interface MessageCommandPort : SaveMessagePort, PublishMessagePort, BookmarkMessageCommandPort, ReadStatusCommandPort

--- a/src/main/kotlin/com/stark/shoot/application/port/out/message/MessagePort.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/out/message/MessagePort.kt
@@ -1,0 +1,3 @@
+package com.stark.shoot.application.port.out.message
+
+interface MessagePort : MessageCommandPort, MessageQueryPort

--- a/src/main/kotlin/com/stark/shoot/application/port/out/message/MessageQueryPort.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/out/message/MessageQueryPort.kt
@@ -1,0 +1,3 @@
+package com.stark.shoot.application.port.out.message
+
+interface MessageQueryPort : LoadMessagePort, LoadThreadPort, BookmarkMessageQueryPort, ReadStatusQueryPort

--- a/src/main/kotlin/com/stark/shoot/application/port/out/notification/NotificationCommandPort.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/out/notification/NotificationCommandPort.kt
@@ -1,0 +1,3 @@
+package com.stark.shoot.application.port.out.notification
+
+interface NotificationCommandPort : SaveNotificationPort, DeleteNotificationPort, SendNotificationPort, PublishNotificationEventPort

--- a/src/main/kotlin/com/stark/shoot/application/port/out/notification/NotificationPort.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/out/notification/NotificationPort.kt
@@ -1,0 +1,3 @@
+package com.stark.shoot.application.port.out.notification
+
+interface NotificationPort : NotificationCommandPort, NotificationQueryPort

--- a/src/main/kotlin/com/stark/shoot/application/port/out/notification/NotificationQueryPort.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/out/notification/NotificationQueryPort.kt
@@ -1,0 +1,3 @@
+package com.stark.shoot.application.port.out.notification
+
+interface NotificationQueryPort : LoadNotificationPort

--- a/src/main/kotlin/com/stark/shoot/application/service/chatroom/ChatRoomSearchService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/chatroom/ChatRoomSearchService.kt
@@ -3,14 +3,14 @@ package com.stark.shoot.application.service.chatroom
 import com.stark.shoot.adapter.`in`.web.dto.chatroom.ChatRoomResponse
 import com.stark.shoot.adapter.`in`.web.mapper.ChatRoomResponseMapper
 import com.stark.shoot.application.port.`in`.chatroom.ChatRoomSearchUseCase
-import com.stark.shoot.application.port.out.chatroom.LoadChatRoomPort
+import com.stark.shoot.application.port.out.chatroom.ChatRoomQueryPort
 import com.stark.shoot.domain.chatroom.service.ChatRoomDomainService
 import com.stark.shoot.domain.user.vo.UserId
 import com.stark.shoot.infrastructure.annotation.UseCase
 
 @UseCase
 class ChatRoomSearchService(
-    private val loadChatRoomPort: LoadChatRoomPort,
+    private val chatRoomQueryPort: ChatRoomQueryPort,
     private val chatRoomDomainService: ChatRoomDomainService,
     private val chatRoomResponseMapper: ChatRoomResponseMapper,
 ) : ChatRoomSearchUseCase {
@@ -31,7 +31,7 @@ class ChatRoomSearchService(
         unreadOnly: Boolean?
     ): List<ChatRoomResponse> {
         // 사용자가 참여한 채팅방 목록을 조회
-        val chatRooms = loadChatRoomPort.findByParticipantId(userId)
+        val chatRooms = chatRoomQueryPort.findByParticipantId(userId)
 
         // 필터링된 채팅방 목록
         val filteredRooms = chatRoomDomainService.filterChatRooms(chatRooms, query, type, unreadOnly)

--- a/src/main/kotlin/com/stark/shoot/application/service/chatroom/CreateChatRoomService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/chatroom/CreateChatRoomService.kt
@@ -2,8 +2,8 @@ package com.stark.shoot.application.service.chatroom
 
 import com.stark.shoot.adapter.`in`.web.dto.chatroom.ChatRoomResponse
 import com.stark.shoot.application.port.`in`.chatroom.CreateChatRoomUseCase
-import com.stark.shoot.application.port.out.chatroom.LoadChatRoomPort
-import com.stark.shoot.application.port.out.chatroom.SaveChatRoomPort
+import com.stark.shoot.application.port.out.chatroom.ChatRoomCommandPort
+import com.stark.shoot.application.port.out.chatroom.ChatRoomQueryPort
 import com.stark.shoot.application.port.out.event.EventPublisher
 import com.stark.shoot.application.port.out.user.FindUserPort
 import com.stark.shoot.domain.chatroom.ChatRoom
@@ -18,8 +18,8 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional
 @UseCase
 class CreateChatRoomService(
-    private val loadChatRoomPort: LoadChatRoomPort,
-    private val saveChatRoomPort: SaveChatRoomPort,
+    private val chatRoomQueryPort: ChatRoomQueryPort,
+    private val chatRoomCommandPort: ChatRoomCommandPort,
     private val findUserPort: FindUserPort,
     private val eventPublisher: EventPublisher,
     private val chatRoomEventService: ChatRoomEventService,
@@ -44,7 +44,7 @@ class CreateChatRoomService(
             ?: throw ResourceNotFoundException("사용자를 찾을 수 없습니다: ${friendId.value}")
 
         // 2. 이미 존재하는 1:1 채팅방이 있는지 확인 (도메인 객체의 정적 메서드 사용)
-        val existingRooms = loadChatRoomPort.findByParticipantId(userId)
+        val existingRooms = chatRoomQueryPort.findByParticipantId(userId)
         val existingRoom = chatRoomDomainService.findDirectChatBetween(existingRooms, userId, friendId)
 
         // 이미 존재하는 채팅방이 있으면 반환
@@ -82,7 +82,7 @@ class CreateChatRoomService(
         )
 
         // 채팅방 저장
-        val savedRoom = saveChatRoomPort.save(newChatRoom)
+        val savedRoom = chatRoomCommandPort.save(newChatRoom)
         return savedRoom
     }
 

--- a/src/main/kotlin/com/stark/shoot/application/service/chatroom/ManageChatRoomService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/chatroom/ManageChatRoomService.kt
@@ -1,9 +1,8 @@
 package com.stark.shoot.application.service.chatroom
 
 import com.stark.shoot.application.port.`in`.chatroom.ManageChatRoomUseCase
-import com.stark.shoot.application.port.out.chatroom.DeleteChatRoomPort
-import com.stark.shoot.application.port.out.chatroom.LoadChatRoomPort
-import com.stark.shoot.application.port.out.chatroom.SaveChatRoomPort
+import com.stark.shoot.application.port.out.chatroom.ChatRoomCommandPort
+import com.stark.shoot.application.port.out.chatroom.ChatRoomQueryPort
 import com.stark.shoot.application.port.out.user.FindUserPort
 import com.stark.shoot.domain.chatroom.ChatRoom
 import com.stark.shoot.domain.chatroom.service.ChatRoomParticipantDomainService
@@ -18,9 +17,8 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional
 @UseCase
 class ManageChatRoomService(
-    private val loadChatRoomPort: LoadChatRoomPort,
-    private val saveChatRoomPort: SaveChatRoomPort,
-    private val deleteChatRoomPort: DeleteChatRoomPort,
+    private val chatRoomQueryPort: ChatRoomQueryPort,
+    private val chatRoomCommandPort: ChatRoomCommandPort,
     private val findUserPort: FindUserPort,
     private val participantDomainService: ChatRoomParticipantDomainService
 ) : ManageChatRoomUseCase {
@@ -39,14 +37,14 @@ class ManageChatRoomService(
         operation: (ChatRoom) -> Pair<ChatRoom, T>
     ): T {
         // 채팅방 조회
-        val chatRoom = loadChatRoomPort.findById(roomId)
+        val chatRoom = chatRoomQueryPort.findById(roomId)
             ?: throw ResourceNotFoundException(errorMessage)
 
         // 작업 수행
         val (updatedRoom, result) = operation(chatRoom)
 
         // 변경사항 저장
-        saveChatRoomPort.save(updatedRoom)
+        chatRoomCommandPort.save(updatedRoom)
 
         return result
     }
@@ -96,7 +94,7 @@ class ManageChatRoomService(
 
             // 채팅방이 삭제 대상이면 삭제 처리
             if (result.shouldDeleteRoom) {
-                deleteChatRoomPort.deleteById(roomId)
+                chatRoomCommandPort.deleteById(roomId)
             }
 
             // 결과 반환 (업데이트된 채팅방과 성공 여부)

--- a/src/main/kotlin/com/stark/shoot/application/service/chatroom/SearchChatRoomsService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/chatroom/SearchChatRoomsService.kt
@@ -3,14 +3,14 @@ package com.stark.shoot.application.service.chatroom
 import com.stark.shoot.adapter.`in`.web.dto.chatroom.ChatRoomResponse
 import com.stark.shoot.adapter.`in`.web.mapper.ChatRoomResponseMapper
 import com.stark.shoot.application.port.`in`.chatroom.SearchChatRoomsUseCase
-import com.stark.shoot.application.port.out.chatroom.LoadChatRoomPort
+import com.stark.shoot.application.port.out.chatroom.ChatRoomQueryPort
 import com.stark.shoot.domain.chatroom.service.ChatRoomDomainService
 import com.stark.shoot.domain.user.vo.UserId
 import com.stark.shoot.infrastructure.annotation.UseCase
 
 @UseCase
 class SearchChatRoomsService(
-    private val loadChatRoomPort: LoadChatRoomPort,
+    private val chatRoomQueryPort: ChatRoomQueryPort,
     private val chatRoomDomainService: ChatRoomDomainService,
     private val chatRoomResponseMapper: ChatRoomResponseMapper
 ) : SearchChatRoomsUseCase {
@@ -31,7 +31,7 @@ class SearchChatRoomsService(
         unreadOnly: Boolean?
     ): List<ChatRoomResponse> {
         // 사용자가 참여한 채팅방 목록을 조회
-        val chatRooms = loadChatRoomPort.findByParticipantId(userId)
+        val chatRooms = chatRoomQueryPort.findByParticipantId(userId)
 
         // 필터링된 채팅방 목록을 반환
         val filteredRooms = chatRoomDomainService.filterChatRooms(chatRooms, query, type, unreadOnly)

--- a/src/main/kotlin/com/stark/shoot/application/service/chatroom/UpdateChatRoomFavoriteService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/chatroom/UpdateChatRoomFavoriteService.kt
@@ -2,9 +2,8 @@ package com.stark.shoot.application.service.chatroom
 
 import com.stark.shoot.adapter.`in`.web.dto.chatroom.ChatRoomResponse
 import com.stark.shoot.application.port.`in`.chatroom.UpdateChatRoomFavoriteUseCase
-import com.stark.shoot.application.port.out.chatroom.LoadChatRoomPort
-import com.stark.shoot.application.port.out.chatroom.LoadPinnedRoomsPort
-import com.stark.shoot.application.port.out.chatroom.SaveChatRoomPort
+import com.stark.shoot.application.port.out.chatroom.ChatRoomCommandPort
+import com.stark.shoot.application.port.out.chatroom.ChatRoomQueryPort
 import com.stark.shoot.domain.chatroom.ChatRoom
 import com.stark.shoot.domain.chatroom.vo.ChatRoomId
 import com.stark.shoot.domain.user.vo.UserId
@@ -15,9 +14,8 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional
 @UseCase
 class UpdateChatRoomFavoriteService(
-    private val loadChatRoomPort: LoadChatRoomPort,
-    private val saveChatRoomPort: SaveChatRoomPort,
-    private val loadPinnedRoomsPort: LoadPinnedRoomsPort
+    private val chatRoomQueryPort: ChatRoomQueryPort,
+    private val chatRoomCommandPort: ChatRoomCommandPort
 ) : UpdateChatRoomFavoriteUseCase {
 
     /**
@@ -29,11 +27,11 @@ class UpdateChatRoomFavoriteService(
         isFavorite: Boolean
     ): ChatRoomResponse {
         // 채팅방 조회 (도메인 객체로 반환)
-        val chatRoom: ChatRoom = loadChatRoomPort.findById(roomId)
+        val chatRoom: ChatRoom = chatRoomQueryPort.findById(roomId)
             ?: throw ResourceNotFoundException("채팅방을 찾을 수 없습니다. id=$roomId")
 
         // 현재 사용자가 핀 처리한 채팅방 목록 조회 (즐겨찾기 제한 체크용)
-        val pinnedRooms = loadPinnedRoomsPort.findByUserId(userId)
+        val pinnedRooms = chatRoomQueryPort.findByUserId(userId)
 
         // 도메인 객체에서 즐겨찾기 상태 업데이트 (비즈니스 로직은 도메인 객체 내부에서 처리)
         val updatedChatRoom = chatRoom.updateFavoriteStatus(
@@ -42,7 +40,7 @@ class UpdateChatRoomFavoriteService(
             userPinnedRoomsCount = pinnedRooms.size
         )
 
-        val saved = saveChatRoomPort.save(updatedChatRoom)
+        val saved = chatRoomCommandPort.save(updatedChatRoom)
         return ChatRoomResponse.from(saved, userId.value)
     }
 }

--- a/src/main/kotlin/com/stark/shoot/application/service/message/DeleteMessageService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/message/DeleteMessageService.kt
@@ -1,16 +1,16 @@
 package com.stark.shoot.application.service.message
 
 import com.stark.shoot.application.port.`in`.message.DeleteMessageUseCase
-import com.stark.shoot.application.port.out.message.LoadMessagePort
-import com.stark.shoot.application.port.out.message.SaveMessagePort
+import com.stark.shoot.application.port.out.message.MessageCommandPort
+import com.stark.shoot.application.port.out.message.MessageQueryPort
 import com.stark.shoot.domain.chat.message.ChatMessage
 import com.stark.shoot.domain.chat.message.vo.MessageId
 import com.stark.shoot.infrastructure.annotation.UseCase
 
 @UseCase
 class DeleteMessageService(
-    private val loadMessagePort: LoadMessagePort,
-    private val saveMessagePort: SaveMessagePort
+    private val messageQueryPort: MessageQueryPort,
+    private val messageCommandPort: MessageCommandPort
 ) : DeleteMessageUseCase {
 
     /**
@@ -19,14 +19,14 @@ class DeleteMessageService(
      */
     override fun deleteMessage(messageId: MessageId): ChatMessage {
         // 메시지 로드
-        val existingMessage = loadMessagePort.findById(messageId)
+        val existingMessage = messageQueryPort.findById(messageId)
             ?: throw IllegalArgumentException("메시지를 찾을 수 없습니다. messageId=$messageId")
 
         // 도메인 객체의 메서드를 사용하여 메시지 삭제 상태로 변경
         val deletedMessage = existingMessage.markAsDeleted()
 
         // 업데이트된 메시지 저장 후 반환
-        return saveMessagePort.save(deletedMessage)
+        return messageCommandPort.save(deletedMessage)
     }
 
 }

--- a/src/main/kotlin/com/stark/shoot/application/service/message/reaction/ToggleMessageReactionService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/message/reaction/ToggleMessageReactionService.kt
@@ -3,8 +3,8 @@ package com.stark.shoot.application.service.message.reaction
 import com.stark.shoot.adapter.`in`.web.dto.message.reaction.ReactionResponse
 import com.stark.shoot.application.port.`in`.message.reaction.ToggleMessageReactionUseCase
 import com.stark.shoot.application.port.out.event.EventPublisher
-import com.stark.shoot.application.port.out.message.LoadMessagePort
-import com.stark.shoot.application.port.out.message.SaveMessagePort
+import com.stark.shoot.application.port.out.message.MessageCommandPort
+import com.stark.shoot.application.port.out.message.MessageQueryPort
 import com.stark.shoot.domain.chat.message.service.MessageReactionService
 import com.stark.shoot.domain.chat.message.vo.MessageId
 import com.stark.shoot.domain.chat.message.vo.ReactionToggleResult
@@ -18,8 +18,8 @@ import org.springframework.messaging.simp.SimpMessagingTemplate
 
 @UseCase
 class ToggleMessageReactionService(
-    private val loadMessagePort: LoadMessagePort,
-    private val saveMessagePort: SaveMessagePort,
+    private val messageQueryPort: MessageQueryPort,
+    private val messageCommandPort: MessageCommandPort,
     private val messagingTemplate: SimpMessagingTemplate,
     private val eventPublisher: EventPublisher,
     private val messageReactionService: MessageReactionService
@@ -44,7 +44,7 @@ class ToggleMessageReactionService(
             ?: throw InvalidInputException("지원하지 않는 리액션 타입입니다: $reactionType")
 
         // 메시지 조회 (없으면 예외 발생)
-        val message = loadMessagePort.findById(messageId)
+        val message = messageQueryPort.findById(messageId)
             ?: throw ResourceNotFoundException("메시지를 찾을 수 없습니다: messageId=$messageId")
 
         // 도메인 객체에 토글 로직 위임
@@ -54,7 +54,7 @@ class ToggleMessageReactionService(
         handleNotificationsAndEvents(messageId, result)
 
         // 저장 및 반환
-        val savedMessage = saveMessagePort.save(result.message)
+        val savedMessage = messageCommandPort.save(result.message)
 
         // 응답 생성
         // savedMessage.reactions는 ChatMessage의 getter를 통해 messageReactions.reactions에 접근

--- a/src/main/kotlin/com/stark/shoot/application/service/notification/NotificationQueryService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/notification/NotificationQueryService.kt
@@ -1,7 +1,7 @@
 package com.stark.shoot.application.service.notification
 
 import com.stark.shoot.application.port.`in`.notification.NotificationQueryUseCase
-import com.stark.shoot.application.port.out.notification.LoadNotificationPort
+import com.stark.shoot.application.port.out.notification.NotificationQueryPort
 import com.stark.shoot.domain.notification.Notification
 import com.stark.shoot.domain.notification.type.NotificationType
 import com.stark.shoot.domain.notification.type.SourceType
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Service
 
 @Service
 class NotificationQueryService(
-    private val loadNotificationPort: LoadNotificationPort
+    private val notificationQueryPort: NotificationQueryPort
 ) : NotificationQueryUseCase {
 
     /**
@@ -27,7 +27,7 @@ class NotificationQueryService(
         limit: Int,
         offset: Int
     ): List<Notification> {
-        return loadNotificationPort.loadNotificationsForUser(userId, limit, offset)
+        return notificationQueryPort.loadNotificationsForUser(userId, limit, offset)
     }
 
     /**
@@ -44,7 +44,7 @@ class NotificationQueryService(
         limit: Int,
         offset: Int
     ): List<Notification> {
-        return loadNotificationPort.loadUnreadNotificationsForUser(userId, limit, offset)
+        return notificationQueryPort.loadUnreadNotificationsForUser(userId, limit, offset)
     }
 
     /**
@@ -63,7 +63,7 @@ class NotificationQueryService(
         limit: Int,
         offset: Int
     ): List<Notification> {
-        return loadNotificationPort.loadNotificationsByType(userId, type, limit, offset)
+        return notificationQueryPort.loadNotificationsByType(userId, type, limit, offset)
     }
 
     /**
@@ -84,7 +84,7 @@ class NotificationQueryService(
         limit: Int,
         offset: Int
     ): List<Notification> {
-        return loadNotificationPort.loadNotificationsBySource(userId, sourceType, sourceId, limit, offset)
+        return notificationQueryPort.loadNotificationsBySource(userId, sourceType, sourceId, limit, offset)
     }
 
     /**
@@ -94,7 +94,7 @@ class NotificationQueryService(
      * @return 읽지 않은 알림 개수
      */
     override fun getUnreadNotificationCount(userId: UserId): Int {
-        return loadNotificationPort.countUnreadNotifications(userId)
+        return notificationQueryPort.countUnreadNotifications(userId)
     }
 
 }

--- a/src/main/kotlin/com/stark/shoot/infrastructure/config/socket/WebSocketConfig.kt
+++ b/src/main/kotlin/com/stark/shoot/infrastructure/config/socket/WebSocketConfig.kt
@@ -1,7 +1,7 @@
 package com.stark.shoot.infrastructure.config.socket
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.stark.shoot.application.port.out.chatroom.LoadChatRoomPort
+import com.stark.shoot.application.port.out.chatroom.ChatRoomQueryPort
 import com.stark.shoot.application.port.out.user.FindUserPort
 import com.stark.shoot.infrastructure.config.security.JwtAuthenticationService
 import com.stark.shoot.infrastructure.config.socket.interceptor.AuthHandshakeInterceptor
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit
 @Configuration
 @EnableWebSocketMessageBroker // STOMP 메시징을 활성화 이로 인해 서버는 STOMP 프로토콜 형식의 메시지를 기대합니다.
 class WebSocketConfig(
-    private val loadChatRoomPort: LoadChatRoomPort,
+    private val chatRoomQueryPort: ChatRoomQueryPort,
     private val findUserPort: FindUserPort,
     private val jwtAuthenticationService: JwtAuthenticationService,
     private val objectMapper: ObjectMapper,
@@ -87,7 +87,7 @@ class WebSocketConfig(
      */
     override fun configureClientInboundChannel(registration: ChannelRegistration) {
         registration.interceptors(
-            StompChannelInterceptor(loadChatRoomPort, findUserPort, objectMapper),
+            StompChannelInterceptor(chatRoomQueryPort, findUserPort, objectMapper),
             rateLimitInterceptor
         )
 

--- a/src/main/kotlin/com/stark/shoot/infrastructure/config/socket/interceptor/StompChannelInterceptor.kt
+++ b/src/main/kotlin/com/stark/shoot/infrastructure/config/socket/interceptor/StompChannelInterceptor.kt
@@ -2,7 +2,7 @@ package com.stark.shoot.infrastructure.config.socket.interceptor
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.stark.shoot.adapter.`in`.web.dto.message.ChatMessageRequest
-import com.stark.shoot.application.port.out.chatroom.LoadChatRoomPort
+import com.stark.shoot.application.port.out.chatroom.ChatRoomQueryPort
 import com.stark.shoot.application.port.out.user.FindUserPort
 import com.stark.shoot.domain.chatroom.vo.ChatRoomId
 import com.stark.shoot.domain.user.vo.UserId
@@ -29,7 +29,7 @@ import kotlin.concurrent.write
  * STOMP 명령어(SEND, SUBSCRIBE 등)를 확인하고 권한 로직을 수행할 수 있습니다.
  */
 class StompChannelInterceptor(
-    private val loadChatRoomPort: LoadChatRoomPort,
+    private val chatRoomQueryPort: ChatRoomQueryPort,
     private val findUserPort: FindUserPort,
     private val objectMapper: ObjectMapper
 ) : ChannelInterceptor {
@@ -148,7 +148,7 @@ class StompChannelInterceptor(
                             // 캐시에 없으면 채팅방 존재 여부 확인 후 캐싱
                             try {
                                 // roomId는 이미 Long 타입이므로 직접 사용
-                                val room = loadChatRoomPort.findById(ChatRoomId.from(roomId))
+                                val room = chatRoomQueryPort.findById(ChatRoomId.from(roomId))
                                 if (room != null) {
                                     roomCache.put(roomIdStr, true, 5) // 5분 캐싱
                                 } else {


### PR DESCRIPTION
## Summary
- refactor `ChatRoomPersistenceAdapter` to directly use repositories
- revise `NotificationMongoAdapter` to handle persistence, sending, and events without delegating to ports
- update `MessageMongoAdapter` with direct MongoDB and Redis interactions

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685822d9e9a48320875b8d0ddaf7cf2c