### PR TITLE
메시지 고정, 반응 websocket 전용 핸들러 추가 

### DIFF
--- a/src/main/kotlin/com/stark/shoot/adapter/in/rest/dto/message/DeleteMessageRequest.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/rest/dto/message/DeleteMessageRequest.kt
@@ -1,5 +1,6 @@
 package com.stark.shoot.adapter.`in`.rest.dto.message
 
 data class DeleteMessageRequest(
-    val messageId: String
+    val messageId: String,
+    val userId: Long // 웹소켓에서 사용자 식별을 위해 추가
 )

--- a/src/main/kotlin/com/stark/shoot/adapter/in/rest/dto/message/EditMessageRequest.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/rest/dto/message/EditMessageRequest.kt
@@ -2,5 +2,6 @@ package com.stark.shoot.adapter.`in`.rest.dto.message
 
 data class EditMessageRequest(
     val messageId: String,
-    val newContent: String
+    val newContent: String,
+    val userId: Long // 웹소켓에서 사용자 식별을 위해 추가
 )

--- a/src/main/kotlin/com/stark/shoot/adapter/in/rest/dto/message/pin/PinMessageRequest.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/rest/dto/message/pin/PinMessageRequest.kt
@@ -1,0 +1,6 @@
+package com.stark.shoot.adapter.`in`.rest.dto.message.pin
+
+data class PinMessageRequest(
+    val messageId: String,
+    val userId: Long
+)

--- a/src/main/kotlin/com/stark/shoot/adapter/in/rest/dto/message/reaction/ReactionRequest.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/rest/dto/message/reaction/ReactionRequest.kt
@@ -1,5 +1,10 @@
 package com.stark.shoot.adapter.`in`.rest.dto.message.reaction
 
 data class ReactionRequest(
-    val reactionType: String  // ReactionType.code 값 (e.g. "like", "sad")
-)
+    val messageId: String,      // 웹소켓에서 메시지 ID 식별을 위해 추가
+    val reactionType: String,   // ReactionType.code 값 (e.g. "like", "sad")
+    val userId: Long           // 웹소켓에서 사용자 식별을 위해 추가
+) {
+    // REST API 호환성을 위한 별칭
+    val reaction: String get() = reactionType
+}

