### PR TITLE
Add configurable Redis lock settings

### DIFF
--- a/src/main/kotlin/com/stark/shoot/infrastructure/config/redis/RedisLockManager.kt
+++ b/src/main/kotlin/com/stark/shoot/infrastructure/config/redis/RedisLockManager.kt
@@ -9,12 +9,13 @@ import java.time.Duration
 
 @Component
 class RedisLockManager(
-    private val redisTemplate: StringRedisTemplate
+    private val redisTemplate: StringRedisTemplate,
+    private val properties: RedisLockProperties,
 ) {
     private val logger = KotlinLogging.logger {}
-    private val lockTimeout = 10000L    // 10초
-    private val lockWaitTimeout = 2000L // 2초
-    private val maxRetries = 3          // 최대 재시도 횟수
+    private val lockTimeout get() = properties.lockTimeout
+    private val lockWaitTimeout get() = properties.lockWaitTimeout
+    private val maxRetries get() = properties.maxRetries
 
     // 락 해제를 위한 Lua 스크립트를 한 번만 생성하여 재사용
     private val releaseScript = RedisScript.of(RELEASE_SCRIPT, Long::class.java)

--- a/src/main/kotlin/com/stark/shoot/infrastructure/config/redis/RedisLockProperties.kt
+++ b/src/main/kotlin/com/stark/shoot/infrastructure/config/redis/RedisLockProperties.kt
@@ -1,0 +1,12 @@
+package com.stark.shoot.infrastructure.config.redis
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+
+@Component
+@ConfigurationProperties(prefix = "redis.lock")
+data class RedisLockProperties(
+    var lockTimeout: Long = 10000,
+    var lockWaitTimeout: Long = 2000,
+    var maxRetries: Int = 3,
+)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -81,6 +81,12 @@ spring:
       max-file-size: 10MB
       max-request-size: 10MB
 
+redis:
+  lock:
+    lock-timeout: 10000      # 락 타임아웃 (ms)
+    lock-wait-timeout: 2000  # 락 대기 타임아웃 (ms)
+    max-retries: 3           # 최대 재시도 횟수
+
 # 알림 설정
 notification:
   # 알림 전송 방식 (redis 또는 kafka)


### PR DESCRIPTION
## Summary
- externalize Redis lock settings via `RedisLockProperties`
- inject `RedisLockProperties` into `RedisLockManager`
- document default redis lock values in `application.yml`

## Testing
- `./gradlew test` *(fails: Could not resolve all files for configuration ':testCompileClasspath'. Received status code 403 from server)*

------
https://chatgpt.com/codex/tasks/task_e_6895f4dab1ac832089b0385dfc9cd91a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * Redis 락 관련 설정(타임아웃, 대기 타임아웃, 최대 재시도 횟수)을 외부 설정 파일에서 직접 지정할 수 있도록 지원합니다.

* **문서**
  * `application.yml`에 Redis 락 설정 항목이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->