### PR TITLE
메시지 저장 로직 리팩토링

### DIFF
--- a/src/main/kotlin/com/stark/shoot/adapter/in/kafka/MessageKafkaConsumer.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/kafka/MessageKafkaConsumer.kt
@@ -27,7 +27,7 @@ class MessageKafkaConsumer(
             if (success) {
                 acknowledgment.acknowledge()
             }
+            // 실패 시 ACK하지 않아서 Kafka가 자동 재시도
         }
     }
-
 }

--- a/src/main/kotlin/com/stark/shoot/adapter/in/redis/MessageRedisStreamListener.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/redis/MessageRedisStreamListener.kt
@@ -21,7 +21,7 @@ import org.springframework.stereotype.Component
  * WebSocket을 통해 클라이언트에게 전달합니다.
  */
 @Component
-class RedisStreamListener(
+class MessageRedisStreamListener(
     private val redisStreamManager: RedisStreamManager,
     private val redisMessageProcessor: RedisMessageProcessor,
     private val appCoroutineScope: ApplicationCoroutineScope,

--- a/src/main/kotlin/com/stark/shoot/adapter/in/rest/dto/message/ChatMessageMapperExtensions.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/rest/dto/message/ChatMessageMapperExtensions.kt
@@ -54,7 +54,7 @@ fun ChatMessageRequest.toDomain(): ChatMessage {
         senderId = UserId.from(this.senderId),
         content = content,
         threadId = this.threadId?.let { MessageId.from(it) },
-        status = this.status ?: MessageStatus.SAVED,
+        status = this.status ?: MessageStatus.SENT,
         readBy = this.readBy?.mapKeys { UserId.from(it.key.toLong()) }?.toMutableMap() ?: mutableMapOf(),
         metadata = metadata
     )

--- a/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/document/message/ChatMessageDocument.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/persistence/mongodb/document/message/ChatMessageDocument.kt
@@ -18,7 +18,7 @@ data class ChatMessageDocument(
     val roomId: Long,                                       // 메시지가 속한 채팅방 ID
     val senderId: Long,                                     // 메시지 보낸 사용자 ID
     val content: MessageContentDocument,                    // 메시지 내용
-    val status: MessageStatus = MessageStatus.SAVED,        // 메시지 상태 (e.g., SENT, READ 등)
+    val status: MessageStatus = MessageStatus.SENT,         // 메시지 상태 (e.g., SENT, READ 등)
     val readBy: MutableMap<Long, Boolean> = mutableMapOf(), // 읽음 상태 추가
     val threadId: ObjectId? = null,                         // 스레드 ID (루트 메시지 ID)
     val replyToMessageId: ObjectId? = null,                 // 답장할 메시지 ID

--- a/src/main/kotlin/com/stark/shoot/application/port/out/message/MessageStatusNotificationPort.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/out/message/MessageStatusNotificationPort.kt
@@ -21,7 +21,7 @@ interface MessageStatusNotificationPort {
         status: MessageStatus,
         errorMessage: String? = null
     )
-    
+
     /**
      * 메시지 처리 중 발생한 오류를 알립니다.
      *

--- a/src/main/kotlin/com/stark/shoot/application/service/message/HandleMessageEventService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/message/HandleMessageEventService.kt
@@ -43,8 +43,6 @@ class HandleMessageEventService(
         val tempId = message.metadata.tempId
 
         return try {
-            throw IllegalArgumentException("HandleMessageEventService는 MESSAGE_CREATED 이벤트만 처리합니다. 현재 이벤트 타입: ${event.type}")
-
             // 메시지 저장 및 메타데이터 업데이트
             saveMessageAndUpdateMetadata(message)
             // URL 미리보기 처리 (백그라운드)

--- a/src/main/kotlin/com/stark/shoot/application/service/message/HandleMessageEventService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/message/HandleMessageEventService.kt
@@ -1,18 +1,15 @@
 package com.stark.shoot.application.service.message
 
-import com.stark.shoot.adapter.`in`.rest.dto.message.MessageStatusResponse
-import com.stark.shoot.adapter.`in`.rest.socket.WebSocketMessageBroker
-import com.stark.shoot.adapter.out.persistence.mongodb.mapper.ChatMessageMapper
 import com.stark.shoot.application.port.`in`.message.HandleMessageEventUseCase
 import com.stark.shoot.application.port.out.chatroom.ChatRoomCommandPort
 import com.stark.shoot.application.port.out.chatroom.ChatRoomQueryPort
 import com.stark.shoot.application.port.out.event.EventPublisher
+import com.stark.shoot.application.port.out.message.MessageStatusNotificationPort
 import com.stark.shoot.application.port.out.message.SaveMessagePort
 import com.stark.shoot.application.port.out.message.preview.CacheUrlPreviewPort
 import com.stark.shoot.application.port.out.message.preview.LoadUrlContentPort
 import com.stark.shoot.domain.chat.message.ChatMessage
 import com.stark.shoot.domain.chat.message.type.MessageStatus
-import com.stark.shoot.domain.chat.message.vo.ChatMessageMetadata
 import com.stark.shoot.domain.chatroom.service.ChatRoomMetadataDomainService
 import com.stark.shoot.domain.event.MessageEvent
 import com.stark.shoot.domain.event.MessageSentEvent
@@ -20,7 +17,6 @@ import com.stark.shoot.domain.event.type.EventType
 import com.stark.shoot.infrastructure.annotation.UseCase
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.transaction.annotation.Transactional
-import java.time.Instant
 
 @UseCase
 class HandleMessageEventService(
@@ -30,8 +26,7 @@ class HandleMessageEventService(
     private val loadUrlContentPort: LoadUrlContentPort,
     private val cacheUrlPreviewPort: CacheUrlPreviewPort,
     private val chatRoomMetadataDomainService: ChatRoomMetadataDomainService,
-    private val webSocketMessageBroker: WebSocketMessageBroker,
-    private val chatMessageMapper: ChatMessageMapper,
+    private val messageStatusNotificationPort: MessageStatusNotificationPort,
     private val eventPublisher: EventPublisher,
 ) : HandleMessageEventUseCase {
 
@@ -39,51 +34,78 @@ class HandleMessageEventService(
 
     /**
      * 메시지를 저장하고 상태 업데이트를 전송합니다.
-     * - 메시지를 저장하고, 채팅방 메타데이터를 업데이트하며, URL 미리보기를 처리합니다.
-     * - 상태 업데이트를 웹소켓을 통해 전송합니다.
      */
     @Transactional
     override fun handle(event: MessageEvent): Boolean {
         if (event.type != EventType.MESSAGE_CREATED) return false
 
-        // 메시지 이벤트에서 임시 ID를 추출합니다. (임시 아이디는 웹소켓 상태 표현을 위함)
-        val tempId = extractTempId(event) ?: return false
+        val message = event.data
+        val tempId = message.metadata.tempId
 
         return try {
-            val savedMessage = saveAndMarkMessage(event.data)
-            updateChatRoomMetadata(savedMessage)
-            publishMessage(savedMessage)
-            // 상태 전송은 MessagePublisherAdapter에서만 담당 (SENT/FAILED)
-            processChatMessageForUrlPreview(savedMessage)
+            throw IllegalArgumentException("HandleMessageEventService는 MESSAGE_CREATED 이벤트만 처리합니다. 현재 이벤트 타입: ${event.type}")
+
+            // 메시지 저장 및 메타데이터 업데이트
+            saveMessageAndUpdateMetadata(message)
+            // URL 미리보기 처리 (백그라운드)
+            processUrlPreviewIfNeeded(message)
             true
         } catch (e: Exception) {
-            sendErrorResponse(event, e)
+            logger.error(e) { "메시지 영속화 실패: messageId=${message.id?.value}" }
+            notifyPersistenceFailure(message, tempId, e)
             false
         }
     }
 
-    private fun extractTempId(event: MessageEvent): String? {
-        return event.data.metadata.tempId ?: run {
-            logger.warn { "Received message event without tempId" }
-            null
+    /**
+     * 영속화 실패를 사용자에게 알립니다.
+     */
+    private fun notifyPersistenceFailure(
+        message: ChatMessage,
+        tempId: String?,
+        exception: Exception
+    ) {
+        if (tempId.isNullOrEmpty()) {
+            logger.warn { "tempId가 없어서 영속화 실패 알림을 보낼 수 없음: messageId=${message.id?.value}" }
+            return
         }
+
+        messageStatusNotificationPort.notifyMessageStatus(
+            roomId = message.roomId.value,
+            tempId = tempId,
+            status = MessageStatus.FAILED,
+            errorMessage = "영속화 실패: ${exception.message}"
+        )
+
+        logger.warn { "영속화 실패 알림 전송: roomId=${message.roomId.value}, tempId=$tempId" }
     }
 
+    /**
+     * 메시지 저장 및 메타데이터 업데이트
+     */
+    private fun saveMessageAndUpdateMetadata(message: ChatMessage) {
+        // 1. 메시지 저장 및 읽음 처리
+        val savedMessage = saveAndMarkMessage(message)
+
+        // 2. 채팅방 메타데이터 업데이트
+        updateChatRoomMetadata(savedMessage)
+
+        // 3. 도메인 이벤트 발행
+        eventPublisher.publish(MessageSentEvent.create(savedMessage))
+    }
 
     /**
      * 메시지를 저장하고 보낸 사람을 읽은 것으로 표시합니다.
-     * - 메시지를 저장하고, 보낸 사람의 읽음 상태를 업데이트합니다.
-     * - 채팅방의 마지막 읽은 메시지 ID를 업데이트합니다.
      */
     private fun saveAndMarkMessage(message: ChatMessage): ChatMessage {
         var savedMessage = saveMessagePort.save(message)
 
-        // 보낸 사람은 메시지를 읽은 것으로 표시합니다.
+        // 보낸 사람은 메시지를 읽은 것으로 표시
         if (savedMessage.readBy[savedMessage.senderId] != true) {
             savedMessage = saveMessagePort.save(savedMessage.markAsRead(savedMessage.senderId))
         }
 
-        // 메시지 ID가 존재하면 채팅방의 마지막 읽은 메시지 ID를 업데이트합니다.
+        // 채팅방의 마지막 읽은 메시지 ID 업데이트
         savedMessage.id?.let { id ->
             chatRoomCommandPort.updateLastReadMessageId(savedMessage.roomId, savedMessage.senderId, id)
         }
@@ -91,10 +113,8 @@ class HandleMessageEventService(
         return savedMessage
     }
 
-
     /**
      * 채팅방 메타데이터를 업데이트합니다.
-     * - 새로운 메시지를 추가하고, 채팅방의 마지막 메시지 ID를 업데이트합니다.
      */
     private fun updateChatRoomMetadata(message: ChatMessage) {
         chatRoomQueryPort.findById(message.roomId)?.let { room ->
@@ -103,113 +123,23 @@ class HandleMessageEventService(
         }
     }
 
-
     /**
-     * 메시지를 웹소켓을 통해 전송하고, 메시지 전송 이벤트를 발행합니다.
-     * - 메시지를 특정 채팅방의 토픽으로 전송합니다.
+     * URL 미리보기 처리 (필요시)
      */
-    private fun publishMessage(message: ChatMessage) {
-        // Redis Stream에서 이미 브로드캐스트했으므로 중복 전송 제거
-        // webSocketMessageBroker.sendMessage("/topic/messages/${message.roomId.value}", message)
-        eventPublisher.publish(MessageSentEvent.create(message))
-    }
-
-
-    /**
-     * 상태 업데이트를 웹소켓을 통해 전송합니다.
-     * - 메시지 상태, 임시 ID, 영구 ID, 오류 메시지를 포함합니다.
-     */
-    private fun sendStatusUpdate(
-        roomId: Long,
-        tempId: String,
-        status: String,
-        persistedId: String?,
-        errorMessage: String? = null
-    ) {
-        val statusUpdate = MessageStatusResponse(
-            tempId = tempId,
-            status = status,
-            persistedId = persistedId,
-            errorMessage = errorMessage,
-            createdAt = Instant.now().toString()
-        )
-
-        webSocketMessageBroker.sendMessage("/topic/message/status/$roomId", statusUpdate)
-    }
-
-    private fun sendErrorResponse(event: MessageEvent, e: Exception) {
-        val tempId = event.data.metadata.tempId
-        if (tempId != null) {
-            sendStatusUpdate(
-                event.data.roomId.value,
-                tempId,
-                MessageStatus.FAILED.name,
-                null,
-                e.message
-            )
-        }
-        logger.error(e) { "메시지 처리 오류: ${e.message}" }
-    }
-
-
-    /**
-     * URL 미리보기를 처리합니다.
-     * - 메시지 메타데이터에 URL 미리보기가 필요한 경우, URL 콘텐츠를 로드하고 캐시합니다.
-     * - URL 미리보기가 성공적으로 로드되면 메시지를 업데이트하고 웹소켓을 통해 전송합니다.
-     */
-    private fun processChatMessageForUrlPreview(savedMessage: ChatMessage) {
-        if (savedMessage.metadata.needsUrlPreview &&
-            savedMessage.metadata.previewUrl != null
-        ) {
-            val previewUrl = savedMessage.metadata.previewUrl ?: return
-
+    private fun processUrlPreviewIfNeeded(message: ChatMessage) {
+        if (message.metadata.needsUrlPreview && message.metadata.previewUrl != null) {
             try {
-                // Jsoup를 사용하여 URL 콘텐츠를 추출합니다.
+                val previewUrl = message.metadata.previewUrl!!
                 val preview = loadUrlContentPort.fetchUrlContent(previewUrl)
 
                 if (preview != null) {
-                    // URL 미리보기를 캐시합니다. (로컬 캐시와 Redis에 저장)
                     cacheUrlPreviewPort.cacheUrlPreview(previewUrl, preview)
-                    val updatedMessage = updateMessageWithPreview(savedMessage, preview)
-                    sendMessageUpdate(updatedMessage)
+                    // URL 미리보기 업데이트는 별도 이벤트로 처리
                 }
             } catch (e: Exception) {
-                logger.error(e) { "URL 미리보기 처리 실패: $previewUrl" }
+                logger.error(e) { "URL 미리보기 처리 실패: ${message.metadata.previewUrl}" }
             }
         }
-    }
-
-
-    /**
-     * 메시지에 URL 미리보기를 추가합니다.
-     * - 메시지의 메타데이터에 URL 미리보기를 업데이트합니다.
-     */
-    private fun updateMessageWithPreview(
-        message: ChatMessage,
-        preview: ChatMessageMetadata.UrlPreview
-    ): ChatMessage {
-        val updatedMetadata = message.metadata
-        val currentContent = message.content
-        val currentMetadata = currentContent.metadata ?: ChatMessageMetadata()
-        val updatedContentMetadata = currentMetadata.copy(urlPreview = preview)
-        val updatedContent = currentContent.copy(metadata = updatedContentMetadata)
-        return message.copy(
-            content = updatedContent,
-            metadata = updatedMetadata
-        )
-    }
-
-    /**
-     * 메시지 업데이트를 웹소켓을 통해 전송합니다.
-     * - 메시지의 변경된 내용을 포함하여 특정 채팅방으로 전송합니다.
-     */
-    private fun sendMessageUpdate(message: ChatMessage) {
-        val messageDto = chatMessageMapper.toDto(message)
-
-        webSocketMessageBroker.sendMessage(
-            "/topic/message/update/${message.roomId}",
-            messageDto
-        )
     }
 
 }

--- a/src/main/kotlin/com/stark/shoot/application/service/message/SendMessageService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/message/SendMessageService.kt
@@ -32,8 +32,8 @@ class SendMessageService(
      * 2. 메시지 발행 (Redis, Kafka)
      *
      * @param command 메시지 전송 커맨드
-     * @see MessageRedisStreamListener Redis 메시지 스트림 리스너
-     * @see HandleMessageEventService kakfa 메시지 처리 서비스
+     * @see com.stark.shoot.adapter.in.redis.MessageRedisStreamListener redis 스트림 리스너
+     * @see HandleMessageEventService Kafka 메시지 처리 서비스
      */
     override fun sendMessage(command: SendMessageCommand) {
         val messageRequest = command.message

--- a/src/main/kotlin/com/stark/shoot/application/service/message/SendMessageService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/message/SendMessageService.kt
@@ -64,6 +64,7 @@ class SendMessageService(
             senderId = UserId.from(messageRequest.senderId),
             contentText = messageRequest.content.text,
             contentType = messageRequest.content.type,
+            tempId = messageRequest.tempId, // front에서 받은 기존 tempId 전달
             threadId = messageRequest.threadId?.let { MessageId.from(it) },
             extractUrls = { text -> extractUrlPort.extractUrls(text) },
             getCachedPreview = { url -> cacheUrlPreviewPort.getCachedUrlPreview(url) }

--- a/src/main/kotlin/com/stark/shoot/application/service/message/SendMessageService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/message/SendMessageService.kt
@@ -32,6 +32,8 @@ class SendMessageService(
      * 2. 메시지 발행 (Redis, Kafka)
      *
      * @param command 메시지 전송 커맨드
+     * @see MessageRedisStreamListener Redis 메시지 스트림 리스너
+     * @see HandleMessageEventService kakfa 메시지 처리 서비스
      */
     override fun sendMessage(command: SendMessageCommand) {
         val messageRequest = command.message

--- a/src/main/kotlin/com/stark/shoot/application/service/message/schedule/ScheduledMessageProcessor.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/message/schedule/ScheduledMessageProcessor.kt
@@ -173,7 +173,7 @@ class ScheduledMessageProcessor(
             roomId = ChatRoomId.from(scheduledMessage.roomId),
             senderId = UserId.from(scheduledMessage.senderId),
             content = scheduledMessage.content,
-            status = MessageStatus.SENDING,
+            status = MessageStatus.SENT, // 예약 메시지는 실행 시점에 이미 처리 완료된 상태
             metadata = scheduledMessage.metadata,
             createdAt = Instant.now()
         )

--- a/src/main/kotlin/com/stark/shoot/application/service/message/schedule/ScheduledMessageService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/message/schedule/ScheduledMessageService.kt
@@ -219,7 +219,7 @@ class ScheduledMessageService(
             roomId = ChatRoomId.from(scheduledMessage.roomId),
             senderId = UserId.from(scheduledMessage.senderId),
             content = scheduledMessage.content,
-            status = MessageStatus.SENDING,
+            status = MessageStatus.SENT, // 예약 메시지는 실행 시점에 이미 처리 완료된 상태
             metadata = scheduledMessage.metadata,
             createdAt = Instant.now()
         )

--- a/src/main/kotlin/com/stark/shoot/domain/chat/message/ChatMessage.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/message/ChatMessage.kt
@@ -320,7 +320,7 @@ data class ChatMessage(
                 roomId = roomId,
                 senderId = senderId,
                 content = content,
-                status = MessageStatus.SENDING,
+                status = MessageStatus.SENT,  // SENDING → SENT로 변경
                 metadata = metadata,
                 threadId = threadId,
                 expiresAt = expiresAt

--- a/src/main/kotlin/com/stark/shoot/domain/chat/message/service/MessageDomainService.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/message/service/MessageDomainService.kt
@@ -19,7 +19,12 @@ class MessageDomainService {
     /**
      * 메시지 요청으로부터 도메인 메시지 객체를 생성하고 처리합니다.
      *
-     * @param messageRequest 메시지 요청 DTO
+     * @param roomId 채팅방 ID
+     * @param senderId 발신자 ID
+     * @param contentText 메시지 내용
+     * @param contentType 메시지 타입
+     * @param tempId 임시 ID (프론트엔드에서 제공, null이면 새로 생성)
+     * @param threadId 스레드 ID (선택)
      * @param extractUrls URL 추출 함수
      * @param getCachedPreview 캐시된 미리보기 조회 함수
      * @return 처리된 도메인 메시지 객체
@@ -29,18 +34,19 @@ class MessageDomainService {
         senderId: UserId,
         contentText: String,
         contentType: MessageType,
+        tempId: String? = null,
         threadId: MessageId? = null,
         extractUrls: (String) -> List<String>,
         getCachedPreview: (String) -> ChatMessageMetadata.UrlPreview?
     ): ChatMessage {
-        // 1. 도메인 객체 생성
-        val tempId = UUID.randomUUID().toString()
+        // 1. 도메인 객체 생성 (기존 tempId 사용 또는 새로 생성)
+        val finalTempId = tempId ?: UUID.randomUUID().toString() // 기존 tempId 우선 사용
         val chatMessage = ChatMessage.create(
             roomId = roomId,
             senderId = senderId,
             text = contentText,
             type = contentType,
-            tempId = tempId,
+            tempId = finalTempId, // 프론트엔드 tempId 유지
             threadId = threadId
         )
 

--- a/src/main/kotlin/com/stark/shoot/domain/chat/message/service/MessageForwardDomainService.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/message/service/MessageForwardDomainService.kt
@@ -49,7 +49,7 @@ class MessageForwardDomainService {
             roomId = targetRoomId,
             senderId = forwardingUserId,
             content = forwardedContent,
-            status = MessageStatus.SAVED,
+            status = MessageStatus.SENT,
             replyToMessageId = null,
             messageReactions = MessageReactions(),
             mentions = emptySet(),

--- a/src/main/kotlin/com/stark/shoot/domain/chat/message/type/MessageStatus.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/chat/message/type/MessageStatus.kt
@@ -1,9 +1,11 @@
 package com.stark.shoot.domain.chat.message.type
 
 enum class MessageStatus {
-    SENDING,
-    PROCESSING,
-    SENT_TO_KAFKA,
-    SAVED,
-    FAILED
+    SENT,       // 전송 및 영속화 완료 (최종 성공 상태)
+    FAILED      // 전송 또는 영속화 실패 (오류 상태)
+
+    // SENDING 상태 제거:
+    // - 클라이언트에서 메시지 전송 시 즉시 UI에 표시 (낙관적 업데이트)
+    // - 서버에서 처리 완료 후 SENT 또는 FAILED로 상태 업데이트
+    // - 이렇게 하면 응답성과 일관성을 모두 확보할 수 있음
 }


### PR DESCRIPTION
메시지 저장 로직 리팩토링

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 메시지 상태가 단순화되어 서버에서는 이제 "SENT"(전송됨) 또는 "FAILED"(실패) 상태만 관리합니다.

* **버그 수정**
  * 메시지 생성, 예약 메시지, 전달 메시지 등 다양한 경로에서 기본 메시지 상태가 "SENT"로 일관되게 적용됩니다.

* **리팩터링**
  * 메시지 발송 및 저장 흐름이 개선되어, 메시지는 즉시 클라이언트에 반영되고 백그라운드에서 영속화가 진행됩니다.
  * 메시지 상태 알림 및 실패 처리 로직이 분리되어 신뢰성과 응답성이 향상되었습니다.
  * 내부 서비스 간 의존성이 명확해지고, WebSocket 직접 호출이 제거되어 구조가 단순해졌습니다.

* **문서화**
  * 관련 서비스 및 처리 흐름에 대한 주석과 KDoc이 보강되었습니다.

* **스타일**
  * 일부 클래스 및 메서드 명칭이 명확하게 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->