### PR TITLE
Refactor chat room update event handling

### DIFF
--- a/src/main/kotlin/com/stark/shoot/adapter/in/event/chatroom/ChatRoomUpdateEventListener.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/event/chatroom/ChatRoomUpdateEventListener.kt
@@ -1,40 +1,17 @@
 package com.stark.shoot.adapter.`in`.event.chatroom
 
-import com.stark.shoot.adapter.`in`.web.socket.dto.chatroom.ChatRoomUpdateDto
+import com.stark.shoot.application.service.chatroom.ChatRoomUpdateNotifyService
 import com.stark.shoot.domain.event.ChatRoomUpdateEvent
-import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.context.event.EventListener
-import org.springframework.data.redis.core.StringRedisTemplate
-import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.stereotype.Component
 
 @Component
 class ChatRoomUpdateEventListener(
-    private val redisTemplate: StringRedisTemplate,
-    private val messagingTemplate: SimpMessagingTemplate
+    private val chatRoomUpdateNotifyService: ChatRoomUpdateNotifyService
 ) {
-    private val logger = KotlinLogging.logger {}
 
     @EventListener
     fun handleChatRoomUpdate(event: ChatRoomUpdateEvent) {
-        val roomId = event.roomId.value
-        event.updates.forEach { (userId, updateInfo) ->
-            val activeKey = "active:${userId.value}:$roomId"
-            val isActive = redisTemplate.opsForValue().get(activeKey) == "true"
-            if (!isActive) {
-                val update = ChatRoomUpdateDto(
-                    roomId = roomId,
-                    unreadCount = updateInfo.unreadCount,
-                    lastMessage = updateInfo.lastMessage
-                )
-                messagingTemplate.convertAndSendToUser(
-                    userId.value.toString(),
-                    "/queue/room-update",
-                    update
-                )
-            } else {
-                logger.debug { "User ${userId.value} active in room $roomId, skip update" }
-            }
-        }
+        chatRoomUpdateNotifyService.notify(event)
     }
 }

