### PR TITLE
Fix event consumption

### DIFF
--- a/src/main/kotlin/com/stark/shoot/adapter/in/event/message/MessageSendedEventListener.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/event/message/MessageSendedEventListener.kt
@@ -1,0 +1,48 @@
+package com.stark.shoot.adapter.`in`.event.message
+
+import com.stark.shoot.adapter.`in`.web.mapper.ChatRoomResponseMapper
+import com.stark.shoot.adapter.`in`.web.socket.WebSocketMessageBroker
+import com.stark.shoot.application.port.out.chatroom.ChatRoomQueryPort
+import com.stark.shoot.domain.chatroom.service.ChatRoomDomainService
+import com.stark.shoot.domain.event.MessageSendedEvent
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+
+/**
+ * Listens for [MessageSendedEvent] and sends chat room update information
+ * to all participants via WebSocket.
+ */
+@Component
+class MessageSendedEventListener(
+    private val chatRoomQueryPort: ChatRoomQueryPort,
+    private val chatRoomDomainService: ChatRoomDomainService,
+    private val chatRoomResponseMapper: ChatRoomResponseMapper,
+    private val webSocketMessageBroker: WebSocketMessageBroker
+) {
+
+    private val logger = KotlinLogging.logger {}
+
+    @EventListener
+    fun handleMessageSended(event: MessageSendedEvent) {
+        val roomId = event.message.roomId
+        val chatRoom = chatRoomQueryPort.findById(roomId) ?: run {
+            logger.warn { "Chat room not found for roomId=$roomId" }
+            return
+        }
+
+        chatRoom.participants.forEach { participant ->
+            val titles = chatRoomDomainService.prepareChatRoomTitles(listOf(chatRoom), participant)
+            val lastMessages = chatRoomDomainService.prepareLastMessages(listOf(chatRoom))
+            val timestamps = chatRoomDomainService.prepareTimestamps(listOf(chatRoom))
+            val response = chatRoomResponseMapper.toResponse(
+                chatRoom,
+                participant,
+                titles[roomId.value] ?: chatRoom.title?.value ?: "",
+                lastMessages[roomId.value] ?: "",
+                timestamps[roomId.value] ?: ""
+            )
+            webSocketMessageBroker.sendMessage("/topic/rooms/${participant.value}", response)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- refactor `ConsumeMessageEventService` to avoid use-case calls
- publish chatroom updates via a new `MessageSendedEventListener`
- update tests for new ports

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6879095e1ec483209c8cc8392749ae6a