--- a/src/main/kotlin/com/stark/shoot/adapter/in/rest/message/MessageController.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/rest/message/MessageController.kt
@@ -24,26 +24,28 @@ class MessageController(
 
     @Operation(
         summary = "메시지 편집",
-        description = "메시지 내용을 수정합니다."
+        description = "메시지 내용을 수정합니다.",
+        deprecated = true
     )
     @PutMapping("/edit")
     fun editMessage(
         @RequestBody request: EditMessageRequest
     ): ResponseDto<MessageResponseDto> {
-        val command = EditMessageCommand.of(request.messageId, request.newContent)
+        val command = EditMessageCommand.of(request.messageId, request.newContent, request.userId)
         val updatedMessage = editMessageUseCase.editMessage(command)
         return ResponseDto.success(chatMessageMapper.toDto(updatedMessage), "메시지가 수정되었습니다.")
     }
 
     @Operation(
         summary = "메시지 삭제",
-        description = "메시지를 삭제 처리합니다."
+        description = "메시지를 삭제 처리합니다.",
+        deprecated = true
     )
     @DeleteMapping("/delete")
     fun deleteMessage(
         @RequestBody request: DeleteMessageRequest
     ): ResponseDto<MessageResponseDto> {
-        val command = DeleteMessageCommand.of(request.messageId)
+        val command = DeleteMessageCommand.of(request.messageId, request.userId)
         val deletedMessage = deleteMessageUseCase.deleteMessage(command)
         return ResponseDto.success(chatMessageMapper.toDto(deletedMessage), "메시지가 삭제되었습니다.")
     }

--- a/src/main/kotlin/com/stark/shoot/adapter/in/rest/message/MessageReadController.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/rest/message/MessageReadController.kt
@@ -20,7 +20,8 @@ class MessageReadController(
 
     @Operation(
         summary = "메시지 조회 (커서 기반 페이지네이션)",
-        description = "특정 채팅방(roomId)의 메시지를 `_id` 기준으로 페이지네이션하여 조회합니다."
+        description = "특정 채팅방(roomId)의 메시지를 `_id` 기준으로 페이지네이션하여 조회합니다.",
+        deprecated = true,
     )
     @GetMapping("/get")
     fun getMessages(

--- a/src/main/kotlin/com/stark/shoot/adapter/in/rest/message/reaction/ToggleMessageReactionController.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/rest/message/reaction/ToggleMessageReactionController.kt
@@ -24,7 +24,8 @@ class ToggleMessageReactionController(
             - 최초 반응 선택: 반응 추가
             - 추가된 반응을 선택: 반응 제거
             - 선택된 상태에서 다른 반응 선택: 기존 반응을 제거하고 새 반응을 추가
-        """
+        """,
+        deprecated = true
     )
     @PutMapping("/{messageId}/reactions")
     fun toggleReaction(

--- a/src/main/kotlin/com/stark/shoot/adapter/in/rest/socket/active/UserActivityStompHandler.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/rest/socket/active/UserActivityStompHandler.kt
@@ -3,7 +3,6 @@ package com.stark.shoot.adapter.`in`.rest.socket.active
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.stark.shoot.application.port.`in`.active.UserActiveUseCase
 import com.stark.shoot.application.port.`in`.active.command.UserActivityCommand
-import io.swagger.v3.oas.annotations.Operation
 import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.stereotype.Controller
 
@@ -13,14 +12,15 @@ class UserActivityStompHandler(
     private val objectMapper: ObjectMapper
 ) {
 
-    @Operation(
-        summary = "유저가 활동중인지 그 여부를 설정합니다.",
-        description = """
-            - user1과 user2가 room123에 있을 때, user1이 채팅방을 나가면 Redis에 active:user1:room123이 "false"로 설정.
-            - 만약 user1이 다시 채팅방에 들어오면 active:user1:room123을 "true"로 설정.
-            - true: 채팅방에 참여 중, false: 채팅방에 참여하지 않음
-        """
-    )
+    /**
+     * 유저가 활동중인지 그 여부를 설정합니다.
+     * - user1과 user2가 room123에 있을 때, user1이 채팅방을 나가면 Redis에 active:user1:room123이 "false"로 설정.
+     * - 만약 user1이 다시 채팅방에 들어오면 active:user1:room123을 "true"로 설정.
+     * - true: 채팅방에 참여 중, false: 채팅방에 참여하지 않음
+     *
+     * WebSocket Endpoint: /active
+     * Protocol: STOMP over WebSocket
+     */
     @MessageMapping("/active")
     fun handleActivity(message: String) {
         val command = UserActivityCommand.of(message, objectMapper)

--- a/src/main/kotlin/com/stark/shoot/adapter/in/rest/socket/chatroom/ChatRoomListStompHandler.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/rest/socket/chatroom/ChatRoomListStompHandler.kt
@@ -3,7 +3,6 @@ package com.stark.shoot.adapter.`in`.rest.socket.chatroom
 import com.stark.shoot.adapter.`in`.rest.socket.dto.chatroom.ChatRoomListRequest
 import com.stark.shoot.application.port.`in`.chatroom.FindChatRoomUseCase
 import com.stark.shoot.application.port.`in`.chatroom.command.GetChatRoomsCommand
-import io.swagger.v3.oas.annotations.Operation
 import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.stereotype.Controller
@@ -14,10 +13,13 @@ class ChatRoomListStompHandler(
     private val messagingTemplate: SimpMessagingTemplate
 ) {
 
-    @Operation(
-        summary = "채팅방 목록 조회 (WebSocket)",
-        description = "사용자가 속한 채팅방 목록을 조회하여 개인 큐로 전달합니다."
-    )
+    /**
+     * 채팅방 목록 조회 (WebSocket)
+     * 사용자가 속한 채팅방 목록을 조회하여 개인 큐로 전달합니다.
+     *
+     * WebSocket Endpoint: /rooms
+     * Protocol: STOMP over WebSocket
+     */
     @MessageMapping("/rooms")
     fun handleChatRoomList(request: ChatRoomListRequest) {
         val command = GetChatRoomsCommand.of(request.userId)

--- a/src/main/kotlin/com/stark/shoot/adapter/in/rest/socket/mark/MessageReadCountStompHandler.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/rest/socket/mark/MessageReadCountStompHandler.kt
@@ -4,7 +4,6 @@ import com.stark.shoot.adapter.`in`.rest.dto.message.read.ChatReadRequest
 import com.stark.shoot.application.port.`in`.message.mark.MessageReadUseCase
 import com.stark.shoot.application.port.`in`.message.mark.command.MarkAllMessagesAsReadCommand
 import com.stark.shoot.application.port.`in`.message.mark.command.MarkMessageAsReadCommand
-import io.swagger.v3.oas.annotations.Operation
 import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.stereotype.Controller
 
@@ -13,13 +12,14 @@ class MessageReadCountStompHandler(
     private val messageReadUseCase: MessageReadUseCase
 ) {
 
-    @Operation(
-        summary = "전체 메시지 읽음 처리 (WebSocket)",
-        description = """
-            - 채팅방의 모든 메시지를 읽음 처리합니다.
-            - WebSocket을 통해 실시간으로 읽음 상태를 업데이트합니다.
-        """
-    )
+    /**
+     * 전체 메시지 읽음 처리 (WebSocket)
+     * - 채팅방의 모든 메시지를 읽음 처리합니다.
+     * - WebSocket을 통해 실시간으로 읽음 상태를 업데이트합니다.
+     *
+     * WebSocket Endpoint: /read-all
+     * Protocol: STOMP over WebSocket
+     */
     @MessageMapping("/read-all")
     fun handleReadAll(request: ChatReadRequest) {
         val command = MarkAllMessagesAsReadCommand.of(
@@ -30,13 +30,14 @@ class MessageReadCountStompHandler(
         messageReadUseCase.markAllMessagesAsRead(command)
     }
 
-    @Operation(
-        summary = "단일 메시지 읽음 처리 (WebSocket)",
-        description = """
-            - 특정 메시지를 읽음 처리합니다.
-            - WebSocket을 통해 실시간으로 읽음 상태를 업데이트합니다.
-        """
-    )
+    /**
+     * 단일 메시지 읽음 처리 (WebSocket)
+     * - 특정 메시지를 읽음 처리합니다.
+     * - WebSocket을 통해 실시간으로 읽음 상태를 업데이트합니다.
+     *
+     * WebSocket Endpoint: /read
+     * Protocol: STOMP over WebSocket
+     */
     @MessageMapping("/read")
     fun handleRead(request: ChatReadRequest) {
         request.messageId?.let { messageId ->

--- a/src/main/kotlin/com/stark/shoot/adapter/in/rest/socket/message/GetMessagePaginationStompHandler.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/rest/socket/message/GetMessagePaginationStompHandler.kt
@@ -8,7 +8,6 @@ import com.stark.shoot.application.port.`in`.message.command.SendSyncMessagesToU
 import com.stark.shoot.infrastructure.config.async.ApplicationCoroutineScope
 import com.stark.shoot.infrastructure.exception.web.ErrorResponse
 import io.github.oshai.kotlinlogging.KotlinLogging
-import io.swagger.v3.oas.annotations.Operation
 import kotlinx.coroutines.flow.toList
 import org.springframework.http.HttpStatus
 import org.springframework.messaging.handler.annotation.MessageMapping
@@ -25,14 +24,15 @@ class GetMessagePaginationStompHandler(
 ) {
     private val logger = KotlinLogging.logger {}
 
-    @Operation(
-        summary = "메시지 조회",
-        description = """
-            요청 타입에 따라 '초기, 이전, 다음' 메시지를 페이징해서 조회한다.
-            - 요청에 담긴 SyncDirection (INITIAL, BEFORE, AFTER)에 따라 메시지를 조회합니다.
-            - API 호출 대신 WebSocket을 통해 실시간으로 메시지를 조회합니다.
-        """,
-    )
+    /**
+     * 메시지 조회
+     * 요청 타입에 따라 '초기, 이전, 다음' 메시지를 페이징해서 조회한다.
+     * - 요청에 담긴 SyncDirection (INITIAL, BEFORE, AFTER)에 따라 메시지를 조회합니다.
+     * - API 호출 대신 WebSocket을 통해 실시간으로 메시지를 조회합니다.
+     *
+     * WebSocket Endpoint: /sync
+     * Protocol: STOMP over WebSocket
+     */
     @MessageMapping("/sync")
     fun syncMessages(@Payload request: SyncRequestDto) {
         // Command 객체 생성

--- a/src/main/kotlin/com/stark/shoot/adapter/in/rest/socket/message/MessageActionStompHandler.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/rest/socket/message/MessageActionStompHandler.kt
@@ -1,0 +1,44 @@
+package com.stark.shoot.adapter.`in`.rest.socket.message
+
+import com.stark.shoot.adapter.`in`.rest.dto.message.DeleteMessageRequest
+import com.stark.shoot.adapter.`in`.rest.dto.message.EditMessageRequest
+import com.stark.shoot.application.port.`in`.message.DeleteMessageUseCase
+import com.stark.shoot.application.port.`in`.message.EditMessageUseCase
+import com.stark.shoot.application.port.`in`.message.command.DeleteMessageCommand
+import com.stark.shoot.application.port.`in`.message.command.EditMessageCommand
+import org.springframework.messaging.handler.annotation.MessageMapping
+import org.springframework.stereotype.Controller
+
+@Controller
+class MessageActionStompHandler(
+    private val editMessageUseCase: EditMessageUseCase,
+    private val deleteMessageUseCase: DeleteMessageUseCase
+) {
+
+    /**
+     * 메시지 편집 (WebSocket)
+     * 메시지 내용을 수정하고 채팅방의 모든 참여자에게 실시간으로 전송합니다.
+     *
+     * WebSocket Endpoint: /edit
+     * Protocol: STOMP over WebSocket
+     */
+    @MessageMapping("/edit")
+    fun handleEditMessage(request: EditMessageRequest) {
+        val command = EditMessageCommand.of(request.messageId, request.newContent, request.userId)
+        editMessageUseCase.editMessage(command)
+    }
+
+    /**
+     * 메시지 삭제 (WebSocket)
+     * 메시지를 삭제 처리하고 채팅방의 모든 참여자에게 실시간으로 전송합니다.
+     *
+     * WebSocket Endpoint: /delete
+     * Protocol: STOMP over WebSocket
+     */
+    @MessageMapping("/delete")
+    fun handleDeleteMessage(request: DeleteMessageRequest) {
+        val command = DeleteMessageCommand.of(request.messageId, request.userId)
+        deleteMessageUseCase.deleteMessage(command)
+    }
+
+}

--- a/src/main/kotlin/com/stark/shoot/adapter/in/rest/socket/message/MessageInteractionStompHandler.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/rest/socket/message/MessageInteractionStompHandler.kt
@@ -1,0 +1,52 @@
+package com.stark.shoot.adapter.`in`.rest.socket.message
+
+import com.stark.shoot.adapter.`in`.rest.dto.message.pin.PinMessageRequest
+import com.stark.shoot.adapter.`in`.rest.dto.message.reaction.ReactionRequest
+import com.stark.shoot.application.port.`in`.message.pin.MessagePinUseCase
+import com.stark.shoot.application.port.`in`.message.pin.command.PinMessageCommand
+import com.stark.shoot.application.port.`in`.message.reaction.ToggleMessageReactionUseCase
+import com.stark.shoot.application.port.`in`.message.reaction.command.ToggleMessageReactionCommand
+import org.springframework.messaging.handler.annotation.MessageMapping
+import org.springframework.stereotype.Controller
+
+@Controller
+class MessageInteractionStompHandler(
+    private val toggleMessageReactionUseCase: ToggleMessageReactionUseCase,
+    private val messagePinUseCase: MessagePinUseCase
+) {
+
+    /**
+     * 메시지 반응 토글 (WebSocket)
+     * 메시지에 이모지 반응을 추가/제거하고 채팅방의 모든 참여자에게 실시간으로 전송합니다.
+     *
+     * WebSocket Endpoint: /reaction
+     * Protocol: STOMP over WebSocket
+     */
+    @MessageMapping("/reaction")
+    fun handleToggleReaction(request: ReactionRequest) {
+        val command = ToggleMessageReactionCommand.of(
+            messageId = request.messageId,
+            reaction = request.reactionType,  // reactionType 필드 사용
+            userId = request.userId
+        )
+        toggleMessageReactionUseCase.toggleReaction(command)
+    }
+
+    /**
+     * 메시지 고정 토글 (WebSocket)
+     * 메시지가 고정되어 있으면 해제하고, 고정되어 있지 않으면 고정합니다.
+     * 모든 참여자에게 실시간으로 전송합니다.
+     *
+     * WebSocket Endpoint: /pin/toggle
+     * Protocol: STOMP over WebSocket
+     */
+    @MessageMapping("/pin/toggle")
+    fun handleTogglePinMessage(request: PinMessageRequest) {
+        val command = PinMessageCommand.of(
+            messageId = request.messageId,
+            userId = request.userId
+        )
+        messagePinUseCase.pinMessage(command)  // 토글 로직은 UseCase에서 처리
+    }
+
+}

--- a/src/main/kotlin/com/stark/shoot/adapter/in/rest/socket/message/SendMessageStompHandler.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/rest/socket/message/SendMessageStompHandler.kt
@@ -3,7 +3,6 @@ package com.stark.shoot.adapter.`in`.rest.socket.message
 import com.stark.shoot.adapter.`in`.rest.dto.message.ChatMessageRequest
 import com.stark.shoot.application.port.`in`.message.SendMessageUseCase
 import com.stark.shoot.application.port.`in`.message.command.SendMessageCommand
-import io.swagger.v3.oas.annotations.Operation
 import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.stereotype.Controller
 
@@ -18,17 +17,10 @@ class SendMessageStompHandler(
      * 2. Redis를 통해 메시지 즉시 브로드캐스트 (실시간성)
      * 3. Kafka를 통해 메시지 영속화 (안정성)
      * 4. 메시지 상태 업데이트를 클라이언트에 전송
+     *
+     * WebSocket Endpoint: /chat
+     * Protocol: STOMP over WebSocket
      */
-    @Operation(
-        summary = "클라이언트로부터 메시지를 수신하여 Redis, Kafka로 전달하여 처리합니다.",
-        description = """
-            - 웹소켓으로 메시지를 받으면 Redis(Pub/Sub)로 실시간 전송을 하고 Kafka로 mongoDB에 저장합니다.
-              - 1. 메시지에 임시 ID와 "sending" 상태 추가 (임시 상태를 웹소켓으로 보내서 프론트에서 상태 제어: 전송중, 실패 등)
-              - 2. Redis를 통해 메시지 즉시 브로드캐스트    (일단 실시간으로 웹소켓으로 상대방에게 메시지 전송)
-              - 3. Kafka를 통해 메시지 영속화            (메시지 저장을 보장하기 위해서 분리)
-              - 4. 메시지 상태 업데이트를 클라이언트에 전송   (최종 저장되면 SAVED 상태 전송)
-        """
-    )
     @MessageMapping("/chat")
     fun handleChatMessage(message: ChatMessageRequest) {
         val command = SendMessageCommand.of(message)

--- a/src/main/kotlin/com/stark/shoot/adapter/in/rest/socket/message/thread/GetThreadDetailStompHandler.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/rest/socket/message/thread/GetThreadDetailStompHandler.kt
@@ -3,7 +3,6 @@ package com.stark.shoot.adapter.`in`.rest.socket.message.thread
 import com.stark.shoot.adapter.`in`.rest.socket.dto.ThreadDetailRequestDto
 import com.stark.shoot.application.port.`in`.message.thread.GetThreadDetailUseCase
 import com.stark.shoot.application.port.`in`.message.thread.command.GetThreadDetailCommand
-import io.swagger.v3.oas.annotations.Operation
 import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.stereotype.Controller
@@ -14,10 +13,13 @@ class GetThreadDetailStompHandler(
     private val messagingTemplate: SimpMessagingTemplate,
 ) {
 
-    @Operation(
-        summary = "스레드 상세 조회 (WebSocket)",
-        description = "스레드를 처음 열 때 사용하며 루트 메시지와 현재까지의 답글을 함께 반환합니다."
-    )
+    /**
+     * 스레드 상세 조회 (WebSocket)
+     * 스레드를 처음 열 때 사용하며 루트 메시지와 현재까지의 답글을 함께 반환합니다.
+     *
+     * WebSocket Endpoint: /thread/detail
+     * Protocol: STOMP over WebSocket
+     */
     @MessageMapping("/thread/detail")
     fun handleGetThreadDetail(request: ThreadDetailRequestDto) {
         val command = GetThreadDetailCommand.of(request)

--- a/src/main/kotlin/com/stark/shoot/adapter/in/rest/socket/message/thread/GetThreadMessagesStompHandler.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/rest/socket/message/thread/GetThreadMessagesStompHandler.kt
@@ -3,7 +3,6 @@ package com.stark.shoot.adapter.`in`.rest.socket.message.thread
 import com.stark.shoot.adapter.`in`.rest.socket.dto.ThreadMessagesRequestDto
 import com.stark.shoot.application.port.`in`.message.thread.GetThreadMessagesUseCase
 import com.stark.shoot.application.port.`in`.message.thread.command.GetThreadMessagesCommand
-import io.swagger.v3.oas.annotations.Operation
 import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.stereotype.Controller
@@ -14,13 +13,14 @@ class GetThreadMessagesStompHandler(
     private val messagingTemplate: SimpMessagingTemplate,
 ) {
 
-    @Operation(
-        summary = "스레드 메시지 조회 (WebSocket)",
-        description = """
-            특정 스레드의 하위 메시지(답글)를 페이징하여 조회합니다.
-            스레드 목록에서 스크롤을 통해 추가 메시지를 가져올 때 `getThreadMessages`를 호출합니다.
-        """
-    )
+    /**
+     * 스레드 메시지 조회 (WebSocket)
+     * 특정 스레드의 하위 메시지(답글)를 페이징하여 조회합니다.
+     * 스레드 목록에서 스크롤을 통해 추가 메시지를 가져올 때 `getThreadMessages`를 호출합니다.
+     *
+     * WebSocket Endpoint: /thread/messages
+     * Protocol: STOMP over WebSocket
+     */
     @MessageMapping("/thread/messages")
     fun handleGetThreadMessages(request: ThreadMessagesRequestDto) {
         val command = GetThreadMessagesCommand.of(

--- a/src/main/kotlin/com/stark/shoot/adapter/in/rest/socket/message/thread/SendThreadMessageStompHandler.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/rest/socket/message/thread/SendThreadMessageStompHandler.kt
@@ -3,7 +3,6 @@ package com.stark.shoot.adapter.`in`.rest.socket.message.thread
 import com.stark.shoot.adapter.`in`.rest.dto.message.ChatMessageRequest
 import com.stark.shoot.application.port.`in`.message.thread.SendThreadMessageUseCase
 import com.stark.shoot.application.port.`in`.message.thread.command.SendThreadMessageCommand
-import io.swagger.v3.oas.annotations.Operation
 import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.stereotype.Controller
 
@@ -12,9 +11,12 @@ class SendThreadMessageStompHandler(
     private val sendThreadMessageUseCase: SendThreadMessageUseCase,
 ) {
 
-    @Operation(
-        summary = "스레드 메시지 전송 (WebSocket)"
-    )
+    /**
+     * 스레드 메시지 전송 (WebSocket)
+     *
+     * WebSocket Endpoint: /thread
+     * Protocol: STOMP over WebSocket
+     */
     @MessageMapping("/thread")
     fun handleSendThreadMessage(request: ChatMessageRequest) {
         val command = SendThreadMessageCommand.of(request)

--- a/src/main/kotlin/com/stark/shoot/adapter/in/rest/socket/typing/TypingIndicatorStompHandler.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/rest/socket/typing/TypingIndicatorStompHandler.kt
@@ -3,7 +3,6 @@ package com.stark.shoot.adapter.`in`.rest.socket.typing
 import com.stark.shoot.adapter.`in`.rest.socket.dto.TypingIndicatorMessage
 import com.stark.shoot.application.port.`in`.message.TypingIndicatorMessageUseCase
 import com.stark.shoot.application.port.`in`.message.command.TypingIndicatorCommand
-import io.swagger.v3.oas.annotations.Operation
 import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.stereotype.Controller
 
@@ -12,13 +11,14 @@ class TypingIndicatorStompHandler(
     private val typingIndicatorMessageUseCase: TypingIndicatorMessageUseCase
 ) {
 
-    @Operation(
-        summary = "타이핑 인디케이터 (작성중 표시)",
-        description = """
-            - 상대방이 글을 작성하면 "xxx님이 작성중입니다." 표시를 위함
-            - 백엔드에서 타이핑 이벤트를 받을 때, 너무 자주 요청이 오면 무시하도록 제한을 겁니다. (예: 1초에 한 번만 처리)
-        """
-    )
+    /**
+     * 타이핑 인디케이터 (작성중 표시)
+     * - 상대방이 글을 작성하면 "xxx님이 작성중입니다." 표시를 위함
+     * - 백엔드에서 타이핑 이벤트를 받을 때, 너무 자주 요청이 오면 무시하도록 제한을 겁니다. (예: 1초에 한 번만 처리)
+     *
+     * WebSocket Endpoint: /typing
+     * Protocol: STOMP over WebSocket
+     */
     @MessageMapping("/typing")
     fun handleTypingIndicator(message: TypingIndicatorMessage) {
         val command = TypingIndicatorCommand.of(message)

--- a/src/main/kotlin/com/stark/shoot/application/port/in/message/command/DeleteMessageCommand.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/message/command/DeleteMessageCommand.kt
@@ -1,17 +1,20 @@
 package com.stark.shoot.application.port.`in`.message.command
 
 import com.stark.shoot.domain.chat.message.vo.MessageId
+import com.stark.shoot.domain.user.vo.UserId
 
 /**
  * Command for deleting a message
  */
 data class DeleteMessageCommand(
-    val messageId: MessageId
+    val messageId: MessageId,
+    val userId: UserId // 웹소켓 응답을 위해 사용자 ID 추가
 ) {
     companion object {
-        fun of(messageId: String): DeleteMessageCommand {
+        fun of(messageId: String, userId: Long): DeleteMessageCommand {
             return DeleteMessageCommand(
-                messageId = MessageId.from(messageId)
+                messageId = MessageId.from(messageId),
+                userId = UserId.from(userId)
             )
         }
     }

--- a/src/main/kotlin/com/stark/shoot/application/port/in/message/command/EditMessageCommand.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/message/command/EditMessageCommand.kt
@@ -1,19 +1,22 @@
 package com.stark.shoot.application.port.`in`.message.command
 
 import com.stark.shoot.domain.chat.message.vo.MessageId
+import com.stark.shoot.domain.user.vo.UserId
 
 /**
  * Command for editing a message
  */
 data class EditMessageCommand(
     val messageId: MessageId,
-    val newContent: String
+    val newContent: String,
+    val userId: UserId // 웹소켓 응답을 위해 사용자 ID 추가
 ) {
     companion object {
-        fun of(messageId: String, newContent: String): EditMessageCommand {
+        fun of(messageId: String, newContent: String, userId: Long): EditMessageCommand {
             return EditMessageCommand(
                 messageId = MessageId.from(messageId),
-                newContent = newContent
+                newContent = newContent,
+                userId = UserId.from(userId)
             )
         }
     }

--- a/src/main/kotlin/com/stark/shoot/application/port/in/message/reaction/command/ToggleMessageReactionCommand.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/message/reaction/command/ToggleMessageReactionCommand.kt
@@ -21,6 +21,15 @@ data class ToggleMessageReactionCommand(
             )
         }
         
+        // 웹소켓용 - reaction 파라미터명 지원
+        fun of(messageId: String, reaction: String, userId: Long): ToggleMessageReactionCommand {
+            return ToggleMessageReactionCommand(
+                messageId = MessageId.from(messageId),
+                userId = UserId.from(userId),
+                reactionType = reaction
+            )
+        }
+
         fun of(messageId: String, authentication: Authentication, reactionType: String): ToggleMessageReactionCommand {
             val userId = authentication.name.toLong()
             return of(messageId, userId, reactionType)

--- a/src/main/kotlin/com/stark/shoot/application/service/message/DeleteMessageService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/message/DeleteMessageService.kt
@@ -1,32 +1,81 @@
 package com.stark.shoot.application.service.message
 
+import com.stark.shoot.adapter.`in`.rest.socket.WebSocketMessageBroker
 import com.stark.shoot.application.port.`in`.message.DeleteMessageUseCase
 import com.stark.shoot.application.port.`in`.message.command.DeleteMessageCommand
 import com.stark.shoot.application.port.out.message.MessageCommandPort
 import com.stark.shoot.application.port.out.message.MessageQueryPort
 import com.stark.shoot.domain.chat.message.ChatMessage
 import com.stark.shoot.infrastructure.annotation.UseCase
+import io.github.oshai.kotlinlogging.KotlinLogging
 
 @UseCase
 class DeleteMessageService(
     private val messageQueryPort: MessageQueryPort,
-    private val messageCommandPort: MessageCommandPort
+    private val messageCommandPort: MessageCommandPort,
+    private val webSocketMessageBroker: WebSocketMessageBroker
 ) : DeleteMessageUseCase {
+
+    private val logger = KotlinLogging.logger {}
 
     /**
      * @apiNote 메시지 삭제
-     * @param command 메시지 삭제 커맨드 (메시지 ID)
+     * @param command 메시지 삭제 커맨드 (메시지 ID, 사용자 ID)
      */
     override fun deleteMessage(command: DeleteMessageCommand): ChatMessage {
-        // 메시지 로드
-        val existingMessage = messageQueryPort.findById(command.messageId)
-            ?: throw IllegalArgumentException("메시지를 찾을 수 없습니다. messageId=${command.messageId}")
+        try {
+            // 메시지 로드
+            val existingMessage = messageQueryPort.findById(command.messageId)
+                ?: run {
+                    sendErrorResponse(command.userId, "메시지를 찾을 수 없습니다.")
+                    throw IllegalArgumentException("메시지를 찾을 수 없습니다. messageId=${command.messageId}")
+                }
 
-        // 도메인 객체의 메서드를 사용하여 메시지 삭제 상태로 변경
-        val deletedMessage = existingMessage.markAsDeleted()
+            // 도메인 객체의 메서드를 사용하여 메시지 삭제 상태로 변경
+            val deletedMessage = existingMessage.markAsDeleted()
+            val savedMessage = messageCommandPort.save(deletedMessage)
 
-        // 업데이트된 메시지 저장 후 반환
-        return messageCommandPort.save(deletedMessage)
+            // 채팅방의 모든 참여자에게 메시지 삭제 알림
+            webSocketMessageBroker.sendMessage(
+                "/topic/message/delete/${savedMessage.roomId.value}",
+                savedMessage
+            )
+
+            // 요청자에게 성공 응답 전송
+            sendSuccessResponse(command.userId, "메시지가 삭제되었습니다.", savedMessage)
+
+            return savedMessage
+
+        } catch (e: IllegalArgumentException) {
+            sendErrorResponse(command.userId, "메시지 삭제에 실패했습니다: ${e.message}")
+            throw e
+        } catch (e: Exception) {
+            logger.error(e) { "메시지 삭제 중 예상치 못한 오류 발생: ${e.message}" }
+            sendErrorResponse(command.userId, "메시지 삭제 중 오류가 발생했습니다.")
+            throw e
+        }
+    }
+
+    private fun sendSuccessResponse(userId: com.stark.shoot.domain.user.vo.UserId, message: String, data: ChatMessage) {
+        webSocketMessageBroker.sendMessage(
+            "/queue/message/delete/response/${userId.value}",
+            mapOf(
+                "success" to true,
+                "message" to message,
+                "data" to data
+            )
+        )
+    }
+
+    private fun sendErrorResponse(userId: com.stark.shoot.domain.user.vo.UserId, message: String) {
+        webSocketMessageBroker.sendMessage(
+            "/queue/message/delete/response/${userId.value}",
+            mapOf(
+                "success" to false,
+                "message" to message,
+                "data" to null
+            )
+        )
     }
 
 }

--- a/src/main/kotlin/com/stark/shoot/application/service/message/EditMessageService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/message/EditMessageService.kt
@@ -1,5 +1,6 @@
 package com.stark.shoot.application.service.message
 
+import com.stark.shoot.adapter.`in`.rest.socket.WebSocketMessageBroker
 import com.stark.shoot.application.port.`in`.message.EditMessageUseCase
 import com.stark.shoot.application.port.`in`.message.command.EditMessageCommand
 import com.stark.shoot.application.port.out.message.MessageCommandPort
@@ -7,32 +8,77 @@ import com.stark.shoot.application.port.out.message.MessageQueryPort
 import com.stark.shoot.domain.chat.message.ChatMessage
 import com.stark.shoot.domain.chat.message.service.MessageEditDomainService
 import com.stark.shoot.infrastructure.annotation.UseCase
+import io.github.oshai.kotlinlogging.KotlinLogging
 
 @UseCase
 class EditMessageService(
     private val messageQueryPort: MessageQueryPort,
     private val messageCommandPort: MessageCommandPort,
-    private val messageEditDomainService: MessageEditDomainService
+    private val messageEditDomainService: MessageEditDomainService,
+    private val webSocketMessageBroker: WebSocketMessageBroker
 ) : EditMessageUseCase {
+
+    private val logger = KotlinLogging.logger {}
 
     /**
      * @apiNote 메시지를 수정합니다.
-     * @param command 메시지 수정 커맨드 (메시지 ID, 새로운 내용)
+     * @param command 메시지 수정 커맨드 (메시지 ID, 새로운 내용, 사용자 ID)
      * @throws IllegalArgumentException 메시지를 찾을 수 없거나, 이미 삭제된 메시지이거나, 텍스트 타입이 아닌 경우, 또는 내용이 비어있는 경우
      */
     override fun editMessage(command: EditMessageCommand): ChatMessage {
-        // 메시지 조회
-        val existingMessage = messageQueryPort.findById(command.messageId)
-            ?: run {
-                throw IllegalArgumentException("메시지를 찾을 수 없습니다.")
-            }
-
         try {
+            // 메시지 조회
+            val existingMessage = messageQueryPort.findById(command.messageId)
+                ?: run {
+                    sendErrorResponse(command.userId, "메시지를 찾을 수 없습니다.")
+                    throw IllegalArgumentException("메시지를 찾을 수 없습니다.")
+                }
+
+            // 메시지 수정
             val updatedMessage = messageEditDomainService.editMessage(existingMessage, command.newContent)
-            return messageCommandPort.save(updatedMessage)
+            val savedMessage = messageCommandPort.save(updatedMessage)
+
+            // 채팅방의 모든 참여자에게 메시지 편집 알림
+            webSocketMessageBroker.sendMessage(
+                "/topic/message/edit/${savedMessage.roomId.value}",
+                savedMessage
+            )
+
+            // 요청자에게 성공 응답 전송
+            sendSuccessResponse(command.userId, "메시지가 수정되었습니다.", savedMessage)
+
+            return savedMessage
+
         } catch (e: IllegalArgumentException) {
+            sendErrorResponse(command.userId, "메시지 수정에 실패했습니다: ${e.message}")
+            throw e
+        } catch (e: Exception) {
+            logger.error(e) { "메시지 수정 중 예상치 못한 오류 발생: ${e.message}" }
+            sendErrorResponse(command.userId, "메시지 수정 중 오류가 발생했습니다.")
             throw e
         }
+    }
+
+    private fun sendSuccessResponse(userId: com.stark.shoot.domain.user.vo.UserId, message: String, data: ChatMessage) {
+        webSocketMessageBroker.sendMessage(
+            "/queue/message/edit/response/${userId.value}",
+            mapOf(
+                "success" to true,
+                "message" to message,
+                "data" to data
+            )
+        )
+    }
+
+    private fun sendErrorResponse(userId: com.stark.shoot.domain.user.vo.UserId, message: String) {
+        webSocketMessageBroker.sendMessage(
+            "/queue/message/edit/response/${userId.value}",
+            mapOf(
+                "success" to false,
+                "message" to message,
+                "data" to null
+            )
+        )
     }
 
 }

--- a/src/main/kotlin/com/stark/shoot/application/service/message/pin/MessagePinService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/message/pin/MessagePinService.kt
@@ -12,7 +12,6 @@ import com.stark.shoot.domain.chat.message.service.MessagePinDomainService
 import com.stark.shoot.domain.user.vo.UserId
 import com.stark.shoot.infrastructure.annotation.UseCase
 import com.stark.shoot.infrastructure.exception.web.ResourceNotFoundException
-import io.github.oshai.kotlinlogging.KotlinLogging
 import java.time.Instant
 
 @UseCase
@@ -23,7 +22,6 @@ class MessagePinService(
     private val eventPublisher: EventPublisher,
     private val messagePinDomainService: MessagePinDomainService
 ) : MessagePinUseCase {
-    private val logger = KotlinLogging.logger {}
 
     /**
      * 메시지를 고정합니다. (채팅방에는 최대 1개의 고정 메시지만 존재)

--- a/src/main/kotlin/com/stark/shoot/application/service/message/reaction/ToggleMessageReactionService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/message/reaction/ToggleMessageReactionService.kt
@@ -1,6 +1,7 @@
 package com.stark.shoot.application.service.message.reaction
 
 import com.stark.shoot.adapter.`in`.rest.dto.message.reaction.ReactionResponse
+import com.stark.shoot.adapter.`in`.rest.socket.WebSocketMessageBroker
 import com.stark.shoot.application.port.`in`.message.reaction.ToggleMessageReactionUseCase
 import com.stark.shoot.application.port.`in`.message.reaction.command.ToggleMessageReactionCommand
 import com.stark.shoot.application.port.out.event.EventPublisher
@@ -15,16 +16,18 @@ import com.stark.shoot.domain.user.vo.UserId
 import com.stark.shoot.infrastructure.annotation.UseCase
 import com.stark.shoot.infrastructure.exception.web.InvalidInputException
 import com.stark.shoot.infrastructure.exception.web.ResourceNotFoundException
-import org.springframework.messaging.simp.SimpMessagingTemplate
+import io.github.oshai.kotlinlogging.KotlinLogging
 
 @UseCase
 class ToggleMessageReactionService(
     private val messageQueryPort: MessageQueryPort,
     private val messageCommandPort: MessageCommandPort,
-    private val messagingTemplate: SimpMessagingTemplate,
+    private val webSocketMessageBroker: WebSocketMessageBroker,
     private val eventPublisher: EventPublisher,
     private val messageReactionService: MessageReactionService
 ) : ToggleMessageReactionUseCase {
+
+    private val logger = KotlinLogging.logger {}
 
     /**
      * 메시지에 리액션을 토글합니다.
@@ -34,29 +37,76 @@ class ToggleMessageReactionService(
      * @return 업데이트된 메시지의 리액션 정보
      */
     override fun toggleReaction(command: ToggleMessageReactionCommand): ReactionResponse {
-        // 리액션 타입 검증
-        val type = ReactionType.fromCode(command.reactionType)
-            ?: throw InvalidInputException("지원하지 않는 리액션 타입입니다: ${command.reactionType}")
+        try {
+            // 리액션 타입 검증
+            val type = ReactionType.fromCode(command.reactionType)
+                ?: run {
+                    sendErrorResponse(command.userId, "지원하지 않는 리액션 타입입니다: ${command.reactionType}")
+                    throw InvalidInputException("지원하지 않는 리액션 타입입니다: ${command.reactionType}")
+                }
 
-        // 메시지 조회 (없으면 예외 발생)
-        val message = messageQueryPort.findById(command.messageId)
-            ?: throw ResourceNotFoundException("메시지를 찾을 수 없습니다: messageId=${command.messageId}")
+            // 메시지 조회 (없으면 예외 발생)
+            val message = messageQueryPort.findById(command.messageId)
+                ?: run {
+                    sendErrorResponse(command.userId, "메시지를 찾을 수 없습니다.")
+                    throw ResourceNotFoundException("메시지를 찾을 수 없습니다: messageId=${command.messageId}")
+                }
 
-        // 도메인 객체에 토글 로직 위임
-        val result = message.toggleReaction(command.userId, type)
+            // 도메인 객체에 토글 로직 위임
+            val result = message.toggleReaction(command.userId, type)
+            val updatedMessage = messageCommandPort.save(result.message)  // result.message 사용
 
-        // 결과에 따라 알림 및 이벤트 처리
-        handleNotificationsAndEvents(command.messageId, result)
+            // 채팅방의 모든 참여자에게 반응 변경 알림
+            webSocketMessageBroker.sendMessage(
+                "/topic/message/reaction/${updatedMessage.roomId.value}",
+                mapOf(
+                    "messageId" to updatedMessage.id?.value,
+                    "reactions" to updatedMessage.reactions,
+                    "userId" to command.userId.value,
+                    "reactionType" to command.reactionType,
+                    "action" to if (result.isAdded) "ADDED" else "REMOVED"
+                )
+            )
 
-        // 저장 및 반환
-        val savedMessage = messageCommandPort.save(result.message)
+            // 요청자에게 성공 응답 전송
+            val reactionResponse = ReactionResponse.from(
+                messageId = updatedMessage.id!!.value,
+                reactions = updatedMessage.reactions,
+                updatedAt = updatedMessage.updatedAt?.toString() ?: ""
+            )
+            sendSuccessResponse(command.userId, "반응이 업데이트되었습니다.", reactionResponse)
 
-        // 응답 생성
-        // savedMessage.reactions는 ChatMessage의 getter를 통해 messageReactions.reactions에 접근
-        return ReactionResponse.from(
-            messageId = savedMessage.id!!.value,
-            reactions = savedMessage.reactions,
-            updatedAt = savedMessage.updatedAt?.toString() ?: ""
+            // 결과에 따라 알림 및 이벤트 처리
+            handleNotificationsAndEvents(command.messageId, result)
+
+            return reactionResponse
+
+        } catch (e: Exception) {
+            logger.error(e) { "메시지 반응 처리 중 오류 발생: ${e.message}" }
+            sendErrorResponse(command.userId, "반응 처리 중 오류가 발생했습니다: ${e.message}")
+            throw e
+        }
+    }
+
+    private fun sendSuccessResponse(userId: UserId, message: String, data: ReactionResponse) {
+        webSocketMessageBroker.sendMessage(
+            "/queue/message/reaction/response/${userId.value}",
+            mapOf(
+                "success" to true,
+                "message" to message,
+                "data" to data
+            )
+        )
+    }
+
+    private fun sendErrorResponse(userId: UserId, message: String) {
+        webSocketMessageBroker.sendMessage(
+            "/queue/message/reaction/response/${userId.value}",
+            mapOf(
+                "success" to false,
+                "message" to message,
+                "data" to null
+            )
         )
     }
 
@@ -109,7 +159,7 @@ class ToggleMessageReactionService(
         val type = ReactionType.fromCode(reactionType) ?: ReactionType.LIKE
 
         // 특정 채팅방에 있는 모든 클라이언트에게 메시지 반응 업데이트를 전송
-        messagingTemplate.convertAndSend(
+        webSocketMessageBroker.sendMessage(
             "/topic/reactions/${roomId.value}",
             mapOf(
                 "messageId" to messageId.value,


### PR DESCRIPTION
메시지 고정, 반응 websocket 전용 핸들러 추가 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 실시간 채팅 메시지 수정, 삭제, 반응, 고정 등 WebSocket(STOMP) 기반의 메시지 액션 및 인터랙션 핸들러가 추가되었습니다.
  * 메시지 삭제, 수정, 반응, 고정 요청에 사용자 식별자(userId)가 포함되어 보다 정교한 실시간 피드백이 제공됩니다.

* **버그 수정**
  * 메시지 수정, 삭제, 반응 처리 시 오류 발생 시 사용자에게 WebSocket을 통한 즉각적인 에러 응답이 전송됩니다.

* **문서화**
  * WebSocket 핸들러의 Swagger 어노테이션이 제거되고, 상세 설명이 코드 주석으로 대체되었습니다.
  * API 일부 엔드포인트가 deprecated로 표시되었습니다.

* **리팩터링**
  * 메시지 수정, 삭제, 반응 서비스에서 WebSocket 브로커를 활용해 성공/실패 응답 및 실시간 알림 로직이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->