--- a/src/main/kotlin/com/stark/shoot/adapter/out/chatroom/SendChatRoomUpdateWebSocketAdapter.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/chatroom/SendChatRoomUpdateWebSocketAdapter.kt
@@ -1,0 +1,27 @@
+package com.stark.shoot.adapter.out.chatroom
+
+import com.stark.shoot.adapter.`in`.web.socket.WebSocketMessageBroker
+import com.stark.shoot.adapter.`in`.web.socket.dto.chatroom.ChatRoomUpdateDto
+import com.stark.shoot.application.port.out.chatroom.SendChatRoomUpdatePort
+import com.stark.shoot.domain.chatroom.vo.ChatRoomId
+import com.stark.shoot.domain.event.ChatRoomUpdateEvent
+import com.stark.shoot.domain.user.vo.UserId
+import com.stark.shoot.infrastructure.annotation.Adapter
+
+@Adapter
+class SendChatRoomUpdateWebSocketAdapter(
+    private val webSocketMessageBroker: WebSocketMessageBroker
+) : SendChatRoomUpdatePort {
+
+    override fun sendUpdate(userId: UserId, roomId: ChatRoomId, update: ChatRoomUpdateEvent.Update) {
+        val dto = ChatRoomUpdateDto(
+            roomId = roomId.value,
+            unreadCount = update.unreadCount,
+            lastMessage = update.lastMessage
+        )
+        webSocketMessageBroker.sendMessage(
+            "/user/${userId.value}/queue/room-update",
+            dto
+        )
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/application/port/out/chatroom/SendChatRoomUpdatePort.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/out/chatroom/SendChatRoomUpdatePort.kt
@@ -1,0 +1,12 @@
+package com.stark.shoot.application.port.out.chatroom
+
+import com.stark.shoot.domain.chatroom.vo.ChatRoomId
+import com.stark.shoot.domain.event.ChatRoomUpdateEvent
+import com.stark.shoot.domain.user.vo.UserId
+
+/**
+ * 채팅방 업데이트 정보를 사용자에게 전송하기 위한 포트
+ */
+interface SendChatRoomUpdatePort {
+    fun sendUpdate(userId: UserId, roomId: ChatRoomId, update: ChatRoomUpdateEvent.Update)
+}

--- a/src/main/kotlin/com/stark/shoot/application/service/chatroom/ChatRoomUpdateNotifyService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/chatroom/ChatRoomUpdateNotifyService.kt
@@ -1,0 +1,28 @@
+package com.stark.shoot.application.service.chatroom
+
+import com.stark.shoot.application.port.out.chatroom.SendChatRoomUpdatePort
+import com.stark.shoot.domain.event.ChatRoomUpdateEvent
+import com.stark.shoot.infrastructure.annotation.UseCase
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.data.redis.core.StringRedisTemplate
+
+@UseCase
+class ChatRoomUpdateNotifyService(
+    private val redisTemplate: StringRedisTemplate,
+    private val sendChatRoomUpdatePort: SendChatRoomUpdatePort
+) {
+    private val logger = KotlinLogging.logger {}
+
+    fun notify(event: ChatRoomUpdateEvent) {
+        val roomId = event.roomId
+        event.updates.forEach { (userId, updateInfo) ->
+            val activeKey = "active:${userId.value}:${roomId.value}"
+            val isActive = redisTemplate.opsForValue().get(activeKey) == "true"
+            if (!isActive) {
+                sendChatRoomUpdatePort.sendUpdate(userId, roomId, updateInfo)
+            } else {
+                logger.debug { "User ${userId.value} active in room ${roomId.value}, skip update" }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/stark/shoot/application/service/chatroom/ChatRoomUpdateNotifyServiceTest.kt
+++ b/src/test/kotlin/com/stark/shoot/application/service/chatroom/ChatRoomUpdateNotifyServiceTest.kt
@@ -1,0 +1,57 @@
+package com.stark.shoot.application.service.chatroom
+
+import com.stark.shoot.application.port.out.chatroom.SendChatRoomUpdatePort
+import com.stark.shoot.domain.chatroom.vo.ChatRoomId
+import com.stark.shoot.domain.event.ChatRoomUpdateEvent
+import com.stark.shoot.domain.user.vo.UserId
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import org.springframework.data.redis.core.ValueOperations
+import org.springframework.data.redis.core.StringRedisTemplate
+
+@DisplayName("ChatRoomUpdateNotifyService 테스트")
+class ChatRoomUpdateNotifyServiceTest {
+
+    private val redisTemplate: StringRedisTemplate = mock()
+    private val valueOps: ValueOperations<String, String> = mock()
+    private val sendPort: SendChatRoomUpdatePort = mock()
+    private val service = ChatRoomUpdateNotifyService(redisTemplate, sendPort)
+
+    @Test
+    @DisplayName("활성 사용자가 아니면 업데이트를 전송한다")
+    fun `inactive user receives update`() {
+        val roomId = ChatRoomId.from(1L)
+        val userId = UserId.from(2L)
+        val update = ChatRoomUpdateEvent.Update(unreadCount = 3, lastMessage = "hi")
+        val event = ChatRoomUpdateEvent.create(roomId, mapOf(userId to update))
+
+        whenever(redisTemplate.opsForValue()).thenReturn(valueOps)
+        whenever(valueOps.get("active:${userId.value}:${roomId.value}"))
+            .thenReturn("false")
+
+        service.notify(event)
+
+        verify(sendPort).sendUpdate(userId, roomId, update)
+    }
+
+    @Test
+    @DisplayName("활성 사용자이면 업데이트를 전송하지 않는다")
+    fun `active user does not receive update`() {
+        val roomId = ChatRoomId.from(1L)
+        val userId = UserId.from(2L)
+        val update = ChatRoomUpdateEvent.Update(unreadCount = 3, lastMessage = "hi")
+        val event = ChatRoomUpdateEvent.create(roomId, mapOf(userId to update))
+
+        whenever(redisTemplate.opsForValue()).thenReturn(valueOps)
+        whenever(valueOps.get("active:${userId.value}:${roomId.value}"))
+            .thenReturn("true")
+
+        service.notify(event)
+
+        verifyNoInteractions(sendPort)
+    }
+}


### PR DESCRIPTION
## Summary
- introduce SendChatRoomUpdatePort and websocket adapter
- add ChatRoomUpdateNotifyService to encapsulate Redis check and notification
- simplify ChatRoomUpdateEventListener to delegate to service
- unit tests for ChatRoomUpdateNotifyService

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to download gradle)*

------
https://chatgpt.com/codex/tasks/task_e_6878e8fe817c8320b0036b571842a12c