### PR TITLE
Fix initial sync query

### DIFF
--- a/src/test/kotlin/com/stark/shoot/application/service/message/PaginationMessageSyncServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/application/service/message/PaginationMessageSyncServiceTest.kt
@@ -84,9 +84,8 @@ class PaginationMessageSyncServiceTest {
                 )
             }
 
-            // For initial load, the service uses a default message ID when lastMessageId is null
-            val defaultMessageId = MessageId.from("default-message-id")
-            `when`(messageQueryPort.findByRoomIdAndAfterIdFlow(ChatRoomId.from(roomId), defaultMessageId, 30)).thenReturn(messageFlow)
+            // For initial load without lastMessageId, the service fetches latest messages
+            `when`(messageQueryPort.findByRoomIdFlow(ChatRoomId.from(roomId), 50)).thenReturn(messageFlow)
 
             // Mock the threadQueryPort for each message
             for (message in messages) {
@@ -108,7 +107,7 @@ class PaginationMessageSyncServiceTest {
             assertThat(result).hasSize(3)
             assertThat(result).containsExactlyElementsOf(syncInfoDtos)
 
-            verify(messageQueryPort).findByRoomIdAndAfterIdFlow(ChatRoomId.from(roomId), defaultMessageId, 30)
+            verify(messageQueryPort).findByRoomIdFlow(ChatRoomId.from(roomId), 50)
             for (message in messages) {
                 message.id?.let { messageId ->
                     verify(threadQueryPort).countByThreadId(messageId)


### PR DESCRIPTION
## Summary
- load the latest messages on initial sync
- update tests for the new behavior

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6863ebc8b8d88320a5e4f829db4b40d3