### PR TITLE
Add tests for redis adapters

### DIFF
--- a/src/test/kotlin/com/stark/shoot/adapter/in/redis/RedisStreamManagerTest.kt
+++ b/src/test/kotlin/com/stark/shoot/adapter/in/redis/RedisStreamManagerTest.kt
@@ -1,0 +1,49 @@
+package com.stark.shoot.adapter.`in`.redis
+
+import com.stark.shoot.adapter.`in`.redis.util.RedisStreamManager
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.*
+import org.springframework.data.redis.connection.stream.RecordId
+import org.springframework.data.redis.connection.stream.StreamOperations
+import org.springframework.data.redis.core.StringRedisTemplate
+
+@DisplayName("RedisStreamManager 테스트")
+class RedisStreamManagerTest {
+
+    private val redisTemplate = mock(StringRedisTemplate::class.java)
+    private val streamOps = mock(StreamOperations::class.java) as StreamOperations<String, Any, *>
+    private val manager = RedisStreamManager(redisTemplate)
+
+    @Test
+    @DisplayName("[happy] 메시지 ACK에 성공하면 true를 반환한다")
+    fun `메시지 ACK에 성공하면 true를 반환한다`() {
+        val recordId = RecordId.of("0-0")
+        `when`(redisTemplate.opsForStream<String, Any>()).thenReturn(streamOps)
+        `when`(streamOps.acknowledge("cg", "key", recordId)).thenReturn(1L)
+
+        val result = manager.acknowledgeMessage("key", "cg", recordId)
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    @DisplayName("[bad] 메시지 ACK 중 오류가 발생하면 false를 반환한다")
+    fun `메시지 ACK 중 오류가 발생하면 false를 반환한다`() {
+        val recordId = RecordId.of("0-0")
+        `when`(redisTemplate.opsForStream<String, Any>()).thenReturn(streamOps)
+        `when`(streamOps.acknowledge("cg", "key", recordId)).thenThrow(RuntimeException("fail"))
+
+        val result = manager.acknowledgeMessage("key", "cg", recordId)
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    @DisplayName("[happy] consumerId가 생성된다")
+    fun `consumerId가 생성된다`() {
+        val id = manager.getConsumerId()
+        assertThat(id).isNotBlank()
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/adapter/in/redis/util/RedisMessageProcessorTest.kt
+++ b/src/test/kotlin/com/stark/shoot/adapter/in/redis/util/RedisMessageProcessorTest.kt
@@ -1,0 +1,78 @@
+package com.stark.shoot.adapter.`in`.redis.util
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.stark.shoot.adapter.`in`.web.dto.message.ChatMessageRequest
+import com.stark.shoot.adapter.`in`.web.dto.message.ChatMessageMetadataRequest
+import com.stark.shoot.adapter.`in`.web.dto.message.MessageContentRequest
+import com.stark.shoot.adapter.`in`.web.socket.WebSocketMessageBroker
+import com.stark.shoot.domain.chat.message.type.MessageType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.*
+
+@DisplayName("RedisMessageProcessor 테스트")
+class RedisMessageProcessorTest {
+
+    private val objectMapper = mock(ObjectMapper::class.java)
+    private val webSocketMessageBroker = mock(WebSocketMessageBroker::class.java)
+    private val processor = RedisMessageProcessor(objectMapper, webSocketMessageBroker)
+
+    @Test
+    @DisplayName("[happy] 스트림 키에서 채팅방 ID를 추출할 수 있다")
+    fun `스트림 키에서 채팅방 ID를 추출할 수 있다`() {
+        val roomId = processor.extractRoomIdFromStreamKey("stream:chat:room:123")
+        assertThat(roomId).isEqualTo("123")
+    }
+
+    @Test
+    @DisplayName("[happy] 잘못된 스트림 키는 null을 반환한다")
+    fun `잘못된 스트림 키는 null을 반환한다`() {
+        val roomId = processor.extractRoomIdFromStreamKey("invalid")
+        assertThat(roomId).isNull()
+    }
+
+    @Test
+    @DisplayName("[happy] 채널에서 채팅방 ID를 추출할 수 있다")
+    fun `채널에서 채팅방 ID를 추출할 수 있다`() {
+        val roomId = processor.extractRoomIdFromChannel("chat:room:456")
+        assertThat(roomId).isEqualTo("456")
+    }
+
+    @Test
+    @DisplayName("[happy] 잘못된 채널은 null을 반환한다")
+    fun `잘못된 채널은 null을 반환한다`() {
+        val roomId = processor.extractRoomIdFromChannel("wrong")
+        assertThat(roomId).isNull()
+    }
+
+    @Test
+    @DisplayName("[happy] 메시지를 성공적으로 처리할 수 있다")
+    fun `메시지를 성공적으로 처리할 수 있다`() {
+        val messageJson = "{}"
+        val request = ChatMessageRequest(
+            roomId = 1L,
+            senderId = 2L,
+            content = MessageContentRequest("t", MessageType.TEXT),
+            metadata = ChatMessageMetadataRequest()
+        )
+        `when`(objectMapper.readValue(messageJson, ChatMessageRequest::class.java)).thenReturn(request)
+
+        val result = processor.processMessage("1", messageJson)
+
+        assertThat(result).isTrue()
+        verify(webSocketMessageBroker).sendMessage("/topic/messages/1", request)
+    }
+
+    @Test
+    @DisplayName("[bad] 메시지 처리 중 오류가 발생하면 false를 반환한다")
+    fun `메시지 처리 중 오류가 발생하면 false를 반환한다`() {
+        val messageJson = "{}"
+        `when`(objectMapper.readValue(messageJson, ChatMessageRequest::class.java)).thenThrow(RuntimeException("fail"))
+
+        val result = processor.processMessage("1", messageJson)
+
+        assertThat(result).isFalse()
+        verifyNoInteractions(webSocketMessageBroker)
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/adapter/out/redis/message/PublishMessageRedisAdapterTest.kt
+++ b/src/test/kotlin/com/stark/shoot/adapter/out/redis/message/PublishMessageRedisAdapterTest.kt
@@ -1,0 +1,43 @@
+package com.stark.shoot.adapter.out.redis.message
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.stark.shoot.adapter.`in`.web.dto.message.ChatMessageMetadataRequest
+import com.stark.shoot.adapter.`in`.web.dto.message.ChatMessageRequest
+import com.stark.shoot.adapter.`in`.web.dto.message.MessageContentRequest
+import com.stark.shoot.domain.chat.message.type.MessageType
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.*
+import org.springframework.data.redis.connection.stream.RecordId
+import org.springframework.data.redis.connection.stream.StreamOperations
+import org.springframework.data.redis.connection.stream.StreamRecords
+import org.springframework.data.redis.core.StringRedisTemplate
+
+@DisplayName("PublishMessageRedisAdapter 테스트")
+class PublishMessageRedisAdapterTest {
+
+    private val redisTemplate = mock(StringRedisTemplate::class.java)
+    private val streamOps = mock(StreamOperations::class.java) as StreamOperations<String, String, *>
+    private val objectMapper = mock(ObjectMapper::class.java)
+    private val adapter = PublishMessageRedisAdapter(redisTemplate, objectMapper)
+
+    @Test
+    @DisplayName("[happy] 메시지를 Redis Stream에 발행할 수 있다")
+    fun `메시지를 Redis Stream에 발행할 수 있다`() {
+        val request = ChatMessageRequest(
+            roomId = 1L,
+            senderId = 2L,
+            content = MessageContentRequest("text", MessageType.TEXT),
+            metadata = ChatMessageMetadataRequest()
+        )
+        val json = "{}"
+        `when`(objectMapper.writeValueAsString(request)).thenReturn(json)
+        `when`(redisTemplate.opsForStream<String, String>()).thenReturn(streamOps)
+        `when`(streamOps.add(any())).thenReturn(RecordId.of("0-0"))
+
+        adapter.publish(request)
+
+        verify(streamOps).add(any())
+        verify(objectMapper).writeValueAsString(request)
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/adapter/out/redis/notification/SendNotificationRedisAdapterTest.kt
+++ b/src/test/kotlin/com/stark/shoot/adapter/out/redis/notification/SendNotificationRedisAdapterTest.kt
@@ -1,0 +1,84 @@
+package com.stark.shoot.adapter.out.redis.notification
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.stark.shoot.domain.notification.Notification
+import com.stark.shoot.domain.notification.type.NotificationType
+import com.stark.shoot.domain.notification.type.SourceType
+import com.stark.shoot.domain.notification.vo.NotificationId
+import com.stark.shoot.domain.notification.vo.NotificationMessage
+import com.stark.shoot.domain.notification.vo.NotificationTitle
+import com.stark.shoot.domain.user.vo.UserId
+import com.stark.shoot.infrastructure.exception.web.RedisOperationException
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.*
+import org.springframework.data.redis.core.StringRedisTemplate
+import java.time.Instant
+
+@DisplayName("SendNotificationRedisAdapter 테스트")
+class SendNotificationRedisAdapterTest {
+
+    private val redisTemplate = mock(StringRedisTemplate::class.java)
+    private val objectMapper = mock(ObjectMapper::class.java)
+    private val adapter = SendNotificationRedisAdapter(redisTemplate, objectMapper)
+
+    private fun createNotification(userId: Long = 1L): Notification {
+        return Notification(
+            id = NotificationId.from("id"),
+            userId = UserId.from(userId),
+            title = NotificationTitle.from("t"),
+            message = NotificationMessage.from("m"),
+            type = NotificationType.NEW_MESSAGE,
+            sourceId = "s",
+            sourceType = SourceType.CHAT_ROOM,
+            createdAt = Instant.now()
+        )
+    }
+
+    @Test
+    @DisplayName("[happy] 단일 알림을 Redis로 전송할 수 있다")
+    fun `단일 알림을 Redis로 전송할 수 있다`() {
+        val notification = createNotification()
+        val json = "{}"
+        `when`(objectMapper.writeValueAsString(notification)).thenReturn(json)
+        `when`(redisTemplate.convertAndSend("notification:user:1", json)).thenReturn(1L)
+
+        adapter.sendNotification(notification)
+
+        verify(redisTemplate).convertAndSend("notification:user:1", json)
+        verify(objectMapper).writeValueAsString(notification)
+    }
+
+    @Test
+    @DisplayName("[bad] 알림 전송 실패 시 예외가 발생한다")
+    fun `알림 전송 실패 시 예외가 발생한다`() {
+        val notification = createNotification()
+        `when`(objectMapper.writeValueAsString(notification)).thenThrow(RuntimeException("fail"))
+
+        assertThatThrownBy { adapter.sendNotification(notification) }
+            .isInstanceOf(RedisOperationException::class.java)
+    }
+
+    @Test
+    @DisplayName("[happy] 여러 알림을 Redis로 전송할 수 있다")
+    fun `여러 알림을 Redis로 전송할 수 있다`() {
+        val n1 = createNotification(1L)
+        val n2 = createNotification(2L)
+        val list = listOf(n1, n2)
+        `when`(objectMapper.writeValueAsString(n1)).thenReturn("n1")
+        `when`(objectMapper.writeValueAsString(n2)).thenReturn("n2")
+
+        adapter.sendNotifications(list)
+
+        verify(redisTemplate).convertAndSend("notification:user:1", "n1")
+        verify(redisTemplate).convertAndSend("notification:user:2", "n2")
+    }
+
+    @Test
+    @DisplayName("[happy] 빈 알림 목록은 아무 작업도 하지 않는다")
+    fun `빈 알림 목록은 아무 작업도 하지 않는다`() {
+        adapter.sendNotifications(emptyList())
+        verifyNoInteractions(redisTemplate, objectMapper)
+    }
+}


### PR DESCRIPTION
## Summary
- add missing unit tests for redis message processor and redis stream manager
- cover redis implementations for message and notification adapters

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685c03115ff48320a3b9d52e64292f2e