### PR TITLE
feat: support websocket notifications

### DIFF
--- a/docs/notification-flow.md
+++ b/docs/notification-flow.md
@@ -264,14 +264,27 @@ Kafka를 사용한 알림 전송은 다음과 같은 특징이 있습니다:
 3. **확장성**: Kafka는 높은 처리량을 지원하므로, 대량의 알림을 처리할 수 있습니다.
 4. **통합**: 다른 시스템이 Kafka 토픽을 구독하여 알림을 처리할 수 있습니다.
 
-#### 6.3 알림 전송 방식 선택
+#### 6.3 WebSocket을 통한 알림 전송
 
-애플리케이션은 설정에 따라 Redis 또는 Kafka를 사용하여 알림을 전송할 수 있습니다. 이는 `NotificationConfig` 클래스에서 설정됩니다:
+`SendNotificationPort`의 또 다른 구현체인 `SendNotificationWebSocketAdapter`는 WebSocket을 사용하여 알림을 전송합니다:
+
+```kotlin
+override fun sendNotification(notification: Notification) {
+    val destination = "/topic/notifications/${'$'}{notification.userId.value}"
+    webSocketMessageBroker.sendMessage(destination, notification)
+}
+```
+
+이 방식은 서버가 사용자의 WebSocket 세션으로 직접 알림을 전달하며, 클라이언트는 해당 목적지를 구독해야 알림을 수신할 수 있습니다.
+
+#### 6.4 알림 전송 방식 선택
+
+애플리케이션은 설정에 따라 Redis, Kafka 또는 WebSocket을 사용하여 알림을 전송할 수 있습니다. 이는 `NotificationConfig` 클래스에서 설정됩니다:
 
 ```yaml
 # application.yml
 notification:
-  transport: redis  # 또는 kafka
+  transport: redis  # 또는 kafka, websocket
 ```
 
 Redis는 실시간성이 중요한 경우에 적합하고, Kafka는 내구성과 확장성이 중요한 경우에 적합합니다.
@@ -302,7 +315,7 @@ Redis는 실시간성이 중요한 경우에 적합하고, Kafka는 내구성과
 4. **수신자 식별**: 알림을 받아야 할 사용자가 식별됩니다.
 5. **알림 생성**: `ChatNotificationFactory`를 사용하여 알림이 생성됩니다.
 6. **알림 저장**: 생성된 알림이 MongoDB에 저장됩니다.
-7. **알림 전송**: 저장된 알림이 Redis Pub/Sub 또는 Kafka를 통해 사용자에게 전송됩니다(설정에 따라 다름).
+7. **알림 전송**: 저장된 알림이 Redis Pub/Sub, Kafka, 또는 WebSocket을 통해 사용자에게 전송됩니다(설정에 따라 다름).
 8. **알림 수신**: 클라이언트가 웹소켓, SSE 등을 통해 알림을 수신합니다.
 9. **알림 처리**: 사용자가 알림을 읽거나 삭제합니다.
 

--- a/src/main/kotlin/com/stark/shoot/adapter/in/socket/WebSocketMessageBroker.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/socket/WebSocketMessageBroker.kt
@@ -6,6 +6,7 @@ import com.stark.shoot.infrastructure.config.async.ApplicationCoroutineScope
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.annotation.PreDestroy
 import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeout
 import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.messaging.simp.SimpMessagingTemplate
