### PR TITLE
Fix duplicate key error on cancelling friend request

### DIFF
--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/user/friend/FriendRequestAdapter.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/postgres/adapter/user/friend/FriendRequestAdapter.kt
@@ -111,9 +111,17 @@ class FriendRequestAdapter(
         val requests = friendRequestRepository
             .findAllBySenderIdAndReceiverId(senderId.value, receiverId.value)
 
-        for (entity in requests) {
+        // 동일한 상태로 이미 존재하는 요청은 제거하여 중복을 방지한다
+        val duplicated = requests.filter { it.status == status }
+        if (duplicated.isNotEmpty()) {
+            friendRequestRepository.deleteAll(duplicated)
+        }
+
+        // 남은 요청의 상태를 업데이트한다
+        val now = Instant.now()
+        for (entity in requests.filter { it.status != status }) {
             entity.status = status
-            entity.respondedAt = Instant.now()
+            entity.respondedAt = now
             friendRequestRepository.save(entity)
         }
     }


### PR DESCRIPTION
## Summary
- avoid unique constraint violation by removing duplicate records before status update
- update persistence adapter logic for cancelling and rejecting friend requests

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6863d94d6de48320adba0fd04e493805