### PR TITLE
Add DisplayName annotations to notification tests

### DIFF
--- a/src/test/kotlin/com/stark/shoot/adapter/persistence/chatroom/SaveChatRoomPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/stark/shoot/adapter/persistence/chatroom/SaveChatRoomPersistenceAdapterTest.kt
@@ -13,10 +13,12 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.junit.jupiter.api.DisplayName
 import org.springframework.context.annotation.Import
 
 @DataJpaTest
 @Import(ChatRoomCommandPersistenceAdapter::class, ChatRoomMapper::class)
+@DisplayName("채팅방 저장 어댑터 테스트")
 class SaveChatRoomPersistenceAdapterTest @Autowired constructor(
     private val chatRoomRepository: ChatRoomRepository,
     private val chatRoomUserRepository: ChatRoomUserRepository,

--- a/src/test/kotlin/com/stark/shoot/domain/notification/NotificationSettingsTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/notification/NotificationSettingsTest.kt
@@ -2,19 +2,23 @@ package com.stark.shoot.domain.notification
 
 import com.stark.shoot.domain.notification.type.NotificationType
 import com.stark.shoot.domain.user.vo.UserId
+import org.junit.jupiter.api.DisplayName
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
+@DisplayName("알림 설정 도메인 테스트")
 class NotificationSettingsTest {
 
     @Test
+    @DisplayName("[happy] 기본 설정이 모두 활성화되어 있다")
     fun defaultAllEnabled() {
         val settings = NotificationSettings(userId = UserId.from(1L))
         assertTrue(settings.isEnabled(NotificationType.NEW_MESSAGE))
     }
 
     @Test
+    @DisplayName("[happy] 선호도 설정을 변경할 수 있다")
     fun updatePreference() {
         val settings = NotificationSettings(userId = UserId.from(1L))
             .updatePreference(NotificationType.NEW_MESSAGE, false)
@@ -22,6 +26,7 @@ class NotificationSettingsTest {
     }
 
     @Test
+    @DisplayName("[happy] 일괄 설정을 적용할 수 있다")
     fun updateAll() {
         val settings = NotificationSettings(userId = UserId.from(1L))
             .updateAll(mapOf(NotificationType.MENTION to false))

--- a/src/test/kotlin/com/stark/shoot/domain/notification/NotificationTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/notification/NotificationTest.kt
@@ -4,13 +4,16 @@ import com.stark.shoot.domain.notification.type.NotificationType
 import com.stark.shoot.domain.notification.type.SourceType
 import com.stark.shoot.domain.user.vo.UserId
 import com.stark.shoot.infrastructure.exception.NotificationException
+import org.junit.jupiter.api.DisplayName
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
+@DisplayName("알림 엔티티 테스트")
 class NotificationTest {
     
     @Test
+    @DisplayName("[happy] 알림을 읽고 삭제 상태로 만들 수 있다")
     fun markReadAndDelete() {
         val n = Notification.create(
             userId = UserId.from(1L),
@@ -27,6 +30,7 @@ class NotificationTest {
     }
 
     @Test
+    @DisplayName("[bad] 다른 사용자의 알림이면 예외가 발생한다")
     fun validateOwnershipThrows() {
         val n = Notification.create(
             userId = UserId.from(1L),

--- a/src/test/kotlin/com/stark/shoot/domain/notification/service/NotificationDomainServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/domain/notification/service/NotificationDomainServiceTest.kt
@@ -5,13 +5,16 @@ import com.stark.shoot.domain.notification.Notification
 import com.stark.shoot.domain.notification.type.NotificationType
 import com.stark.shoot.domain.notification.type.SourceType
 import com.stark.shoot.domain.user.vo.UserId
+import org.junit.jupiter.api.DisplayName
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
+@DisplayName("알림 도메인 서비스 테스트")
 class NotificationDomainServiceTest {
     private val service = NotificationDomainService()
 
     @Test
+    @DisplayName("[happy] 읽음 처리 후 삭제 상태로 변경할 수 있다")
     fun markAsReadAndDeleted() {
         val n = Notification.create(UserId.from(1L), "t", "m", NotificationType.NEW_MESSAGE, "s", SourceType.CHAT)
         val read = service.markNotificationsAsRead(listOf(n))
@@ -20,6 +23,7 @@ class NotificationDomainServiceTest {
     }
 
     @Test
+    @DisplayName("[happy] 읽지 않은 알림만 필터링한다")
     fun filterUnread() {
         val n1 = Notification.create(UserId.from(1L), "t", "m", NotificationType.NEW_MESSAGE, "s", SourceType.CHAT)
         val n2 = n1.markAsRead()
@@ -28,6 +32,7 @@ class NotificationDomainServiceTest {
     }
 
     @Test
+    @DisplayName("[happy] 이벤트로부터 알림을 생성할 수 있다")
     fun createNotificationsFromEvent() {
         val event = object : NotificationEvent(
             type = NotificationType.NEW_MESSAGE,


### PR DESCRIPTION
## Summary
- add missing `DisplayName` annotations on several notification-related tests
- categorize test cases with `[happy]` and `[bad]` prefixes

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685bf52f59008320acf8e197ea6faa66