### PR TITLE
Implement websocket chatroom list and update

### DIFF
--- a/src/main/kotlin/com/stark/shoot/adapter/in/event/chatroom/ChatRoomUpdateEventListener.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/event/chatroom/ChatRoomUpdateEventListener.kt
@@ -1,0 +1,40 @@
+package com.stark.shoot.adapter.`in`.event.chatroom
+
+import com.stark.shoot.adapter.`in`.web.socket.dto.chatroom.ChatRoomUpdateDto
+import com.stark.shoot.domain.event.MessageUnreadCountUpdatedEvent
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.context.event.EventListener
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.stereotype.Component
+
+@Component
+class ChatRoomUpdateEventListener(
+    private val redisTemplate: StringRedisTemplate,
+    private val messagingTemplate: SimpMessagingTemplate
+) {
+    private val logger = KotlinLogging.logger {}
+
+    @EventListener
+    fun handleUnreadCountUpdate(event: MessageUnreadCountUpdatedEvent) {
+        val roomId = event.roomId.value
+        event.unreadCounts.forEach { (userId, count) ->
+            val activeKey = "active:${userId.value}:$roomId"
+            val isActive = redisTemplate.opsForValue().get(activeKey) == "true"
+            if (!isActive) {
+                val update = ChatRoomUpdateDto(
+                    roomId = roomId,
+                    unreadCount = count,
+                    lastMessage = event.lastMessage
+                )
+                messagingTemplate.convertAndSendToUser(
+                    userId.value.toString(),
+                    "/queue/room-update",
+                    update
+                )
+            } else {
+                logger.debug { "User ${userId.value} active in room $roomId, skip update" }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/socket/chatroom/ChatRoomListStompHandler.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/socket/chatroom/ChatRoomListStompHandler.kt
@@ -1,0 +1,31 @@
+package com.stark.shoot.adapter.`in`.web.socket.chatroom
+
+import com.stark.shoot.adapter.`in`.web.socket.dto.chatroom.ChatRoomListRequest
+import com.stark.shoot.application.port.`in`.chatroom.FindChatRoomUseCase
+import com.stark.shoot.application.port.`in`.chatroom.command.GetChatRoomsCommand
+import io.swagger.v3.oas.annotations.Operation
+import org.springframework.messaging.handler.annotation.MessageMapping
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.stereotype.Controller
+
+@Controller
+class ChatRoomListStompHandler(
+    private val findChatRoomUseCase: FindChatRoomUseCase,
+    private val messagingTemplate: SimpMessagingTemplate
+) {
+
+    @Operation(
+        summary = "채팅방 목록 조회 (WebSocket)",
+        description = "사용자가 속한 채팅방 목록을 조회하여 개인 큐로 전달합니다."
+    )
+    @MessageMapping("/rooms")
+    fun handleChatRoomList(request: ChatRoomListRequest) {
+        val command = GetChatRoomsCommand.of(request.userId)
+        val rooms = findChatRoomUseCase.getChatRoomsForUser(command)
+        messagingTemplate.convertAndSendToUser(
+            request.userId.toString(),
+            "/queue/rooms",
+            rooms
+        )
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/socket/dto/chatroom/ChatRoomListRequest.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/socket/dto/chatroom/ChatRoomListRequest.kt
@@ -1,0 +1,8 @@
+package com.stark.shoot.adapter.`in`.web.socket.dto.chatroom
+
+import com.stark.shoot.infrastructure.annotation.ApplicationDto
+
+@ApplicationDto
+data class ChatRoomListRequest(
+    val userId: Long
+)

--- a/src/main/kotlin/com/stark/shoot/adapter/in/web/socket/dto/chatroom/ChatRoomUpdateDto.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/web/socket/dto/chatroom/ChatRoomUpdateDto.kt
@@ -1,0 +1,10 @@
+package com.stark.shoot.adapter.`in`.web.socket.dto.chatroom
+
+import java.time.Instant
+
+data class ChatRoomUpdateDto(
+    val roomId: Long,
+    val unreadCount: Int,
+    val lastMessage: String?,
+    val timestamp: Instant = Instant.now()
+)


### PR DESCRIPTION
## Summary
- add `ChatRoomListStompHandler` to fetch rooms via websocket
- send per-user room updates with `ChatRoomUpdateEventListener`
- create DTOs for room requests and updates

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6878ddf9cb0483209a2abc909bdaf76e