@@ -74,6 +75,61 @@ class WebSocketMessageBroker(
             throwable?.let {
                 logger.error(it) { "코루틴 처리중 예외 발생" }
                 if (!result.isDone) result.complete(false)
+            }
+        }
+
+        return result
+    }
+
+    // 새로 추가하는 메서드
+    fun sendToUser(
+        userId: String,
+        destination: String,
+        payload: Any,
+        retryCount: Int = 3
+    ): CompletableFuture<Boolean> {
+        val result = CompletableFuture<Boolean>()
+
+        coroutineScope.launch {
+            var attempt = 0
+            var success = false
+
+            while (!success && attempt < retryCount) {
+                try {
+                    withTimeout(MESSAGE_SEND_TIMEOUT) {
+                        simpMessagingTemplate.convertAndSendToUser(userId, destination, payload)
+                        logger.debug {
+                            "사용자에게 메시지 전송 성공: userId=$userId, destination=$destination, attempt=${attempt + 1}"
+                        }
+                    }
+                    success = true
+                } catch (e: TimeoutCancellationException) {
+                    attempt++
+                    logger.warn {
+                        "사용자 메시지 전송 시간 초과: userId=$userId, destination=$destination, attempt=$attempt/$retryCount"
+                    }
+                    if (attempt < retryCount) {
+                        delay(1000L * attempt) // 지수 백오프
+                    }
+                } catch (e: Exception) {
+                    attempt++
+                    logger.error(e) {
+                        "사용자 메시지 전송 실패: userId=$userId, destination=$destination, attempt=$attempt/$retryCount"
+                    }
+                    if (attempt < retryCount) {
+                        delay(1000L * attempt) // 지수 백오프
+                    }
+                }
+            }
+
+            if (success) {
+                result.complete(true)
+                logger.info { "사용자에게 메시지 전송 완료: userId=$userId, destination=$destination" }
+            } else {
+                result.complete(false)
+                logger.error {
+                    "사용자 메시지 전송 최종 실패: userId=$userId, destination=$destination, 총 시도 횟수=$attempt"
+                }
             }
         }
 

--- a/src/main/kotlin/com/stark/shoot/adapter/out/socket/notification/SendNotificationWebSocketAdapter.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/socket/notification/SendNotificationWebSocketAdapter.kt
@@ -1,0 +1,33 @@
+package com.stark.shoot.adapter.out.socket.notification
+
+import com.stark.shoot.adapter.`in`.socket.WebSocketMessageBroker
+import com.stark.shoot.application.port.out.notification.SendNotificationPort
+import com.stark.shoot.domain.notification.Notification
+import com.stark.shoot.infrastructure.annotation.Adapter
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+@Adapter
+class SendNotificationWebSocketAdapter(
+    private val webSocketMessageBroker: WebSocketMessageBroker
+) : SendNotificationPort {
+
+    private val logger = KotlinLogging.logger {}
+
+    companion object {
+        private const val NOTIFICATION_DESTINATION_PREFIX = "/topic/notifications/"
+    }
+
+    override fun sendNotification(notification: Notification) {
+        val destination = "$NOTIFICATION_DESTINATION_PREFIX${notification.userId.value}"
+        webSocketMessageBroker.sendMessage(destination, notification)
+            .exceptionally { ex ->
+                logger.error(ex) { "WebSocket 알림 전송 실패: userId=${notification.userId.value}, type=${notification.type}" }
+                false
+            }
+    }
+
+    override fun sendNotifications(notifications: List<Notification>) {
+        notifications.forEach { sendNotification(it) }
+    }
+}
+

--- a/src/main/kotlin/com/stark/shoot/adapter/out/socket/notification/SendNotificationWebSocketAdapter.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/out/socket/notification/SendNotificationWebSocketAdapter.kt
@@ -14,20 +14,38 @@ class SendNotificationWebSocketAdapter(
     private val logger = KotlinLogging.logger {}
 
     companion object {
-        private const val NOTIFICATION_DESTINATION_PREFIX = "/topic/notifications/"
+        private const val USER_DESTINATION = "/queue/notifications"
     }
 
+    /**
+     * 알림을 WebSocket을 통해 전송합니다.
+     * 사용자별로 WebSocket 메시지를 전송하여 실시간으로 알림을 전달합니다.
+     *
+     * @param notification 알림 객체
+     */
     override fun sendNotification(notification: Notification) {
-        val destination = "$NOTIFICATION_DESTINATION_PREFIX${notification.userId.value}"
-        webSocketMessageBroker.sendMessage(destination, notification)
-            .exceptionally { ex ->
+        try {
+            webSocketMessageBroker.sendToUser(
+                notification.userId.value.toString(),
+                USER_DESTINATION,
+                notification
+            ).exceptionally { ex ->
                 logger.error(ex) { "WebSocket 알림 전송 실패: userId=${notification.userId.value}, type=${notification.type}" }
                 false
             }
+        } catch (ex: Exception) {
+            logger.error(ex) { "WebSocket 알림 전송 중 오류 발생: userId=${notification.userId.value}, type=${notification.type}" }
+        }
     }
 
+    /**
+     * 여러 알림을 WebSocket을 통해 전송합니다.
+     * 각 알림은 사용자별로 전송됩니다.
+     *
+     * @param notifications 알림 객체 목록
+     */
     override fun sendNotifications(notifications: List<Notification>) {
         notifications.forEach { sendNotification(it) }
     }
-}
 
+}


### PR DESCRIPTION
## Summary
- add WebSocket-based notification sender
- allow choosing `websocket` transport in notification config
- document WebSocket notification usage and configuration

## Testing
- `./gradlew test` *(fails: Could not resolve dependencies; status code 403 from Maven repository)*

------
https://chatgpt.com/codex/tasks/task_e_689744bbc7508320a48cb63a7d2e53e0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서화**
  * WebSocket을 통한 알림 전송 방식을 문서에 추가하였습니다.
  * WebSocket 클라이언트 구독 방법 및 설정 예시가 포함되었습니다.
  * 알림 전송 방식 선택 문서에 WebSocket 옵션이 반영되었습니다.

* **신규 기능**
  * WebSocket을 이용한 실시간 알림 전송 기능이 추가되었습니다.
  * WebSocket 전송 방식을 위한 설정 옵션 및 관련 구성 요소가 도입되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->