### PR TITLE
그룹 채팅 websocket 통신 구현

### DIFF
--- a/src/main/kotlin/com/stark/shoot/adapter/in/rest/chatroom/group/GroupChatController.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/rest/chatroom/group/GroupChatController.kt
@@ -1,0 +1,112 @@
+package com.stark.shoot.adapter.`in`.rest.chatroom.group
+
+import com.stark.shoot.adapter.`in`.rest.dto.ResponseDto
+import com.stark.shoot.adapter.`in`.rest.dto.chatroom.group.CreateGroupChatRequest
+import com.stark.shoot.adapter.`in`.rest.dto.chatroom.group.GroupChatResponse
+import com.stark.shoot.adapter.`in`.rest.dto.chatroom.group.ManageParticipantsRequest
+import com.stark.shoot.adapter.`in`.rest.dto.chatroom.group.UpdateGroupTitleRequest
+import com.stark.shoot.application.port.`in`.chatroom.group.CreateGroupChatUseCase
+import com.stark.shoot.application.port.`in`.chatroom.group.ManageGroupChatUseCase
+import com.stark.shoot.application.port.`in`.chatroom.group.command.CreateGroupChatCommand
+import com.stark.shoot.application.port.`in`.chatroom.group.command.LeaveGroupChatCommand
+import com.stark.shoot.application.port.`in`.chatroom.group.command.ManageGroupParticipantsCommand
+import com.stark.shoot.application.port.`in`.chatroom.group.command.UpdateGroupChatTitleCommand
+import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/v1/chatrooms/group")
+class GroupChatController(
+    private val createGroupChatUseCase: CreateGroupChatUseCase,
+    private val manageGroupChatUseCase: ManageGroupChatUseCase
+) {
+    
+    private val logger = KotlinLogging.logger {}
+
+    /**
+     * 그룹 채팅방 생성
+     */
+    @PostMapping
+    fun createGroupChat(
+        @Valid @RequestBody request: CreateGroupChatRequest,
+        @RequestParam userId: Long
+    ): ResponseEntity<ResponseDto<GroupChatResponse>> {
+        logger.info { "Creating group chat: title=${request.title}, participants=${request.participants.size}" }
+
+        val command = CreateGroupChatCommand.of(request, userId)
+        val chatRoom = createGroupChatUseCase.createGroupChat(command)
+        val response = GroupChatResponse.from(chatRoom)
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(ResponseDto.success(response, "그룹 채팅방이 생성되었습니다."))
+    }
+
+    /**
+     * 그룹 채팅방 참여자 관리 (추가/제거)
+     */
+    @PutMapping("/{chatRoomId}/participants")
+    fun manageParticipants(
+        @PathVariable chatRoomId: Long,
+        @Valid @RequestBody request: ManageParticipantsRequest,
+        @RequestParam userId: Long
+    ): ResponseEntity<ResponseDto<GroupChatResponse>> {
+        logger.info { 
+            "Managing group chat participants: roomId=$chatRoomId, " +
+            "toAdd=${request.participantsToAdd.size}, toRemove=${request.participantsToRemove.size}" 
+        }
+        val command = ManageGroupParticipantsCommand(
+            chatRoomId = chatRoomId,
+            participantsToAdd = request.participantsToAdd,
+            participantsToRemove = request.participantsToRemove,
+            managedBy = userId
+        )
+        val chatRoom = manageGroupChatUseCase.manageParticipants(command)
+        val response = GroupChatResponse.from(chatRoom)
+
+        return ResponseEntity.ok(ResponseDto.success(response, "참여자가 변경되었습니다."))
+    }
+
+    /**
+     * 그룹 채팅방 제목 변경
+     */
+    @PutMapping("/{chatRoomId}/title")
+    fun updateTitle(
+        @PathVariable chatRoomId: Long,
+        @Valid @RequestBody request: UpdateGroupTitleRequest,
+        @RequestParam userId: Long
+    ): ResponseEntity<ResponseDto<GroupChatResponse>> {
+        logger.info { "Updating group chat title: roomId=$chatRoomId, newTitle=${request.newTitle}" }
+        val command = UpdateGroupChatTitleCommand(
+            chatRoomId = chatRoomId,
+            newTitle = request.newTitle,
+            updatedBy = userId
+        )
+        val chatRoom = manageGroupChatUseCase.updateTitle(command)
+        val response = GroupChatResponse.from(chatRoom)
+
+        return ResponseEntity.ok(ResponseDto.success(response, "채팅방 제목이 변경되었습니다."))
+    }
+
+    /**
+     * 그룹 채팅방 나가기
+     */
+    @DeleteMapping("/{chatRoomId}/participants/me")
+    fun leaveGroup(
+        @PathVariable chatRoomId: Long,
+        @RequestParam userId: Long
+    ): ResponseEntity<ResponseDto<GroupChatResponse?>> {
+        logger.info { "User leaving group chat: roomId=$chatRoomId, userId=$userId" }
+        val command = LeaveGroupChatCommand(
+            chatRoomId = chatRoomId,
+            userId = userId
+        )
+        val chatRoom = manageGroupChatUseCase.leaveGroup(command)
+        val response = chatRoom?.let { GroupChatResponse.from(it) }
+
+        val message = if (response != null) "그룹 채팅방을 나갔습니다." else "그룹 채팅방이 삭제되었습니다."
+        return ResponseEntity.ok(ResponseDto.success(response, message))
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/adapter/in/rest/dto/chatroom/group/CreateGroupChatRequest.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/rest/dto/chatroom/group/CreateGroupChatRequest.kt
@@ -1,0 +1,18 @@
+package com.stark.shoot.adapter.`in`.rest.dto.chatroom.group
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.Size
+
+/**
+ * 그룹 채팅방 생성 요청 DTO
+ */
+data class CreateGroupChatRequest(
+    @field:NotBlank(message = "채팅방 제목은 필수입니다.")
+    @field:Size(max = 50, message = "채팅방 제목은 50자 이하여야 합니다.")
+    val title: String,
+    
+    @field:NotEmpty(message = "참여자는 최소 1명 이상이어야 합니다.")
+    @field:Size(min = 1, max = 99, message = "참여자는 1명 이상 99명 이하여야 합니다.")
+    val participants: Set<Long>
+)

--- a/src/main/kotlin/com/stark/shoot/adapter/in/rest/dto/chatroom/group/GroupChatResponse.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/rest/dto/chatroom/group/GroupChatResponse.kt
@@ -1,0 +1,33 @@
+package com.stark.shoot.adapter.`in`.rest.dto.chatroom.group
+
+import com.stark.shoot.domain.chatroom.ChatRoom
+import java.time.Instant
+
+/**
+ * 그룹 채팅방 응답 DTO
+ */
+data class GroupChatResponse(
+    val id: Long,
+    val title: String,
+    val participants: Set<Long>,
+    val participantCount: Int,
+    val pinnedParticipants: Set<Long>,
+    val lastActiveAt: Instant,
+    val createdAt: Instant,
+    val announcement: String? = null
+) {
+    companion object {
+        fun from(chatRoom: ChatRoom): GroupChatResponse {
+            return GroupChatResponse(
+                id = chatRoom.id?.value ?: throw IllegalStateException("채팅방 ID가 없습니다."),
+                title = chatRoom.title?.value ?: "제목 없음",
+                participants = chatRoom.participants.map { it.value }.toSet(),
+                participantCount = chatRoom.participants.size,
+                pinnedParticipants = chatRoom.pinnedParticipants.map { it.value }.toSet(),
+                lastActiveAt = chatRoom.lastActiveAt,
+                createdAt = chatRoom.createdAt,
+                announcement = chatRoom.announcement?.value
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/adapter/in/rest/dto/chatroom/group/ManageParticipantsRequest.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/rest/dto/chatroom/group/ManageParticipantsRequest.kt
@@ -1,0 +1,20 @@
+package com.stark.shoot.adapter.`in`.rest.dto.chatroom.group
+
+import jakarta.validation.constraints.NotEmpty
+
+/**
+ * 참여자 관리 요청 DTO
+ */
+data class ManageParticipantsRequest(
+    val participantsToAdd: Set<Long> = emptySet(),
+    val participantsToRemove: Set<Long> = emptySet()
+) {
+    init {
+        require(participantsToAdd.isNotEmpty() || participantsToRemove.isNotEmpty()) {
+            "추가하거나 제거할 참여자가 있어야 합니다."
+        }
+        require((participantsToAdd intersect participantsToRemove).isEmpty()) {
+            "동일한 사용자를 동시에 추가하고 제거할 수 없습니다."
+        }
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/adapter/in/rest/dto/chatroom/group/UpdateGroupTitleRequest.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/rest/dto/chatroom/group/UpdateGroupTitleRequest.kt
@@ -1,0 +1,13 @@
+package com.stark.shoot.adapter.`in`.rest.dto.chatroom.group
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+/**
+ * 그룹 채팅방 제목 변경 요청 DTO
+ */
+data class UpdateGroupTitleRequest(
+    @field:NotBlank(message = "새 제목은 필수입니다.")
+    @field:Size(max = 50, message = "제목은 50자 이하여야 합니다.")
+    val newTitle: String
+)

--- a/src/main/kotlin/com/stark/shoot/adapter/in/socket/dto/group/GroupChatActionDto.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/socket/dto/group/GroupChatActionDto.kt
@@ -1,0 +1,22 @@
+package com.stark.shoot.adapter.`in`.socket.dto.group
+
+/**
+ * 그룹 채팅방 액션 DTO
+ */
+data class GroupChatActionDto(
+    val action: String, // "CREATE", "ADD_PARTICIPANT", "REMOVE_PARTICIPANT", "UPDATE_TITLE", "LEAVE"
+    val chatRoomId: Long? = null,
+    val title: String? = null,
+    val participants: Set<Long>? = null,
+    val participantsToAdd: Set<Long>? = null,
+    val participantsToRemove: Set<Long>? = null,
+    val newTitle: String? = null
+) {
+    enum class Action(val value: String) {
+        CREATE("CREATE"),
+        ADD_PARTICIPANT("ADD_PARTICIPANT"),
+        REMOVE_PARTICIPANT("REMOVE_PARTICIPANT"),
+        UPDATE_TITLE("UPDATE_TITLE"),
+        LEAVE("LEAVE")
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/adapter/in/socket/group/GroupChatStompHandler.kt
+++ b/src/main/kotlin/com/stark/shoot/adapter/in/socket/group/GroupChatStompHandler.kt
@@ -1,0 +1,139 @@
+package com.stark.shoot.adapter.`in`.socket.group
+
+import com.stark.shoot.adapter.`in`.socket.dto.group.GroupChatActionDto
+import com.stark.shoot.application.port.`in`.chatroom.group.CreateGroupChatUseCase
+import com.stark.shoot.application.port.`in`.chatroom.group.ManageGroupChatUseCase
+import com.stark.shoot.application.port.`in`.chatroom.group.command.CreateGroupChatCommand
+import com.stark.shoot.application.port.`in`.chatroom.group.command.LeaveGroupChatCommand
+import com.stark.shoot.application.port.`in`.chatroom.group.command.ManageGroupParticipantsCommand
+import com.stark.shoot.application.port.`in`.chatroom.group.command.UpdateGroupChatTitleCommand
+import com.stark.shoot.infrastructure.config.socket.StompPrincipal
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.messaging.handler.annotation.MessageMapping
+import org.springframework.messaging.handler.annotation.Payload
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.stereotype.Controller
+
+@Controller
+class GroupChatStompHandler(
+    private val createGroupChatUseCase: CreateGroupChatUseCase,
+    private val manageGroupChatUseCase: ManageGroupChatUseCase
+) {
+    
+    private val logger = KotlinLogging.logger {}
+
+    /**
+     * 그룹 채팅방 관련 WebSocket 액션 처리
+     * 
+     * WebSocket Endpoint: /app/group-chat
+     * Protocol: STOMP over WebSocket
+     */
+    @MessageMapping("/group-chat")
+    fun handleGroupChatAction(
+        @Payload actionDto: GroupChatActionDto,
+        @AuthenticationPrincipal principal: StompPrincipal
+    ) {
+        val userId = principal.name.toLong()
+        logger.info { "Group chat action received: ${actionDto.action} from user $userId" }
+
+        try {
+            when (actionDto.action.uppercase()) {
+                GroupChatActionDto.Action.CREATE.value -> {
+                    handleCreateGroupChat(actionDto, userId)
+                }
+                
+                GroupChatActionDto.Action.ADD_PARTICIPANT.value -> {
+                    handleAddParticipants(actionDto, userId)
+                }
+                
+                GroupChatActionDto.Action.REMOVE_PARTICIPANT.value -> {
+                    handleRemoveParticipants(actionDto, userId)
+                }
+                
+                GroupChatActionDto.Action.UPDATE_TITLE.value -> {
+                    handleUpdateTitle(actionDto, userId)
+                }
+                
+                GroupChatActionDto.Action.LEAVE.value -> {
+                    handleLeaveGroup(actionDto, userId)
+                }
+                
+                else -> {
+                    logger.warn { "Unknown group chat action: ${actionDto.action}" }
+                }
+            }
+        } catch (e: Exception) {
+            logger.error(e) { "Failed to handle group chat action: ${actionDto.action}" }
+            // WebSocket에서는 예외를 직접 클라이언트로 전송할 수 없으므로
+            // 에러 상황을 별도 채널로 전송하거나 로깅만 수행
+        }
+    }
+
+    private fun handleCreateGroupChat(actionDto: GroupChatActionDto, userId: Long) {
+        val title = actionDto.title ?: throw IllegalArgumentException("제목이 필요합니다.")
+        val participants = actionDto.participants ?: throw IllegalArgumentException("참여자가 필요합니다.")
+        
+        val command = CreateGroupChatCommand(
+            title = title,
+            participants = participants + userId, // 생성자 포함
+            createdBy = userId
+        )
+        
+        createGroupChatUseCase.createGroupChat(command)
+        logger.info { "Group chat created via WebSocket: title=$title, participants=${participants.size + 1}" }
+    }
+
+    private fun handleAddParticipants(actionDto: GroupChatActionDto, userId: Long) {
+        val chatRoomId = actionDto.chatRoomId ?: throw IllegalArgumentException("채팅방 ID가 필요합니다.")
+        val participantsToAdd = actionDto.participantsToAdd ?: throw IllegalArgumentException("추가할 참여자가 필요합니다.")
+        
+        val command = ManageGroupParticipantsCommand.addParticipants(
+            chatRoomId = chatRoomId,
+            participants = participantsToAdd,
+            managedBy = userId
+        )
+        
+        manageGroupChatUseCase.manageParticipants(command)
+        logger.info { "Participants added via WebSocket: roomId=$chatRoomId, count=${participantsToAdd.size}" }
+    }
+
+    private fun handleRemoveParticipants(actionDto: GroupChatActionDto, userId: Long) {
+        val chatRoomId = actionDto.chatRoomId ?: throw IllegalArgumentException("채팅방 ID가 필요합니다.")
+        val participantsToRemove = actionDto.participantsToRemove ?: throw IllegalArgumentException("제거할 참여자가 필요합니다.")
+        
+        val command = ManageGroupParticipantsCommand.removeParticipants(
+            chatRoomId = chatRoomId,
+            participants = participantsToRemove,
+            managedBy = userId
+        )
+        
+        manageGroupChatUseCase.manageParticipants(command)
+        logger.info { "Participants removed via WebSocket: roomId=$chatRoomId, count=${participantsToRemove.size}" }
+    }
+
+    private fun handleUpdateTitle(actionDto: GroupChatActionDto, userId: Long) {
+        val chatRoomId = actionDto.chatRoomId ?: throw IllegalArgumentException("채팅방 ID가 필요합니다.")
+        val newTitle = actionDto.newTitle ?: throw IllegalArgumentException("새 제목이 필요합니다.")
+        
+        val command = UpdateGroupChatTitleCommand(
+            chatRoomId = chatRoomId,
+            newTitle = newTitle,
+            updatedBy = userId
+        )
+        
+        manageGroupChatUseCase.updateTitle(command)
+        logger.info { "Group chat title updated via WebSocket: roomId=$chatRoomId, newTitle=$newTitle" }
+    }
+
+    private fun handleLeaveGroup(actionDto: GroupChatActionDto, userId: Long) {
+        val chatRoomId = actionDto.chatRoomId ?: throw IllegalArgumentException("채팅방 ID가 필요합니다.")
+        
+        val command = LeaveGroupChatCommand(
+            chatRoomId = chatRoomId,
+            userId = userId
+        )
+        
+        manageGroupChatUseCase.leaveGroup(command)
+        logger.info { "User left group via WebSocket: roomId=$chatRoomId, userId=$userId" }
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/application/port/in/chatroom/group/CreateGroupChatUseCase.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/chatroom/group/CreateGroupChatUseCase.kt
@@ -1,0 +1,18 @@
+package com.stark.shoot.application.port.`in`.chatroom.group
+
+import com.stark.shoot.application.port.`in`.chatroom.group.command.CreateGroupChatCommand
+import com.stark.shoot.domain.chatroom.ChatRoom
+
+/**
+ * 그룹 채팅방 생성 Use Case
+ */
+interface CreateGroupChatUseCase {
+    
+    /**
+     * 그룹 채팅방을 생성합니다.
+     * 
+     * @param command 그룹 채팅방 생성 명령
+     * @return 생성된 채팅방
+     */
+    fun createGroupChat(command: CreateGroupChatCommand): ChatRoom
+}

--- a/src/main/kotlin/com/stark/shoot/application/port/in/chatroom/group/ManageGroupChatUseCase.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/chatroom/group/ManageGroupChatUseCase.kt
@@ -1,0 +1,27 @@
+package com.stark.shoot.application.port.`in`.chatroom.group
+
+import com.stark.shoot.application.port.`in`.chatroom.group.command.LeaveGroupChatCommand
+import com.stark.shoot.application.port.`in`.chatroom.group.command.ManageGroupParticipantsCommand
+import com.stark.shoot.application.port.`in`.chatroom.group.command.UpdateGroupChatTitleCommand
+import com.stark.shoot.domain.chatroom.ChatRoom
+
+/**
+ * 그룹 채팅방 관리 Use Case
+ */
+interface ManageGroupChatUseCase {
+    
+    /**
+     * 그룹 채팅방에 참여자를 추가하거나 제거합니다.
+     */
+    fun manageParticipants(command: ManageGroupParticipantsCommand): ChatRoom
+    
+    /**
+     * 그룹 채팅방 제목을 변경합니다.
+     */
+    fun updateTitle(command: UpdateGroupChatTitleCommand): ChatRoom
+    
+    /**
+     * 그룹 채팅방을 나갑니다.
+     */
+    fun leaveGroup(command: LeaveGroupChatCommand): ChatRoom?
+}

--- a/src/main/kotlin/com/stark/shoot/application/port/in/chatroom/group/command/CreateGroupChatCommand.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/chatroom/group/command/CreateGroupChatCommand.kt
@@ -1,0 +1,30 @@
+package com.stark.shoot.application.port.`in`.chatroom.group.command
+
+import com.stark.shoot.adapter.`in`.rest.dto.chatroom.group.CreateGroupChatRequest
+
+/**
+ * 그룹 채팅방 생성 명령
+ */
+data class CreateGroupChatCommand(
+    val title: String,
+    val participants: Set<Long>, // 참여자 사용자 ID 목록
+    val createdBy: Long // 생성자 사용자 ID
+) {
+    init {
+        require(title.isNotBlank()) { "채팅방 제목은 필수입니다." }
+        require(title.length <= 50) { "채팅방 제목은 50자 이하여야 합니다." }
+        require(participants.size >= 2) { "그룹 채팅방은 최소 2명의 참여자가 필요합니다." }
+        require(participants.size <= 100) { "그룹 채팅방은 최대 100명까지 참여할 수 있습니다." }
+        require(createdBy in participants) { "생성자는 참여자에 포함되어야 합니다." }
+    }
+
+    companion object {
+        fun of(request: CreateGroupChatRequest, createdBy: Long): CreateGroupChatCommand {
+            return CreateGroupChatCommand(
+                title = request.title,
+                participants = request.participants,
+                createdBy = createdBy
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/application/port/in/chatroom/group/command/LeaveGroupChatCommand.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/chatroom/group/command/LeaveGroupChatCommand.kt
@@ -1,0 +1,14 @@
+package com.stark.shoot.application.port.`in`.chatroom.group.command
+
+/**
+ * 그룹 채팅방 나가기 명령
+ */
+data class LeaveGroupChatCommand(
+    val chatRoomId: Long,
+    val userId: Long
+) {
+    init {
+        require(chatRoomId > 0) { "채팅방 ID가 유효하지 않습니다." }
+        require(userId > 0) { "사용자 ID가 유효하지 않습니다." }
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/application/port/in/chatroom/group/command/ManageGroupParticipantsCommand.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/chatroom/group/command/ManageGroupParticipantsCommand.kt
@@ -1,0 +1,39 @@
+package com.stark.shoot.application.port.`in`.chatroom.group.command
+
+/**
+ * 그룹 채팅방 참여자 관리 명령
+ */
+data class ManageGroupParticipantsCommand(
+    val chatRoomId: Long,
+    val participantsToAdd: Set<Long> = emptySet(),
+    val participantsToRemove: Set<Long> = emptySet(),
+    val managedBy: Long
+) {
+    init {
+        require(chatRoomId > 0) { "채팅방 ID가 유효하지 않습니다." }
+        require(participantsToAdd.isNotEmpty() || participantsToRemove.isNotEmpty()) { 
+            "추가하거나 제거할 참여자가 있어야 합니다." 
+        }
+        require((participantsToAdd intersect participantsToRemove).isEmpty()) { 
+            "동일한 사용자를 동시에 추가하고 제거할 수 없습니다." 
+        }
+    }
+
+    companion object {
+        fun addParticipants(chatRoomId: Long, participants: Set<Long>, managedBy: Long): ManageGroupParticipantsCommand {
+            return ManageGroupParticipantsCommand(
+                chatRoomId = chatRoomId,
+                participantsToAdd = participants,
+                managedBy = managedBy
+            )
+        }
+
+        fun removeParticipants(chatRoomId: Long, participants: Set<Long>, managedBy: Long): ManageGroupParticipantsCommand {
+            return ManageGroupParticipantsCommand(
+                chatRoomId = chatRoomId,
+                participantsToRemove = participants,
+                managedBy = managedBy
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/application/port/in/chatroom/group/command/UpdateGroupChatTitleCommand.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/in/chatroom/group/command/UpdateGroupChatTitleCommand.kt
@@ -1,0 +1,17 @@
+package com.stark.shoot.application.port.`in`.chatroom.group.command
+
+/**
+ * 그룹 채팅방 제목 변경 명령
+ */
+data class UpdateGroupChatTitleCommand(
+    val chatRoomId: Long,
+    val newTitle: String,
+    val updatedBy: Long
+) {
+    init {
+        require(chatRoomId > 0) { "채팅방 ID가 유효하지 않습니다." }
+        require(newTitle.isNotBlank()) { "새 제목은 필수입니다." }
+        require(newTitle.length <= 50) { "제목은 50자 이하여야 합니다." }
+        require(updatedBy > 0) { "수정자 ID가 유효하지 않습니다." }
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/application/port/out/chatroom/LoadChatRoomPort.kt
+++ b/src/main/kotlin/com/stark/shoot/application/port/out/chatroom/LoadChatRoomPort.kt
@@ -7,4 +7,11 @@ import com.stark.shoot.domain.user.vo.UserId
 interface LoadChatRoomPort {
     fun findById(roomId: ChatRoomId): ChatRoom?
     fun findByParticipantId(participantId: UserId): List<ChatRoom>
+    
+    /**
+     * 동일한 참여자로 구성된 그룹 채팅방 조회
+     * 그룹 채팅방 중복 생성 방지용
+     * TODO: 실제 구현 필요시 구현체에서 구현
+     */
+    fun findGroupChatByParticipants(participants: Set<UserId>): ChatRoom? = null
 }

--- a/src/main/kotlin/com/stark/shoot/application/service/chatroom/group/CreateGroupChatService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/chatroom/group/CreateGroupChatService.kt
@@ -1,0 +1,91 @@
+package com.stark.shoot.application.service.chatroom.group
+
+import com.stark.shoot.application.port.`in`.chatroom.group.CreateGroupChatUseCase
+import com.stark.shoot.application.port.`in`.chatroom.group.command.CreateGroupChatCommand
+import com.stark.shoot.application.port.out.chatroom.ChatRoomCommandPort
+import com.stark.shoot.application.port.out.chatroom.ChatRoomQueryPort
+import com.stark.shoot.application.port.out.event.EventPublishPort
+import com.stark.shoot.application.port.out.user.UserQueryPort
+import com.stark.shoot.domain.chatroom.ChatRoom
+import com.stark.shoot.domain.chatroom.type.ChatRoomType
+import com.stark.shoot.domain.chatroom.vo.ChatRoomTitle
+import com.stark.shoot.domain.event.ChatRoomCreatedEvent
+import com.stark.shoot.domain.user.vo.UserId
+import com.stark.shoot.infrastructure.annotation.UseCase
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+@Transactional
+class CreateGroupChatService(
+    private val chatRoomQueryPort: ChatRoomQueryPort,
+    private val chatRoomCommandPort: ChatRoomCommandPort,
+    private val userQueryPort: UserQueryPort,
+    private val eventPublishPort: EventPublishPort
+) : CreateGroupChatUseCase {
+
+    private val logger = KotlinLogging.logger {}
+
+    override fun createGroupChat(command: CreateGroupChatCommand): ChatRoom {
+        logger.info { "Creating group chat: title=${command.title}, participants=${command.participants.size}, createdBy=${command.createdBy}" }
+
+        val participants = command.participants.map { UserId.from(it) }.toSet()
+        val createdBy = UserId.from(command.createdBy)
+
+        // 그룹 채팅 생성 규칙 검증
+        require(participants.size >= 2) { "그룹 채팅방은 최소 2명의 참여자가 필요합니다." }
+        require(participants.size <= 100) { "그룹 채팅방은 최대 100명까지 참여할 수 있습니다." }
+        require(createdBy in participants) { "채팅방 생성자는 참여자에 포함되어야 합니다." }
+        
+        // 참여자 검증
+        validateParticipants(participants)
+        
+        // 중복 채팅방 체크
+        findExistingGroupChat(participants)?.let {
+            throw IllegalStateException("동일한 참여자로 구성된 그룹 채팅방이 이미 존재합니다.")
+        }
+
+        // 채팅방 생성
+        val chatRoom = ChatRoom(
+            title = ChatRoomTitle.from(command.title),
+            type = ChatRoomType.GROUP,
+            participants = participants
+        )
+
+        val savedChatRoom = chatRoomCommandPort.save(chatRoom)
+
+        // 채팅방 생성 이벤트 발행
+        val createdEvent = ChatRoomCreatedEvent(
+            roomId = savedChatRoom.id!!,
+            userId = createdBy
+        )
+        eventPublishPort.publishEvent(createdEvent)
+
+        logger.info { "Group chat created successfully: roomId=${savedChatRoom.id?.value}" }
+        return savedChatRoom
+    }
+
+    /**
+     * 참여자 검증
+     */
+    private fun validateParticipants(participants: Set<UserId>) {
+        // 모든 참여자가 존재하는지 확인
+        participants.forEach { userId ->
+            if (!userQueryPort.existsById(userId)) {
+                throw IllegalArgumentException("존재하지 않는 사용자입니다: ${userId.value}")
+            }
+        }
+    }
+
+    /**
+     * 동일한 참여자로 구성된 기존 그룹 채팅방 조회
+     */
+    private fun findExistingGroupChat(participants: Set<UserId>): ChatRoom? {
+        return try {
+            chatRoomQueryPort.findGroupChatByParticipants(participants)
+        } catch (e: Exception) {
+            logger.warn(e) { "Failed to check existing group chat" }
+            null
+        }
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/application/service/chatroom/group/ManageGroupChatService.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/chatroom/group/ManageGroupChatService.kt
@@ -1,0 +1,198 @@
+package com.stark.shoot.application.service.chatroom.group
+
+import com.stark.shoot.application.port.`in`.chatroom.group.ManageGroupChatUseCase
+import com.stark.shoot.application.port.`in`.chatroom.group.command.LeaveGroupChatCommand
+import com.stark.shoot.application.port.`in`.chatroom.group.command.ManageGroupParticipantsCommand
+import com.stark.shoot.application.port.`in`.chatroom.group.command.UpdateGroupChatTitleCommand
+import com.stark.shoot.application.port.out.chatroom.ChatRoomCommandPort
+import com.stark.shoot.application.port.out.chatroom.ChatRoomQueryPort
+import com.stark.shoot.application.port.out.event.EventPublishPort
+import com.stark.shoot.application.port.out.user.UserQueryPort
+import com.stark.shoot.domain.chatroom.ChatRoom
+import com.stark.shoot.domain.chatroom.type.ChatRoomType
+import com.stark.shoot.domain.chatroom.vo.ChatRoomId
+import com.stark.shoot.domain.chatroom.vo.ChatRoomTitle
+import com.stark.shoot.domain.event.ChatRoomParticipantChangedEvent
+import com.stark.shoot.domain.event.ChatRoomTitleChangedEvent
+import com.stark.shoot.domain.user.vo.UserId
+import com.stark.shoot.infrastructure.annotation.UseCase
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+@Transactional
+class ManageGroupChatService(
+    private val chatRoomQueryPort: ChatRoomQueryPort,
+    private val chatRoomCommandPort: ChatRoomCommandPort,
+    private val userQueryPort: UserQueryPort,
+    private val eventPublishPort: EventPublishPort
+) : ManageGroupChatUseCase {
+
+    private val logger = KotlinLogging.logger {}
+
+    override fun manageParticipants(command: ManageGroupParticipantsCommand): ChatRoom {
+        logger.info { 
+            "Managing group chat participants: roomId=${command.chatRoomId}, " +
+            "toAdd=${command.participantsToAdd.size}, toRemove=${command.participantsToRemove.size}"
+        }
+
+        val roomId = ChatRoomId.from(command.chatRoomId)
+        val managedBy = UserId.from(command.managedBy)
+        
+        val chatRoom = chatRoomQueryPort.findById(roomId) 
+            ?: throw IllegalArgumentException("채팅방을 찾을 수 없습니다: ${command.chatRoomId}")
+
+        // 그룹 채팅방인지 확인
+        require(chatRoom.type == ChatRoomType.GROUP) { 
+            "그룹 채팅방이 아닙니다." 
+        }
+
+        // 관리자가 채팅방 참여자인지 확인
+        require(managedBy in chatRoom.participants) { 
+            "채팅방 참여자만 다른 참여자를 관리할 수 있습니다." 
+        }
+
+        // 현재 참여자 목록 생성
+        val currentParticipants = chatRoom.participants.toMutableSet()
+        
+        // 추가할 참여자 검증 및 추가
+        val participantsToAdd = command.participantsToAdd.map { UserId.from(it) }.toSet()
+        participantsToAdd.forEach { userId ->
+            if (!userQueryPort.existsById(userId)) {
+                throw IllegalArgumentException("존재하지 않는 사용자입니다: ${userId.value}")
+            }
+            if (userId in currentParticipants) {
+                throw IllegalArgumentException("이미 참여 중인 사용자입니다: ${userId.value}")
+            }
+        }
+        
+        // 제거할 참여자 검증
+        val participantsToRemove = command.participantsToRemove.map { UserId.from(it) }.toSet()
+        participantsToRemove.forEach { userId ->
+            if (userId !in currentParticipants) {
+                throw IllegalArgumentException("참여하지 않은 사용자입니다: ${userId.value}")
+            }
+        }
+
+        // 새로운 참여자 목록 계산
+        val newParticipants = (currentParticipants + participantsToAdd) - participantsToRemove
+
+        // 참여자 변경 검증
+        require(newParticipants.size >= 2) { "그룹 채팅방은 최소 2명의 참여자가 필요합니다." }
+        require(newParticipants.size <= 100) { "그룹 채팅방은 최대 100명까지 참여할 수 있습니다." }
+        
+        val changes = ChatRoom.ParticipantChanges(
+            participantsToAdd = participantsToAdd,
+            participantsToRemove = participantsToRemove
+        )
+
+        // 채팅방 참여자 업데이트
+        chatRoom.updateParticipants(newParticipants)
+        val updatedChatRoom = chatRoomCommandPort.save(chatRoom)
+
+        // 참여자 변경 이벤트 발행
+        if (!changes.isEmpty()) {
+            val event = ChatRoomParticipantChangedEvent(
+                roomId = roomId,
+                participantsAdded = changes.participantsToAdd,
+                participantsRemoved = changes.participantsToRemove,
+                changedBy = managedBy
+            )
+            eventPublishPort.publishEvent(event)
+        }
+
+        logger.info { "Group chat participants updated: roomId=${roomId.value}" }
+        return updatedChatRoom
+    }
+
+    override fun updateTitle(command: UpdateGroupChatTitleCommand): ChatRoom {
+        logger.info { "Updating group chat title: roomId=${command.chatRoomId}, newTitle=${command.newTitle}" }
+
+        val roomId = ChatRoomId.from(command.chatRoomId)
+        val updatedBy = UserId.from(command.updatedBy)
+        
+        val chatRoom = chatRoomQueryPort.findById(roomId)
+            ?: throw IllegalArgumentException("채팅방을 찾을 수 없습니다: ${command.chatRoomId}")
+
+        // 그룹 채팅방인지 확인
+        require(chatRoom.type == ChatRoomType.GROUP) { 
+            "그룹 채팅방이 아닙니다." 
+        }
+
+        // 수정자가 채팅방 참여자인지 확인
+        require(updatedBy in chatRoom.participants) { 
+            "채팅방 참여자만 제목을 변경할 수 있습니다." 
+        }
+
+        val oldTitle = chatRoom.title?.value
+        val newTitle = ChatRoomTitle.from(command.newTitle)
+        
+        // 제목이 실제로 변경되었는지 확인
+        if (chatRoom.title?.value == newTitle.value) {
+            return chatRoom
+        }
+
+        // 제목 업데이트
+        chatRoom.update(title = newTitle)
+        val updatedChatRoom = chatRoomCommandPort.save(chatRoom)
+
+        // 제목 변경 이벤트 발행
+        val event = ChatRoomTitleChangedEvent(
+            roomId = roomId,
+            oldTitle = oldTitle,
+            newTitle = newTitle.value,
+            changedBy = updatedBy
+        )
+        eventPublishPort.publishEvent(event)
+
+        logger.info { "Group chat title updated: roomId=${roomId.value}" }
+        return updatedChatRoom
+    }
+
+    override fun leaveGroup(command: LeaveGroupChatCommand): ChatRoom? {
+        logger.info { "User leaving group chat: roomId=${command.chatRoomId}, userId=${command.userId}" }
+
+        val roomId = ChatRoomId.from(command.chatRoomId)
+        val userId = UserId.from(command.userId)
+        
+        val chatRoom = chatRoomQueryPort.findById(roomId)
+            ?: throw IllegalArgumentException("채팅방을 찾을 수 없습니다: ${command.chatRoomId}")
+
+        // 그룹 채팅방인지 확인
+        require(chatRoom.type == ChatRoomType.GROUP) { 
+            "그룹 채팅방이 아닙니다." 
+        }
+
+        // 사용자가 실제로 참여 중인지 확인
+        require(userId in chatRoom.participants) { 
+            "채팅방에 참여하고 있지 않습니다." 
+        }
+
+        // 참여자에서 사용자 제거
+        val success = chatRoom.removeParticipant(userId)
+        if (!success) {
+            return chatRoom
+        }
+
+        // 빈 채팅방인지 확인하여 삭제
+        if (chatRoom.participants.isEmpty()) {
+            chatRoomCommandPort.deleteById(roomId)
+            logger.info { "Empty group chat deleted: roomId=${roomId.value}" }
+            return null
+        }
+
+        val updatedChatRoom = chatRoomCommandPort.save(chatRoom)
+
+        // 참여자 변경 이벤트 발행
+        val event = ChatRoomParticipantChangedEvent(
+            roomId = roomId,
+            participantsAdded = emptySet(),
+            participantsRemoved = setOf(userId),
+            changedBy = userId
+        )
+        eventPublishPort.publishEvent(event)
+
+        logger.info { "User left group chat: roomId=${roomId.value}, userId=${userId.value}" }
+        return updatedChatRoom
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/application/service/event/chatroom/ChatRoomCreatedEventListener.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/event/chatroom/ChatRoomCreatedEventListener.kt
@@ -1,0 +1,65 @@
+package com.stark.shoot.application.service.event.chatroom
+
+import com.stark.shoot.adapter.`in`.socket.WebSocketMessageBroker
+import com.stark.shoot.application.port.out.chatroom.ChatRoomQueryPort
+import com.stark.shoot.domain.event.ChatRoomCreatedEvent
+import com.stark.shoot.infrastructure.annotation.ApplicationEventListener
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+@ApplicationEventListener
+class ChatRoomCreatedEventListener(
+    private val chatRoomQueryPort: ChatRoomQueryPort,
+    private val webSocketMessageBroker: WebSocketMessageBroker
+) {
+
+    private val logger = KotlinLogging.logger {}
+
+    /**
+     * 채팅방 생성 이벤트 처리
+     * - 모든 참여자에게 새 채팅방 생성 알림
+     * - 채팅방 목록 실시간 업데이트
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handleChatRoomCreated(event: ChatRoomCreatedEvent) {
+        logger.info { "Processing chat room created event: roomId=${event.roomId.value}, userId=${event.userId.value}" }
+
+        val chatRoom = chatRoomQueryPort.findById(event.roomId)
+        if (chatRoom == null) {
+            logger.warn { "Chat room not found for created event: ${event.roomId.value}" }
+            return
+        }
+
+        val chatRoomInfo = mapOf(
+            "roomId" to chatRoom.id?.value,
+            "title" to chatRoom.title?.value,
+            "type" to chatRoom.type.name,
+            "participants" to chatRoom.participants.map { it.value },
+            "participantCount" to chatRoom.participants.size,
+            "createdBy" to event.userId.value,
+            "createdAt" to chatRoom.createdAt.toString()
+        )
+
+        // 모든 참여자에게 새 채팅방 생성 알림 전송
+        chatRoom.participants.forEach { participantId ->
+            try {
+                webSocketMessageBroker.sendMessage(
+                    "/topic/user/${participantId.value}/chatrooms/new",
+                    chatRoomInfo,
+                    retryCount = 2
+                ).whenComplete { success, throwable ->
+                    if (success) {
+                        logger.debug { "New chat room notification sent to user ${participantId.value}" }
+                    } else {
+                        logger.warn { "Failed to send new chat room notification to user ${participantId.value}: ${throwable?.message}" }
+                    }
+                }
+            } catch (e: Exception) {
+                logger.error(e) { "Failed to send chat room creation notification to user ${participantId.value}" }
+            }
+        }
+
+        logger.info { "Chat room created event processed: roomId=${event.roomId.value}" }
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/application/service/event/chatroom/ChatRoomParticipantChangedEventListener.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/event/chatroom/ChatRoomParticipantChangedEventListener.kt
@@ -1,0 +1,145 @@
+package com.stark.shoot.application.service.event.chatroom
+
+import com.stark.shoot.adapter.`in`.socket.WebSocketMessageBroker
+import com.stark.shoot.application.port.out.chatroom.ChatRoomQueryPort
+import com.stark.shoot.application.port.out.user.UserQueryPort
+import com.stark.shoot.domain.event.ChatRoomParticipantChangedEvent
+import com.stark.shoot.infrastructure.annotation.ApplicationEventListener
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+@ApplicationEventListener
+class ChatRoomParticipantChangedEventListener(
+    private val chatRoomQueryPort: ChatRoomQueryPort,
+    private val userQueryPort: UserQueryPort,
+    private val webSocketMessageBroker: WebSocketMessageBroker
+) {
+
+    private val logger = KotlinLogging.logger {}
+
+    /**
+     * 채팅방 참여자 변경 이벤트 처리
+     * - 채팅방 내 모든 참여자에게 변경 사항 알림
+     * - 추가/제거된 참여자들에게 개별 알림
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handleParticipantChanged(event: ChatRoomParticipantChangedEvent) {
+        logger.info { 
+            "Processing participant changed event: roomId=${event.roomId.value}, " +
+            "added=${event.participantsAdded.size}, removed=${event.participantsRemoved.size}" 
+        }
+
+        val chatRoom = chatRoomQueryPort.findById(event.roomId)
+        if (chatRoom == null) {
+            logger.warn { "Chat room not found for participant changed event: ${event.roomId.value}" }
+            return
+        }
+
+        val changedByName = try {
+            userQueryPort.findUserById(event.changedBy)?.nickname?.value ?: "사용자"
+        } catch (e: Exception) {
+            "사용자"
+        }
+
+        // 채팅방 내 모든 현재 참여자에게 변경 사항 브로드캐스트
+        broadcastToCurrentParticipants(chatRoom, event, changedByName)
+
+        // 추가된 참여자들에게 환영 메시지
+        sendWelcomeMessagesToNewParticipants(event, chatRoom, changedByName)
+
+        // 제거된 참여자들에게 알림
+        sendGoodbyeMessagesToRemovedParticipants(event, chatRoom, changedByName)
+
+        logger.info { "Participant changed event processed: roomId=${event.roomId.value}" }
+    }
+
+    private fun broadcastToCurrentParticipants(
+        chatRoom: com.stark.shoot.domain.chatroom.ChatRoom,
+        event: ChatRoomParticipantChangedEvent,
+        changedByName: String
+    ) {
+        val participantUpdate = mapOf(
+            "roomId" to event.roomId.value,
+            "type" to "PARTICIPANT_CHANGED",
+            "participantsAdded" to event.participantsAdded.map { it.value },
+            "participantsRemoved" to event.participantsRemoved.map { it.value },
+            "changedBy" to event.changedBy.value,
+            "changedByName" to changedByName,
+            "currentParticipants" to chatRoom.participants.map { it.value },
+            "participantCount" to chatRoom.participants.size,
+            "timestamp" to event.occurredOn
+        )
+
+        chatRoom.participants.forEach { participantId ->
+            webSocketMessageBroker.sendMessage(
+                "/topic/chat/${event.roomId.value}/participants",
+                participantUpdate,
+                retryCount = 1
+            ).whenComplete { success, throwable ->
+                if (!success) {
+                    logger.warn { "Failed to send participant update to user ${participantId.value}: ${throwable?.message}" }
+                }
+            }
+        }
+    }
+
+    private fun sendWelcomeMessagesToNewParticipants(
+        event: ChatRoomParticipantChangedEvent,
+        chatRoom: com.stark.shoot.domain.chatroom.ChatRoom,
+        changedByName: String
+    ) {
+        event.participantsAdded.forEach { newParticipantId ->
+            val welcomeMessage = mapOf(
+                "type" to "WELCOME_TO_GROUP",
+                "roomId" to event.roomId.value,
+                "title" to chatRoom.title?.value,
+                "participantCount" to chatRoom.participants.size,
+                "addedBy" to changedByName,
+                "timestamp" to event.occurredOn
+            )
+
+            webSocketMessageBroker.sendMessage(
+                "/topic/user/${newParticipantId.value}/notifications",
+                welcomeMessage,
+                retryCount = 2
+            ).whenComplete { success, throwable ->
+                if (success) {
+                    logger.debug { "Welcome message sent to new participant ${newParticipantId.value}" }
+                } else {
+                    logger.warn { "Failed to send welcome message to ${newParticipantId.value}: ${throwable?.message}" }
+                }
+            }
+        }
+    }
+
+    private fun sendGoodbyeMessagesToRemovedParticipants(
+        event: ChatRoomParticipantChangedEvent,
+        chatRoom: com.stark.shoot.domain.chatroom.ChatRoom,
+        changedByName: String
+    ) {
+        event.participantsRemoved.forEach { removedParticipantId ->
+            val isRemovedBySelf = removedParticipantId == event.changedBy
+            val goodbyeMessage = mapOf(
+                "type" to "REMOVED_FROM_GROUP",
+                "roomId" to event.roomId.value,
+                "title" to chatRoom.title?.value,
+                "removedBy" to if (isRemovedBySelf) null else changedByName,
+                "isVoluntary" to isRemovedBySelf,
+                "timestamp" to event.occurredOn
+            )
+
+            webSocketMessageBroker.sendMessage(
+                "/topic/user/${removedParticipantId.value}/notifications",
+                goodbyeMessage,
+                retryCount = 1
+            ).whenComplete { success, throwable ->
+                if (success) {
+                    logger.debug { "Goodbye message sent to removed participant ${removedParticipantId.value}" }
+                } else {
+                    logger.warn { "Failed to send goodbye message to ${removedParticipantId.value}: ${throwable?.message}" }
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/application/service/event/chatroom/ChatRoomTitleChangedEventListener.kt
+++ b/src/main/kotlin/com/stark/shoot/application/service/event/chatroom/ChatRoomTitleChangedEventListener.kt
@@ -1,0 +1,97 @@
+package com.stark.shoot.application.service.event.chatroom
+
+import com.stark.shoot.adapter.`in`.socket.WebSocketMessageBroker
+import com.stark.shoot.application.port.out.chatroom.ChatRoomQueryPort
+import com.stark.shoot.application.port.out.user.UserQueryPort
+import com.stark.shoot.domain.event.ChatRoomTitleChangedEvent
+import com.stark.shoot.infrastructure.annotation.ApplicationEventListener
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+@ApplicationEventListener
+class ChatRoomTitleChangedEventListener(
+    private val chatRoomQueryPort: ChatRoomQueryPort,
+    private val userQueryPort: UserQueryPort,
+    private val webSocketMessageBroker: WebSocketMessageBroker
+) {
+
+    private val logger = KotlinLogging.logger {}
+
+    /**
+     * 채팅방 제목 변경 이벤트 처리
+     * - 채팅방 내 모든 참여자에게 제목 변경 알림
+     * - 채팅방 목록 업데이트
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handleTitleChanged(event: ChatRoomTitleChangedEvent) {
+        logger.info { 
+            "Processing title changed event: roomId=${event.roomId.value}, " +
+            "oldTitle=${event.oldTitle}, newTitle=${event.newTitle}" 
+        }
+
+        val chatRoom = chatRoomQueryPort.findById(event.roomId)
+        if (chatRoom == null) {
+            logger.warn { "Chat room not found for title changed event: ${event.roomId.value}" }
+            return
+        }
+
+        val changedByName = try {
+            userQueryPort.findUserById(event.changedBy)?.nickname?.value ?: "사용자"
+        } catch (e: Exception) {
+            "사용자"
+        }
+
+        val titleChangeNotification = mapOf(
+            "type" to "TITLE_CHANGED",
+            "roomId" to event.roomId.value,
+            "oldTitle" to event.oldTitle,
+            "newTitle" to event.newTitle,
+            "changedBy" to event.changedBy.value,
+            "changedByName" to changedByName,
+            "timestamp" to event.occurredOn
+        )
+
+        // 모든 참여자에게 제목 변경 알림 브로드캐스트
+        var successCount = 0
+        var failureCount = 0
+
+        chatRoom.participants.forEach { participantId ->
+            // 채팅방 내 제목 변경 알림
+            webSocketMessageBroker.sendMessage(
+                "/topic/chat/${event.roomId.value}/title",
+                titleChangeNotification,
+                retryCount = 1
+            ).whenComplete { success, throwable ->
+                if (success) {
+                    successCount++
+                } else {
+                    failureCount++
+                    logger.warn { "Failed to send title change notification to user ${participantId.value}: ${throwable?.message}" }
+                }
+            }
+
+            // 채팅방 목록의 제목 업데이트
+            val chatRoomListUpdate = mapOf(
+                "roomId" to event.roomId.value,
+                "title" to event.newTitle,
+                "lastActiveAt" to chatRoom.lastActiveAt.toString()
+            )
+
+            webSocketMessageBroker.sendMessage(
+                "/topic/user/${participantId.value}/chatrooms/update",
+                chatRoomListUpdate,
+                retryCount = 2
+            ).whenComplete { success, throwable ->
+                if (!success) {
+                    logger.warn { "Failed to update chat room list for user ${participantId.value}: ${throwable?.message}" }
+                }
+            }
+        }
+
+        logger.info { 
+            "Title changed event processed: roomId=${event.roomId.value}, " +
+            "notifications sent: $successCount success, $failureCount failure" 
+        }
+    }
+}

--- a/src/main/kotlin/com/stark/shoot/domain/event/ChatRoomParticipantChangedEvent.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/event/ChatRoomParticipantChangedEvent.kt
@@ -1,0 +1,15 @@
+package com.stark.shoot.domain.event
+
+import com.stark.shoot.domain.chatroom.vo.ChatRoomId
+import com.stark.shoot.domain.user.vo.UserId
+
+/**
+ * 채팅방 참여자 변경 이벤트
+ */
+data class ChatRoomParticipantChangedEvent(
+    val roomId: ChatRoomId,
+    val participantsAdded: Set<UserId>,
+    val participantsRemoved: Set<UserId>,
+    val changedBy: UserId,
+    override val occurredOn: Long = System.currentTimeMillis()
+) : DomainEvent

--- a/src/main/kotlin/com/stark/shoot/domain/event/ChatRoomTitleChangedEvent.kt
+++ b/src/main/kotlin/com/stark/shoot/domain/event/ChatRoomTitleChangedEvent.kt
@@ -1,0 +1,15 @@
+package com.stark.shoot.domain.event
+
+import com.stark.shoot.domain.chatroom.vo.ChatRoomId
+import com.stark.shoot.domain.user.vo.UserId
+
+/**
+ * 채팅방 제목 변경 이벤트
+ */
+data class ChatRoomTitleChangedEvent(
+    val roomId: ChatRoomId,
+    val oldTitle: String?,
+    val newTitle: String,
+    val changedBy: UserId,
+    override val occurredOn: Long = System.currentTimeMillis()
+) : DomainEvent

--- a/src/main/kotlin/com/stark/shoot/infrastructure/event/AutoPublishEvents.kt
+++ b/src/main/kotlin/com/stark/shoot/infrastructure/event/AutoPublishEvents.kt
@@ -1,0 +1,10 @@
+package com.stark.shoot.infrastructure.event
+
+/**
+ * 자동 이벤트 발행을 위한 애노테이션
+ * 클래스나 메서드에 적용할 수 있습니다.
+ */
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@MustBeDocumented
+annotation class AutoPublishEvents


### PR DESCRIPTION
그룹 채팅 websocket 통신 구현

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 그룹 채팅방 생성 지원(제목·참여자 지정). REST와 웹소켓 액션 모두 제공.
  * 참여자 추가/제거, 채팅방 나가기, 제목 변경 기능 추가.
  * 실시간 알림: 새 채팅방 생성, 참여자 변경, 제목 변경 시 관련 사용자·채팅방에 푸시 브로드캐스트.
  * 입력 유효성 강화: 제목 필수/최대 50자, 참여자 최소/최대 인원, 추가·제거 충돌 방지 등.
  * API 응답 개선: 생성 시 201 Created, 변경/탈퇴 시 200 OK와 안내 메시지 제공.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->