### PR TITLE
Fix send sync messages usecase to use command object

### DIFF
--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/socket/message/GetMessagePaginationStompHandler.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/socket/message/GetMessagePaginationStompHandler.kt
@@ -4,6 +4,7 @@ import com.stark.shoot.adapter.`in`.web.socket.dto.SyncRequestDto
 import com.stark.shoot.application.port.`in`.message.GetPaginationMessageUseCase
 import com.stark.shoot.application.port.`in`.message.SendSyncMessagesToUserUseCase
 import com.stark.shoot.application.port.`in`.message.command.GetPaginationMessageCommand
+import com.stark.shoot.application.port.`in`.message.command.SendSyncMessagesToUserCommand
 import com.stark.shoot.infrastructure.config.async.ApplicationCoroutineScope
 import com.stark.shoot.infrastructure.exception.web.ErrorResponse
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -44,7 +45,8 @@ class GetMessagePaginationStompHandler(
         appCoroutineScope.launch {
             try {
                 val messages = messagesFlow.toList() // Flow를 List로 변환
-                sendSyncMessagesToUserUseCase.sendMessagesToUser(request, messages) // 메시지 전송
+                val sendCommand = SendSyncMessagesToUserCommand.of(request, messages)
+                sendSyncMessagesToUserUseCase.sendMessagesToUser(sendCommand) // 메시지 전송
             } catch (e: Exception) {
                 logger.error { "동기화 중 에러 발생" + e.message }
                 messagingTemplate.convertAndSendToUser(

--- a/src/main/kotlin/com/stark/shoot/application/port/in/message/SendSyncMessagesToUserUseCase.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/message/SendSyncMessagesToUserUseCase.kt
@@ -1,8 +1,7 @@
 package com.stark.shoot.application.port.`in`.message
 
-import com.stark.shoot.adapter.`in`.web.socket.dto.MessageSyncInfoDto
-import com.stark.shoot.adapter.`in`.web.socket.dto.SyncRequestDto
+import com.stark.shoot.application.port.`in`.message.command.SendSyncMessagesToUserCommand
 
 interface SendSyncMessagesToUserUseCase {
-    fun sendMessagesToUser(request: SyncRequestDto, messages: List<MessageSyncInfoDto>)
+    fun sendMessagesToUser(command: SendSyncMessagesToUserCommand)
 }

--- a/src/main/kotlin/com/stark/shoot/application/port/in/message/command/SendSyncMessagesToUserCommand.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/message/command/SendSyncMessagesToUserCommand.kt
@@ -1,0 +1,21 @@
+package com.stark.shoot.application.port.`in`.message.command
+
+import com.stark.shoot.adapter.`in`.web.socket.dto.MessageSyncInfoDto
+import com.stark.shoot.adapter.`in`.web.socket.dto.SyncRequestDto
+
+/**
+ * Command for sending synchronized messages to a user
+ */
+data class SendSyncMessagesToUserCommand(
+    val request: SyncRequestDto,
+    val messages: List<MessageSyncInfoDto>,
+) {
+    companion object {
+        fun of(request: SyncRequestDto, messages: List<MessageSyncInfoDto>): SendSyncMessagesToUserCommand {
+            return SendSyncMessagesToUserCommand(
+                request = request,
+                messages = messages,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/application/service/message/PaginationMessageSyncService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/message/PaginationMessageSyncService.kt
@@ -1,5 +1,6 @@
 package com.stark.shoot.application.service.message
 
+import com.stark.shoot.application.port.`in`.message.command.SendSyncMessagesToUserCommand
 import com.stark.shoot.adapter.`in`.web.socket.dto.MessageSyncInfoDto
 import com.stark.shoot.adapter.`in`.web.socket.dto.SyncRequestDto
 import com.stark.shoot.adapter.`in`.web.socket.dto.SyncResponseDto
@@ -110,13 +111,13 @@ class PaginationMessageSyncService(
     /**
      * WebSocket을 통해 메시지를 사용자에게 전송
      *
-     * @param request 동기화 요청 정보
-     * @param messages 전송할 메시지 목록
+     * @param command 동기화 요청 및 전송할 메시지 목록을 담은 커맨드
      */
     override fun sendMessagesToUser(
-        request: SyncRequestDto,
-        messages: List<MessageSyncInfoDto>
+        command: SendSyncMessagesToUserCommand
     ) {
+        val request = command.request
+        val messages = command.messages
         val response = SyncResponseDto(
             roomId = request.roomId,
             userId = request.userId,

--- a/src/test/kotlin/com/stark/shoot/application/service/message/PaginationMessageSyncServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/application/service/message/PaginationMessageSyncServiceTest.kt
@@ -6,6 +6,7 @@ import com.stark.shoot.adapter.`in`.web.socket.dto.SyncRequestDto
 import com.stark.shoot.adapter.`in`.web.socket.dto.SyncResponseDto
 import com.stark.shoot.adapter.`in`.web.socket.mapper.MessageSyncMapper
 import com.stark.shoot.application.port.`in`.message.command.GetPaginationMessageCommand
+import com.stark.shoot.application.port.`in`.message.command.SendSyncMessagesToUserCommand
 import com.stark.shoot.application.port.out.message.MessageQueryPort
 import com.stark.shoot.application.port.out.message.thread.ThreadQueryPort
 import com.stark.shoot.domain.chat.message.ChatMessage
@@ -226,7 +227,8 @@ class PaginationMessageSyncServiceTest {
             )
 
             // when
-            paginationMessageSyncService.sendMessagesToUser(request, messages)
+            val sendCommand = SendSyncMessagesToUserCommand.of(request, messages)
+            paginationMessageSyncService.sendMessagesToUser(sendCommand)
 
             // then
             verify(messagingTemplate).convertAndSendToUser(


### PR DESCRIPTION
## Summary
- refactor SendSyncMessagesToUserUseCase to accept `SendSyncMessagesToUserCommand`
- implement new command class
- adjust service, handler, and tests to use the command

## Testing
- `./gradlew test --no-daemon` *(fails: unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685fbf00f23c83208af3c961b2835f3f