### PR TITLE
Rename RedisConfig redisTemplate bean to stringRedisTemplate

### DIFF
--- a/src/main/kotlin/com/stark/shoot/infrastructure/config/redis/RedisConfig.kt
+++ b/src/main/kotlin/com/stark/shoot/infrastructure/config/redis/RedisConfig.kt
@@ -14,7 +14,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer
 class RedisConfig {
 
     @Bean
-    fun redisTemplate(
+    fun stringRedisTemplate(
         connectionFactory: RedisConnectionFactory
     ): StringRedisTemplate {
         val template = StringRedisTemplate()


### PR DESCRIPTION
## Summary
- rename redisTemplate bean to stringRedisTemplate

## Testing
- `./gradlew test` *(fails: Received status code 403 from server: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6895f4e1fdf08320b079ba40b6d0eb49